### PR TITLE
deps: bump etherparse 0.16→0.20 (#16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "etherparse"
-version = "0.16.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d8a704b617484e9d867a0423cd45f7577f008c4068e2e33378f8d3860a6d73"
+checksum = "3ac016aaf11dfe643edcd088a166234bfcb72e7f06691abfcf21e9af524037f4"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["website/", "demos/", "tasks/", "fuzz/", ".githooks/", "tests/pcap-sa
 [dependencies]
 # Phase 1: Capture & core
 pcap = { version = "2", optional = true }
-etherparse = "0.16"
+etherparse = "0.20"
 clap = { version = "4", features = ["derive", "env", "string"], optional = true }
 regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }

--- a/src/capture/parse.rs
+++ b/src/capture/parse.rs
@@ -385,6 +385,9 @@ fn extract_parsed_packet(
                 v6.payload().ip_number.0,
             )
         }
+        // ARP (added as a NetSlice variant in etherparse 0.20) carries no IP
+        // layer; sipnab only parses SIP/RTP over IP, so reject it here.
+        NetSlice::Arp(_) => anyhow::bail!("ARP packet has no IP layer to parse"),
     };
 
     // Check if this is a fragment (non-first fragment has no transport header)
@@ -394,6 +397,8 @@ fn extract_parsed_packet(
             // etherparse sets fragmented in the payload slice
             net.ip_payload_ref().map(|p| p.fragmented).unwrap_or(false)
         }
+        // Unreachable: the IP-address match above already bails on ARP.
+        NetSlice::Arp(_) => false,
     };
 
     // For non-first fragments, there's no transport header


### PR DESCRIPTION
Dependabot #16. etherparse 0.20 added a `NetSlice::Arp` variant. ARP frames have no IP layer, so `extract_parsed_packet` rejects them (IP-address match bails; fragment match returns false). Builds default + `--features full`, capture tests 145/145, clippy clean. Supersedes #16.