### PR TITLE
Add CODEOWNERS (default owner @NormB)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for sipnab.
+# These owners are automatically requested for review on PRs that touch
+# matching paths, and (with "Require review from Code Owners" enabled on the
+# protected branch) their approval is required before merge.
+#
+# Syntax: https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repository.
+*       @NormB


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with @NormB as default owner for all paths. Pairs with the new branch-protection rule (1 approval + required Code Owner review) so outside contributions require your review, while you self-merge via admin.