### PR TITLE
deps: bump nom 7→8 (#14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2893,7 +2902,7 @@ dependencies = [
  "js-sys",
  "libc",
  "log",
- "nom",
+ "nom 8.0.0",
  "opus-decoder",
  "parking_lot",
  "pcap",
@@ -3042,7 +3051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 pcap-file = { version = "2", optional = true }
-nom = "7"
+nom = "8"
 indexmap = "2"
 bytes = "1"
 

--- a/src/sip/dsl.rs
+++ b/src/sip/dsl.rs
@@ -15,13 +15,13 @@
 
 use anyhow::{Result, bail};
 use nom::{
-    IResult,
+    IResult, Parser,
     branch::alt,
     bytes::complete::{tag, tag_no_case, take_while1},
     character::complete::{char, multispace0, multispace1},
     combinator::{map, opt, recognize},
     number::complete::double,
-    sequence::{preceded, tuple},
+    sequence::preceded,
 };
 
 use super::dialog::{DialogState, SipDialog};
@@ -274,7 +274,7 @@ fn parse_or_expr(input: &str) -> IResult<&str, Expr, NomErr<'_>> {
     loop {
         let trimmed = remaining.trim_start();
         if let Ok((after_or, _)) =
-            preceded(tag_no_case::<&str, &str, NomErr<'_>>("OR"), multispace1)(trimmed)
+            preceded(tag_no_case::<&str, &str, NomErr<'_>>("OR"), multispace1).parse(trimmed)
         {
             let (rest, right) = parse_and_expr(after_or)?;
             result = Expr::Or(Box::new(result), Box::new(right));
@@ -297,7 +297,7 @@ fn parse_and_expr(input: &str) -> IResult<&str, Expr, NomErr<'_>> {
     loop {
         let trimmed = remaining.trim_start();
         if let Ok((after_and, _)) =
-            preceded(tag_no_case::<&str, &str, NomErr<'_>>("AND"), multispace1)(trimmed)
+            preceded(tag_no_case::<&str, &str, NomErr<'_>>("AND"), multispace1).parse(trimmed)
         {
             let (rest, right) = parse_not_expr(after_and)?;
             result = Expr::And(Box::new(result), Box::new(right));
@@ -316,7 +316,7 @@ fn parse_not_expr(input: &str) -> IResult<&str, Expr, NomErr<'_>> {
 
     // Try "NOT" followed by whitespace
     if let Ok((after_not, _)) =
-        preceded(tag_no_case::<&str, &str, NomErr<'_>>("NOT"), multispace1)(input)
+        preceded(tag_no_case::<&str, &str, NomErr<'_>>("NOT"), multispace1).parse(input)
     {
         let (rest, inner) = parse_atom(after_not)?;
         return Ok((rest, Expr::Not(Box::new(inner))));
@@ -331,10 +331,10 @@ fn parse_atom(input: &str) -> IResult<&str, Expr, NomErr<'_>> {
 
     // Try parenthesized expression
     if input.starts_with('(') {
-        let (input, _) = char('(')(input)?;
+        let (input, _) = char('(').parse(input)?;
         let (input, expr) = parse_or_expr(input)?;
         let (input, _) = multispace0(input)?;
-        let (input, _) = char(')')(input)?;
+        let (input, _) = char(')').parse(input)?;
         return Ok((input, expr));
     }
 
@@ -356,13 +356,14 @@ fn parse_comparison(input: &str) -> IResult<&str, Expr, NomErr<'_>> {
 
 /// Parse a dotted field identifier.
 fn parse_field(input: &str) -> IResult<&str, Field, NomErr<'_>> {
-    let (rest, ident) = recognize(tuple((
+    let (rest, ident) = recognize((
         take_while1(|c: char| c.is_ascii_alphanumeric() || c == '_'),
         opt(preceded(
             char('.'),
             take_while1(|c: char| c.is_ascii_alphanumeric() || c == '_'),
         )),
-    )))(input)?;
+    ))
+    .parse(input)?;
 
     let field = match ident {
         "from.user" => Field::FromUser,
@@ -482,7 +483,8 @@ fn parse_operator(input: &str) -> IResult<&str, Operator, NomErr<'_>> {
         map(tag(">="), |_| Operator::Ge),
         map(tag("<"), |_| Operator::Lt),
         map(tag(">"), |_| Operator::Gt),
-    ))(input)
+    ))
+    .parse(input)
 }
 
 /// Parse a value literal (string, number, or boolean).
@@ -493,7 +495,7 @@ fn parse_value(input: &str, op: Operator) -> IResult<&str, Value, NomErr<'_>> {
     let (input, _) = multispace0(input)?;
 
     // Try boolean literals first
-    if let Ok((rest, _)) = tag_no_case::<&str, &str, NomErr<'_>>("true")(input) {
+    if let Ok((rest, _)) = tag_no_case::<&str, &str, NomErr<'_>>("true").parse(input) {
         // Ensure "true" is not a prefix of a longer identifier
         if rest.is_empty()
             || !rest
@@ -504,7 +506,7 @@ fn parse_value(input: &str, op: Operator) -> IResult<&str, Value, NomErr<'_>> {
             return Ok((rest, Value::Bool(true)));
         }
     }
-    if let Ok((rest, _)) = tag_no_case::<&str, &str, NomErr<'_>>("false")(input)
+    if let Ok((rest, _)) = tag_no_case::<&str, &str, NomErr<'_>>("false").parse(input)
         && (rest.is_empty()
             || !rest
                 .chars()


### PR DESCRIPTION
Dependabot #14. nom 8: combinators return `Parser` types invoked via `.parse(input)`, and `sequence::tuple` is removed (plain tuples impl `Parser`). Migrated `src/sip/dsl.rs` (the only nom user): added `Parser` import, `.parse()` at call sites, `recognize((a,b))` instead of `recognize(tuple((a,b)))`. DSL tests 33/33, clippy clean. Supersedes #14.