### PR TITLE
feat(website): add Download page

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -22,7 +22,7 @@ enabled = true
 theme = "ayu-dark"
 
 [extra]
-version = "0.4.1"
+version = "0.4.2"
 github_url = "https://github.com/NormB/sipnab"
 author = "Norm Brandinger"
 linkedin_url = "https://www.linkedin.com/in/nbrandinger"

--- a/website/content/download.md
+++ b/website/content/download.md
@@ -1,0 +1,5 @@
++++
+title = "Download"
+description = "Download sipnab — macOS (Homebrew), Debian/Ubuntu .deb packages, and static Linux binaries for x86-64 and ARM64."
+template = "download.html"
++++

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -1468,3 +1468,39 @@ img { max-width: 100%; height: auto; }
   .arch-stat { font-size: 2rem; }
   .version-badge { font-size: 0.7rem; }
 }
+
+
+// Download page
+.download { max-width: $max-width; margin: 0 auto; padding: 4rem 1.5rem 5rem; }
+.download-head { text-align: center; margin-bottom: 3rem; }
+.download-head h1 { font-size: 2.5rem; margin: 0; }
+.download-sub { color: $text-dim; max-width: 640px; margin: 1rem auto 0; line-height: 1.6; }
+.download-sub a, .download-foot a, .dl-alt a, .dl-files a { color: $link; }
+.download-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1.5rem; }
+.dl-card {
+  background: $surface; border: 1px solid $border; border-top: 3px solid $border-light;
+  border-radius: 10px; padding: 1.5rem;
+  h2 { font-size: 1.2rem; margin: 0; }
+  p { color: $text-dim; font-size: 0.9rem; margin: 0.5rem 0 0; }
+}
+.dl-card--amber { border-top-color: $accent; }
+.dl-card--green { border-top-color: $code-green; }
+.dl-card--blue  { border-top-color: $link; }
+.dl-card-head { display: flex; align-items: baseline; justify-content: space-between; gap: 0.5rem; }
+.dl-tag { font-family: $font-mono; font-size: 0.72rem; color: $text-dim; white-space: nowrap; }
+.dl-cmd {
+  background: $bg; border: 1px solid $border; border-radius: 6px; padding: 0.75rem 1rem;
+  overflow-x: auto; margin: 1rem 0 0;
+  code { font-family: $font-mono; font-size: 0.82rem; color: $code-green; white-space: pre; background: none; padding: 0; }
+}
+.dl-alt { font-size: 0.85rem; margin-top: 1rem !important; }
+.dl-files {
+  list-style: none; padding: 0; margin: 0.75rem 0 0;
+  li { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0;
+       border-bottom: 1px solid $border; font-family: $font-mono; font-size: 0.82rem; }
+  li:last-child { border-bottom: none; }
+  a { word-break: break-all; }
+  span { color: $text-dim; font-size: 0.72rem; margin-left: 1rem; white-space: nowrap; }
+}
+.download-foot { text-align: center; color: $text-dim; margin-top: 3rem; font-size: 0.9rem; line-height: 1.7; }
+@media (max-width: 600px) { .download-grid { grid-template-columns: 1fr; } }

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -52,6 +52,7 @@
       </button>
 
       <div class="nav-links" id="nav-links">
+        <a href="{{ get_url(path='@/download.md') }}" {% if current_path is defined and current_path == "/download/" %}class="active"{% endif %}>Download</a>
         <a href="{{ get_url(path='@/_index.md') }}#metrics">Metrics</a>
         <a href="{{ get_url(path='@/analyze/_index.md') }}" {% if current_path is defined and current_path is starting_with("/analyze") %}class="active"{% endif %}>Analyze</a>
         <a href="{{ get_url(path='@/docs/_index.md') }}" {% if current_path is defined and current_path is starting_with("/docs") %}class="active"{% endif %}>Docs</a>

--- a/website/templates/download.html
+++ b/website/templates/download.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+
+{% block title %}Download -- {{ config.title }}{% endblock title %}
+{% block og_title %}Download sipnab{% endblock og_title %}
+{% block description %}Download sipnab {{ config.extra.version }} -- macOS (Homebrew), Debian/Ubuntu .deb, and static Linux binaries for x86-64 and ARM64.{% endblock description %}
+
+{% block content %}
+{% set v = config.extra.version %}
+{% set rel = config.extra.github_url ~ "/releases/download/v" ~ v %}
+<section class="download">
+  <div class="download-inner">
+    <header class="download-head">
+      <h1>Download <span class="version-badge">v{{ v }}</span></h1>
+      <p class="download-sub">One binary, one dependency (libpcap). Every build is produced by CI and checksummed. Pick your platform, or browse the <a href="{{ config.extra.github_url }}/releases/latest">full release</a>.</p>
+    </header>
+
+    <div class="download-grid">
+
+      <article class="dl-card dl-card--amber">
+        <div class="dl-card-head"><h2>macOS</h2><span class="dl-tag">Intel &amp; Apple Silicon</span></div>
+        <p>Install with Homebrew &mdash; recommended.</p>
+        <pre class="dl-cmd"><code>brew install NormB/tap/sipnab</code></pre>
+        <p class="dl-alt">Or a binary tarball:
+          <a href="{{ rel }}/sipnab-{{ v }}-aarch64-apple-darwin.tar.gz">Apple&nbsp;Silicon</a> &middot;
+          <a href="{{ rel }}/sipnab-{{ v }}-x86_64-apple-darwin.tar.gz">Intel</a>
+        </p>
+      </article>
+
+      <article class="dl-card dl-card--green">
+        <div class="dl-card-head"><h2>Debian / Ubuntu</h2><span class="dl-tag">.deb &middot; x86-64 &amp; ARM64</span></div>
+        <ul class="dl-files">
+          <li><a href="{{ rel }}/sipnab_{{ v }}_amd64.deb">sipnab_{{ v }}_amd64.deb</a><span>x86-64</span></li>
+          <li><a href="{{ rel }}/sipnab_{{ v }}_arm64.deb">sipnab_{{ v }}_arm64.deb</a><span>ARM64</span></li>
+        </ul>
+        <pre class="dl-cmd"><code>sudo apt install ./sipnab_{{ v }}_amd64.deb</code></pre>
+      </article>
+
+      <article class="dl-card dl-card--blue">
+        <div class="dl-card-head"><h2>Linux &mdash; static</h2><span class="dl-tag">musl &middot; no dependencies</span></div>
+        <p>Self-contained; runs on any distro.</p>
+        <ul class="dl-files">
+          <li><a href="{{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-musl.tar.gz">sipnab-{{ v }}-x86_64-musl.tar.gz</a><span>x86-64</span></li>
+          <li><a href="{{ rel }}/sipnab-{{ v }}-aarch64-unknown-linux-musl.tar.gz">sipnab-{{ v }}-aarch64-musl.tar.gz</a><span>ARM64</span></li>
+        </ul>
+      </article>
+
+      <article class="dl-card">
+        <div class="dl-card-head"><h2>Linux &mdash; glibc</h2><span class="dl-tag">dynamic &middot; needs libpcap</span></div>
+        <ul class="dl-files">
+          <li><a href="{{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-gnu.tar.gz">sipnab-{{ v }}-x86_64-gnu.tar.gz</a><span>x86-64</span></li>
+          <li><a href="{{ rel }}/sipnab-{{ v }}-aarch64-unknown-linux-gnu.tar.gz">sipnab-{{ v }}-aarch64-gnu.tar.gz</a><span>ARM64</span></li>
+        </ul>
+      </article>
+
+      <article class="dl-card">
+        <div class="dl-card-head"><h2>From source</h2><span class="dl-tag">Rust 1.92+</span></div>
+        <pre class="dl-cmd"><code>git clone {{ config.extra.github_url }}.git
+cd sipnab &amp;&amp; cargo build --release --features full</code></pre>
+      </article>
+
+    </div>
+
+    <p class="download-foot">
+      Verify downloads against <a href="{{ rel }}/SHA256SUMS.txt">SHA256SUMS.txt</a>.
+      Need setup help? See the <a href="{{ get_url(path='@/docs/install.md') }}">install guide</a>.
+    </p>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
Adds a dedicated **/download** page linking every v0.4.2 install artifact, wired into the nav, styled to match the site.

Covers:
- **macOS** — `brew install NormB/tap/sipnab` (Intel + Apple Silicon) + direct tarballs
- **Debian/Ubuntu** — `.deb` amd64 + arm64 with apt instructions
- **Linux static (musl)** and **glibc** tarballs, x86-64 + ARM64
- **From source** + **SHA256SUMS** verification

All download URLs are built from `config.extra.version`, so a version bump updates them automatically. Also bumps the site version 0.4.1 → 0.4.2 (the hero badge was stale). Verified with a local `zola build` (11 pages, 0 orphans, internal-link check passed).