### PR TITLE
ci(dependabot): ignore dtolnay/rust-toolchain bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,7 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "ci"
+    ignore:
+      # The CI Rust toolchain is pinned deliberately; Dependabot misreads the
+      # action tag as a version bump (e.g. proposing a non-existent 1.100.0).
+      - dependency-name: "dtolnay/rust-toolchain"


### PR DESCRIPTION
Stops Dependabot from reproposing toolchain bumps like the spurious 1.100.0 (#7). The CI Rust version is pinned deliberately.