### PR TITLE
deps: bump toml 0.8→1.x (#13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2756,11 +2756,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3208,23 +3208,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3238,28 +3232,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -3268,14 +3248,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -4002,15 +3982,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ libc = { version = "0.2", optional = true }
 # Phase 2: SIP parsing & output
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.8"
+toml = "1"
 pcap-file = { version = "2", optional = true }
 nom = "7"
 indexmap = "2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -534,10 +534,11 @@ impl Config {
         // Parse into a generic TOML value to walk keys. Use `from_str` (full
         // document) rather than `str::parse`, which in toml 1.x parses a single
         // value expression (so `[capture]` would be read as an array).
-        let value: toml::Value = toml::from_str(content).map_err(|e| crate::Error::ConfigParse {
-            path: display.clone(),
-            reason: format!("{e}"),
-        })?;
+        let value: toml::Value =
+            toml::from_str(content).map_err(|e| crate::Error::ConfigParse {
+                path: display.clone(),
+                reason: format!("{e}"),
+            })?;
 
         warn_unknown_keys(&value);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -531,8 +531,10 @@ impl Config {
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| "<inline>".to_string());
 
-        // Parse into generic TOML value to walk keys
-        let value: toml::Value = content.parse().map_err(|e| crate::Error::ConfigParse {
+        // Parse into a generic TOML value to walk keys. Use `from_str` (full
+        // document) rather than `str::parse`, which in toml 1.x parses a single
+        // value expression (so `[capture]` would be read as an array).
+        let value: toml::Value = toml::from_str(content).map_err(|e| crate::Error::ConfigParse {
             path: display.clone(),
             reason: format!("{e}"),
         })?;


### PR DESCRIPTION
Dependabot #13. toml 1.x changed `str::parse::<Value>()` semantics to parse a single value expression rather than a full document, breaking config key-walking (`[capture]` was read as an array). Fixed by using `toml::from_str` for the generic-Value parse in `config.rs`. Config tests 23/23, clippy clean. Supersedes #13.