### PR TITLE
deps: bump aes 0.8→0.9 + cbc 0.1→0.2 (cipher 0.5 migration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,13 +4,13 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -273,11 +273,11 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
  "cipher",
 ]
@@ -432,11 +432,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -600,6 +600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +742,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,7 +855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "crypto-common",
+ "crypto-common 0.1.7",
 ]
 
 [[package]]
@@ -1283,6 +1298,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,12 +1400,12 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding",
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3367,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ base64 = { version = "0.22", optional = true }
 zeroize = { version = "1", features = ["derive"], optional = true }
 ring = { version = "0.17", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"], optional = true }
-aes = { version = "0.8", optional = true }
-cbc = { version = "0.1", features = ["alloc"], optional = true }
+aes = { version = "0.9", optional = true }
+cbc = { version = "0.2", features = ["alloc"], optional = true }
 
 # Audio playback (feature-gated)
 rodio = { version = "0.22", default-features = false, features = ["playback"], optional = true }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -120,7 +120,7 @@ impl CryptoBackend for RingCryptoBackend {
     }
 
     fn aes_cbc_decrypt(&self, key: &[u8], iv: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>> {
-        use cbc::cipher::{BlockDecryptMut, KeyIvInit};
+        use cbc::cipher::{BlockModeDecrypt, KeyIvInit};
 
         if iv.len() != 16 {
             anyhow::bail!("AES-CBC IV must be 16 bytes, got {}", iv.len());
@@ -140,7 +140,7 @@ impl CryptoBackend for RingCryptoBackend {
                 let decryptor = Aes128CbcDec::new_from_slices(key, iv)
                     .map_err(|e| anyhow::anyhow!("AES-128-CBC key/IV error: {e}"))?;
                 let plaintext = decryptor
-                    .decrypt_padded_mut::<cbc::cipher::block_padding::Pkcs7>(&mut buf)
+                    .decrypt_padded::<cbc::cipher::block_padding::Pkcs7>(&mut buf)
                     .map_err(|e| anyhow::anyhow!("AES-128-CBC decrypt failed: {e}"))?;
                 Ok(plaintext.to_vec())
             }
@@ -149,7 +149,7 @@ impl CryptoBackend for RingCryptoBackend {
                 let decryptor = Aes256CbcDec::new_from_slices(key, iv)
                     .map_err(|e| anyhow::anyhow!("AES-256-CBC key/IV error: {e}"))?;
                 let plaintext = decryptor
-                    .decrypt_padded_mut::<cbc::cipher::block_padding::Pkcs7>(&mut buf)
+                    .decrypt_padded::<cbc::cipher::block_padding::Pkcs7>(&mut buf)
                     .map_err(|e| anyhow::anyhow!("AES-256-CBC decrypt failed: {e}"))?;
                 Ok(plaintext.to_vec())
             }
@@ -395,7 +395,7 @@ mod tests {
 
         #[test]
         fn aes_128_cbc_roundtrip() {
-            use cbc::cipher::{BlockEncryptMut, KeyIvInit};
+            use cbc::cipher::{BlockModeEncrypt, KeyIvInit};
 
             let key = [0xAAu8; 16];
             let iv = [0xBBu8; 16];
@@ -405,7 +405,7 @@ mod tests {
             type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
             let encryptor = Aes128CbcEnc::new_from_slices(&key, &iv).unwrap();
             let ciphertext =
-                encryptor.encrypt_padded_vec_mut::<cbc::cipher::block_padding::Pkcs7>(plaintext);
+                encryptor.encrypt_padded_vec::<cbc::cipher::block_padding::Pkcs7>(plaintext);
 
             // Decrypt
             let backend = RingCryptoBackend;
@@ -415,7 +415,7 @@ mod tests {
 
         #[test]
         fn aes_256_cbc_roundtrip() {
-            use cbc::cipher::{BlockEncryptMut, KeyIvInit};
+            use cbc::cipher::{BlockModeEncrypt, KeyIvInit};
 
             let key = [0xCCu8; 32];
             let iv = [0xDDu8; 16];
@@ -424,7 +424,7 @@ mod tests {
             type Aes256CbcEnc = cbc::Encryptor<aes::Aes256>;
             let encryptor = Aes256CbcEnc::new_from_slices(&key, &iv).unwrap();
             let ciphertext =
-                encryptor.encrypt_padded_vec_mut::<cbc::cipher::block_padding::Pkcs7>(plaintext);
+                encryptor.encrypt_padded_vec::<cbc::cipher::block_padding::Pkcs7>(plaintext);
 
             let backend = RingCryptoBackend;
             let decrypted = backend.aes_cbc_decrypt(&key, &iv, &ciphertext).unwrap();


### PR DESCRIPTION
Dependabot #15 (aes) and #12 (cbc) — migrated together since they share the `cipher` trait version (0.4→0.5).

cipher 0.5 API changes applied in `src/crypto.rs`:
- `BlockDecryptMut`/`BlockEncryptMut` → `BlockModeDecrypt`/`BlockModeEncrypt`
- `decrypt_padded_mut` → `decrypt_padded`
- `encrypt_padded_vec_mut` → `encrypt_padded_vec`

Verified: builds with `--features tls`, crypto roundtrip tests pass (17/17), clippy clean. Supersedes #12 and #15.