### PR TITLE
chore(release): v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-13
+
+### Added
+- Debian/Ubuntu `.deb` packages for amd64 and arm64, plus fully-static musl tarballs for both architectures.
+- Build-time audio include/exclude option for release binaries (gnu/macOS ship audio; musl stays static, no-audio).
+- Standards-based quality metrics section on the website (ITU-T G.107 / RFC 3550).
+
+### Fixed
+- Release pipeline now builds all six targets (Linux gnu/musl + macOS, x86_64/aarch64), including ALSA build deps and aarch64-musl static libpcap.
+
 ## [0.4.1] - 2026-06-12
 
 (Version 0.4.0 was skipped: its tag name was consumed and then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,7 +2780,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sipnab"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Norm Brandinger"]


### PR DESCRIPTION
Bumps version 0.4.1 → 0.4.2 (Cargo.toml, Cargo.lock) and adds the 0.4.2 CHANGELOG entry, in preparation for tagging v0.4.2.

Highlights since 0.4.1:
- Debian/Ubuntu .deb packages (amd64 + arm64) and static musl tarballs
- macOS Intel + Apple Silicon binaries (Homebrew tap to follow)
- Release pipeline green across all six targets; audio include/exclude build option
- Standards-based quality metrics section; funding links; repo hardening