### PR TITLE
feat(website): site-wide UI/UX overhaul to industry standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 # Cancel superseded runs on the same ref to save runner minutes.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   check:

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -310,25 +310,80 @@ img { max-width: 100%; height: auto; }
 // Hero
 // =============================================================================
 
-.hero {
-  padding: 6rem 1.5rem 3rem;
+// =============================================================================
+// Homepage section rhythm & shared primitives
+// =============================================================================
+
+// Consistent vertical spacing scale for every homepage section below the hero.
+%home-section {
+  padding: 5.5rem 1.5rem;
+  border-top: 1px solid $border;
+}
+
+// Section header block: kicker + title, centered, with consistent spacing.
+.section-head {
   text-align: center;
-  background: radial-gradient(ellipse at 50% 0%, rgba(255,204,102,0.06) 0%, transparent 60%);
+  margin-bottom: 3rem;
+}
+
+.section-kicker {
+  font-family: $font-mono;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: $accent;
+  margin: 0 0 0.6rem;
+}
+
+.hero {
+  position: relative;
+  padding: 7rem 1.5rem 3rem;
+  text-align: center;
+  overflow: hidden;
+  background: radial-gradient(ellipse at 50% -10%, rgba(255,204,102,0.10) 0%, transparent 55%);
+}
+
+// Subtle grid + glow wash behind the hero copy. Decorative only.
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(115,208,255,0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(115,208,255,0.035) 1px, transparent 1px);
+  background-size: 48px 48px;
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 0%, transparent 75%);
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 0%, transparent 75%);
 }
 
 .hero-inner {
+  position: relative;
+  z-index: 1;
   max-width: 720px;
   margin: 0 auto;
 }
 
+.hero-kicker {
+  font-family: $font-mono;
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: $accent;
+  margin: 0 0 1.1rem;
+}
+
 .hero-title {
   font-family: $font-mono;
-  font-size: 4.5rem;
+  font-size: clamp(3rem, 8vw, 4.75rem);
   font-weight: 700;
   color: $accent;
   letter-spacing: -0.03em;
-  line-height: 1.1;
-  margin-bottom: 1rem;
+  line-height: 1.05;
+  margin-bottom: 1.1rem;
+  text-shadow: 0 0 60px rgba($accent, 0.25);
 }
 
 .version-badge {
@@ -343,15 +398,16 @@ img { max-width: 100%; height: auto; }
   padding: 0.2rem 0.6rem;
   vertical-align: middle;
   position: relative;
-  top: -0.15em;
+  top: -0.35em;
 }
 
 .hero-tagline {
-  font-size: 1.35rem;
+  font-size: clamp(1.15rem, 2.5vw, 1.4rem);
   font-weight: 500;
   color: $text;
   line-height: 1.4;
-  margin-bottom: 0.75rem;
+  margin: 0 auto 0.85rem;
+  max-width: 34rem;
 }
 
 // Inline reference to a standards document (e.g. "SIP", "RTP" -> RFC).
@@ -365,8 +421,9 @@ img { max-width: 100%; height: auto; }
 .hero-sub {
   font-size: 1.05rem;
   color: $text-dim;
-  line-height: 1.6;
-  margin-bottom: 2rem;
+  line-height: 1.65;
+  margin: 0 auto 2.25rem;
+  max-width: 36rem;
 }
 
 .hero-actions {
@@ -377,34 +434,37 @@ img { max-width: 100%; height: auto; }
 }
 
 .btn {
-  display: inline-block;
-  font-size: 0.925rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.95rem;
   font-weight: 600;
   font-family: $font-sans;
-  padding: 0.65rem 1.5rem;
+  padding: 0.72rem 1.6rem;
   border-radius: 8px;
-  transition: transform 0.1s, box-shadow 0.15s, background 0.15s;
-  &:hover { transform: translateY(-1px); }
+  transition: transform 0.12s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+  &:hover { transform: translateY(-2px); }
 }
 
 .btn-primary {
   background: $accent;
   color: $bg;
+  box-shadow: 0 4px 14px rgba($accent, 0.18);
   &:hover {
     color: $bg;
     background: lighten($accent, 5%);
-    box-shadow: 0 4px 16px rgba($accent, 0.3);
+    box-shadow: 0 8px 26px rgba($accent, 0.35);
   }
 }
 
 .btn-secondary {
-  background: transparent;
+  background: rgba($surface, 0.6);
   color: $text;
   border: 1px solid $border-light;
   &:hover {
     color: $text;
-    border-color: $text-dim;
-    background: rgba($text, 0.04);
+    border-color: $accent;
+    background: rgba($accent, 0.06);
   }
 }
 
@@ -415,18 +475,21 @@ img { max-width: 100%; height: auto; }
 }
 
 .terminal-wrap {
-  max-width: 900px;
-  margin: 3rem auto 0;
+  position: relative;
+  z-index: 1;
+  max-width: 920px;
+  margin: 3.5rem auto 0;
   padding: 0 1.5rem;
 }
 
 .hero-screenshot {
   width: 100%;
-  border-radius: 10px;
-  border: 2px solid $border-light;
-  outline: 1px solid rgba($accent, 0.15);
-  outline-offset: 2px;
-  box-shadow: 0 20px 80px rgba($accent, 0.08), 0 0 0 1px rgba($accent, 0.1);
+  border-radius: 12px;
+  border: 1px solid $border-light;
+  box-shadow:
+    0 30px 90px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba($accent, 0.10),
+    0 0 80px rgba($accent, 0.07);
 }
 
 .terminal {
@@ -501,78 +564,82 @@ img { max-width: 100%; height: auto; }
 }
 
 // =============================================================================
-// Features (3 columns)
+// Demos (single panel with tabs)
 // =============================================================================
 
-// -- Demo video (single panel with tabs) --
 .demos {
-  padding: 4rem 1.5rem;
-  border-top: 1px solid $border;
+  @extend %home-section;
 }
 
 .demos-inner {
   max-width: 960px;
   margin: 0 auto;
 
-  h2 {
-    font-size: 1.75rem;
+  > h2 {
+    font-size: clamp(1.6rem, 3vw, 2rem);
     font-weight: 700;
     color: $text;
-    margin-bottom: 1.5rem;
+    letter-spacing: -0.01em;
+    margin: 0 0 1.75rem;
     text-align: center;
   }
+
+  .section-kicker { text-align: center; }
 }
 
 .demo-tabs {
   display: flex;
-  gap: 0.25rem;
+  gap: 0.4rem;
   justify-content: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.75rem;
   flex-wrap: wrap;
 }
 
 .demo-tab {
-  background: none;
+  background: rgba($surface, 0.5);
   border: 1px solid $border;
-  border-radius: 6px;
+  border-radius: 7px;
   color: $text-dim;
   font-family: $font-sans;
   font-size: 0.875rem;
   font-weight: 500;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1.05rem;
   cursor: pointer;
-  transition: color 0.15s, background 0.15s, border-color 0.15s;
+  transition: color 0.15s, background 0.15s, border-color 0.15s, transform 0.12s;
 
   &:hover {
     color: $text;
-    border-color: $text-dim;
+    border-color: $border-light;
+    transform: translateY(-1px);
   }
 
   &.active {
-    color: $accent;
+    color: $bg;
     border-color: $accent;
-    background: $accent-glow;
+    background: $accent;
+    font-weight: 600;
   }
 }
 
 .demo-panel {
   display: none;
 
-  &.active { display: block; }
+  &.active { display: block; animation: fadeInUp 0.4s ease both; }
 }
 
 .demo-desc {
   font-size: 0.95rem;
   color: $text-dim;
-  margin-bottom: 1rem;
+  margin-bottom: 1.1rem;
   text-align: center;
-  line-height: 1.5;
+  line-height: 1.55;
 
   kbd {
     font-family: $font-mono;
     font-size: 0.85em;
+    color: $text;
     background: $surface;
-    border: 1px solid $border;
+    border: 1px solid $border-light;
     border-bottom-width: 2px;
     border-radius: 4px;
     padding: 0.1em 0.4em;
@@ -583,9 +650,9 @@ img { max-width: 100%; height: auto; }
 
 .demo-panel img {
   width: 100%;
-  border-radius: 10px;
+  border-radius: 12px;
   border: 1px solid $border;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 204, 102, 0.06);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(255, 204, 102, 0.06);
 }
 
 // =============================================================================
@@ -593,30 +660,34 @@ img { max-width: 100%; height: auto; }
 // =============================================================================
 
 .features {
-  padding: 4rem 1.5rem;
-  border-top: 1px solid $border;
+  @extend %home-section;
 }
 
 .features-inner {
   max-width: $max-width;
   margin: 0 auto;
+}
+
+.features-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 2rem;
+  gap: 1.5rem;
 }
 
 .feature-card {
+  position: relative;
   background: $surface;
   border: 1px solid $border;
   border-top: 3px solid transparent;
-  border-radius: 10px;
+  border-radius: 12px;
   padding: 2rem;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
 
   &:hover {
     border-color: $border-light;
     border-top-color: inherit;
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+    transform: translateY(-4px);
+    box-shadow: 0 14px 40px rgba(0, 0, 0, 0.35);
   }
 
   &--amber { border-top-color: $accent; }
@@ -628,16 +699,18 @@ img { max-width: 100%; height: auto; }
   &--blue:hover  { border-top-color: $link; }
 
   h3 {
-    font-size: 1.125rem;
+    font-size: 1.2rem;
     font-weight: 700;
     color: $text;
-    margin: 1rem 0 0.5rem;
+    margin: 1.1rem 0 0.55rem;
+    letter-spacing: -0.01em;
   }
 
   p {
     font-size: 0.9rem;
     color: $text-dim;
-    line-height: 1.65;
+    line-height: 1.7;
+    margin: 0;
   }
 }
 
@@ -647,9 +720,12 @@ img { max-width: 100%; height: auto; }
   align-items: center;
   justify-content: center;
   background: rgba($accent, 0.08);
-  border-radius: 50%;
+  border-radius: 14px;
   width: 56px;
   height: 56px;
+  transition: transform 0.2s ease, background 0.2s ease;
+
+  .feature-card:hover & { transform: scale(1.06); }
 
   .feature-card--green & { color: $code-green; background: rgba($code-green, 0.08); }
   .feature-card--blue &  { color: $link; background: rgba($link, 0.08); }
@@ -660,68 +736,70 @@ img { max-width: 100%; height: auto; }
 // =============================================================================
 
 .quickstart {
-  padding: 4rem 1.5rem;
-  border-top: 1px solid $border;
+  @extend %home-section;
 }
 
 .quickstart-inner {
   max-width: $doc-width;
   margin: 0 auto;
-
-  h2 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    color: $text;
-    margin-bottom: 1.5rem;
-    text-align: center;
-  }
 }
 
 .code-block-wrap {
   background: $surface;
   border: 1px solid $border;
-  border-radius: 10px;
+  border-radius: 12px;
   overflow: hidden;
   position: relative;
+  box-shadow: 0 14px 44px rgba(0, 0, 0, 0.3);
 
   pre {
     font-family: $font-mono;
     font-size: 0.85rem;
-    line-height: 1.65;
+    line-height: 1.7;
     padding: 1.5rem;
+    margin: 0;
     overflow-x: auto;
     color: $code-green;
 
     .t-muted { color: $text-dim; }
-    .t-comment { color: lighten($text-dim, 10%); }
-  }
-
-  // Line numbers via CSS counter
-  pre.line-numbers {
-    counter-reset: line;
-    padding-left: 3.5rem;
-
-    code {
-      display: block;
-    }
-
-    code > span,
-    code > br {
-      // Handled via wrapping below
-    }
-  }
-
-  pre.line-numbers code::before {
-    // Not practical with inline HTML — use wrapper approach
+    .t-comment { color: lighten($text-dim, 12%); }
   }
 }
 
-// Copy button
-.copy-btn {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+// macOS-style window header on the quickstart terminal — matches the download page.
+.code-block-head {
   display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem;
+  background: darken($surface, 3%);
+  border-bottom: 1px solid $border;
+}
+
+.code-block-dots {
+  display: inline-flex;
+  gap: 0.4rem;
+  i {
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    display: block;
+    &:nth-child(1) { background: #ff5f57; }
+    &:nth-child(2) { background: #febc2e; }
+    &:nth-child(3) { background: #28c840; }
+  }
+}
+
+.code-block-title {
+  flex: 1;
+  font-family: $font-mono;
+  font-size: 0.74rem;
+  color: $text-dim;
+}
+
+// Copy button — sits inside the window header at the right.
+.copy-btn {
+  display: inline-flex;
   align-items: center;
   gap: 0.35rem;
   background: $surface-2;
@@ -732,134 +810,75 @@ img { max-width: 100%; height: auto; }
   font-size: 0.75rem;
   padding: 0.3rem 0.6rem;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
-  z-index: 2;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
 
   &:hover {
     color: $text;
-    border-color: $text-dim;
+    border-color: $border-light;
+    background: lighten($surface-2, 3%);
   }
 }
 
 // =============================================================================
-// Comparison table
+// What sipnab does (reference table)
 // =============================================================================
 
 .comparison {
-  padding: 4rem 1.5rem;
-  border-top: 1px solid $border;
+  @extend %home-section;
 }
 
 .comparison-inner {
   max-width: $doc-width;
   margin: 0 auto;
-
-  h2 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    color: $text;
-    margin-bottom: 1.5rem;
-    text-align: center;
-  }
 }
 
 .comparison-table-wrap {
-  overflow-x: auto;
+  overflow: hidden;
   border: 1px solid $border;
-  border-radius: 10px;
+  border-radius: 12px;
+  box-shadow: 0 14px 44px rgba(0, 0, 0, 0.25);
 }
 
 .comparison-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
 
   th, td {
-    padding: 0.75rem 1rem;
+    padding: 0.9rem 1.15rem;
     text-align: left;
     border-bottom: 1px solid $border;
-    white-space: nowrap;
+    vertical-align: top;
   }
 
   th {
     font-weight: 600;
     color: $text;
     background: darken($surface, 2%);
+    font-size: 0.82rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
   }
 
-  td { color: $text-dim; }
-  td:first-child { color: $text; font-weight: 500; }
-
-  td.yes { color: $good; font-weight: 600; }
-  td.no { color: $text-dim; }
-  td.lang { color: $text; font-weight: 500; font-family: $font-mono; font-size: 0.8rem; }
-
-  // sipnab column highlight
-  th.col-sipnab,
-  td.col-sipnab {
-    background: rgba($accent, 0.04);
+  // Capability column: emphasized, never wraps awkwardly.
+  td:first-child {
+    color: $text;
+    font-weight: 600;
+    width: 34%;
+    white-space: nowrap;
   }
 
-  // Checkmark/cross sizing
-  td.yes span { font-size: 1.1em; }
-  td.no span { font-size: 1.0em; opacity: 0.5; }
+  td:last-child {
+    color: $text-dim;
+    line-height: 1.55;
+  }
 
   tr:last-child td { border-bottom: none; }
-  tr:hover td { background: rgba($text, 0.02); }
-  tr:hover td.col-sipnab { background: rgba($accent, 0.07); }
-}
-
-// =============================================================================
-// Architecture callout
-// =============================================================================
-
-.arch-callout {
-  padding: 4rem 1.5rem;
-  border-top: 1px solid $border;
-}
-
-.arch-inner {
-  max-width: $max-width;
-  margin: 0 auto;
-
-  h2 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    color: $text;
-    margin-bottom: 2rem;
-    text-align: center;
+  tbody tr {
+    transition: background 0.12s ease;
+    &:hover td { background: rgba($accent, 0.03); }
+    &:hover td:first-child { color: $accent; }
   }
-}
-
-.arch-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 1.5rem;
-}
-
-.arch-item {
-  text-align: center;
-  padding: 1.75rem 1rem;
-  background: $surface;
-  border: 1px solid $border;
-  border-radius: 10px;
-}
-
-.arch-stat {
-  display: block;
-  font-family: $font-mono;
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: $accent;
-  line-height: 1.2;
-}
-
-.arch-label {
-  display: block;
-  font-size: 0.825rem;
-  color: $text-dim;
-  margin-top: 0.5rem;
-  line-height: 1.4;
 }
 
 // =============================================================================
@@ -867,30 +886,21 @@ img { max-width: 100%; height: auto; }
 // =============================================================================
 
 .metrics {
-  padding: 4rem 1.5rem;
-  border-top: 1px solid $border;
+  @extend %home-section;
 }
 
 .metrics-inner {
   max-width: $max-width;
   margin: 0 auto;
-
-  h2 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    color: $text;
-    margin-bottom: 0.75rem;
-    text-align: center;
-  }
 }
 
 .metrics-sub {
   max-width: 640px;
-  margin: 0 auto 2.5rem;
+  margin: 1rem auto 0;
   text-align: center;
   color: $text-dim;
   font-size: 0.95rem;
-  line-height: 1.6;
+  line-height: 1.65;
 }
 
 .metrics-grid {
@@ -900,15 +910,16 @@ img { max-width: 100%; height: auto; }
 }
 
 .metric-card {
-  padding: 1.5rem;
+  padding: 1.6rem;
   background: $surface;
   border: 1px solid $border;
-  border-radius: 10px;
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  border-radius: 12px;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 
   &:hover {
     border-color: $border-light;
-    transform: translateY(-2px);
+    transform: translateY(-4px);
+    box-shadow: 0 14px 40px rgba(0, 0, 0, 0.3);
   }
 }
 
@@ -935,18 +946,72 @@ img { max-width: 100%; height: auto; }
 }
 
 .metric-name {
-  font-size: 1.2rem;
+  font-size: 1.25rem;
   font-weight: 700;
   color: $text;
   margin: 0 0 0.4rem;
+  letter-spacing: -0.01em;
 }
 
 .metric-desc {
   font-size: 0.875rem;
   color: $text-dim;
-  line-height: 1.55;
+  line-height: 1.6;
   margin: 0;
 }
+
+// =============================================================================
+// Architecture callout (stat band)
+// =============================================================================
+
+.arch-callout {
+  @extend %home-section;
+}
+
+.arch-inner {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.arch-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.arch-item {
+  text-align: center;
+  padding: 2.25rem 1rem;
+  background: linear-gradient(180deg, $surface 0%, darken($surface, 1.5%) 100%);
+  border: 1px solid $border;
+  border-radius: 12px;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    border-color: rgba($accent, 0.35);
+    transform: translateY(-4px);
+    box-shadow: 0 14px 40px rgba(0, 0, 0, 0.3);
+  }
+}
+
+.arch-stat {
+  display: block;
+  font-family: $font-mono;
+  font-size: clamp(2.2rem, 5vw, 2.75rem);
+  font-weight: 700;
+  color: $accent;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+.arch-label {
+  display: block;
+  font-size: 0.84rem;
+  color: $text-dim;
+  margin-top: 0.6rem;
+  line-height: 1.45;
+}
+
 
 // =============================================================================
 // Doc layout (single-column + floating TOC)
@@ -1432,13 +1497,19 @@ img { max-width: 100%; height: auto; }
 
   .nav-toggle { display: flex; }
 
-  .hero { padding: 3rem 1rem 2rem; }
-  .hero-title { font-size: 2.75rem; }
-  .hero-tagline { font-size: 1.1rem; }
+  .hero { padding: 4rem 1.25rem 2rem; }
 
-  .features-inner { grid-template-columns: 1fr; gap: 1rem; }
-  .arch-grid { grid-template-columns: repeat(2, 1fr); }
+  // Tighter vertical rhythm on small screens (sections use 5.5rem on desktop).
+  .demos, .features, .quickstart, .comparison, .metrics, .arch-callout {
+    padding: 3.5rem 1.25rem;
+  }
+  .section-head { margin-bottom: 2rem; }
+
+  .features-grid { grid-template-columns: 1fr; gap: 1rem; }
+  .arch-grid { grid-template-columns: repeat(3, 1fr); gap: 1rem; }
   .metrics-grid { grid-template-columns: repeat(2, 1fr); }
+
+  .terminal-wrap { margin-top: 2.5rem; padding: 0 1rem; }
 
   .doc-layout { padding: 1.5rem 1rem 3rem; }
   .doc-content {
@@ -1461,12 +1532,23 @@ img { max-width: 100%; height: auto; }
 }
 
 @media (max-width: 480px) {
-  .hero-title { font-size: 2.25rem; }
-  .hero-actions { flex-direction: column; align-items: center; }
+  .hero { padding: 3.25rem 1rem 1.5rem; }
+  .hero-kicker { font-size: 0.66rem; letter-spacing: 0.18em; }
+  .hero-actions { flex-direction: column; align-items: stretch; }
+  .hero-actions .btn { justify-content: center; }
   .arch-grid { grid-template-columns: 1fr; }
   .metrics-grid { grid-template-columns: 1fr; }
-  .arch-stat { font-size: 2rem; }
   .version-badge { font-size: 0.7rem; }
+
+  .demo-tabs { gap: 0.3rem; }
+  .demo-tab { padding: 0.4rem 0.8rem; font-size: 0.8rem; }
+
+  // Keep the reference table readable on narrow screens.
+  .comparison-table { font-size: 0.82rem; }
+  .comparison-table th, .comparison-table td { padding: 0.7rem 0.8rem; }
+  .comparison-table td:first-child { width: auto; white-space: normal; }
+
+  .code-block-wrap pre { font-size: 0.78rem; padding: 1.1rem; }
 }
 
 // Download page

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -7,7 +7,7 @@ $bg:          #0a0e14;
 $surface:     #1f2430;
 $surface-2:   #242936;
 $text:        #cbccc6;
-$text-dim:    #707a8c;
+$text-dim:    #8a93a3; // WCAG AA: 6.25:1 on bg, 5.01:1 on surface (was #707a8c)
 $accent:      #ffcc66;
 $accent-glow: rgba(255, 204, 102, 0.12);
 $link:        #73d0ff;
@@ -63,6 +63,62 @@ a {
 }
 
 img { max-width: 100%; height: auto; }
+
+// =============================================================================
+// Accessibility
+// =============================================================================
+
+// Skip-to-content link: visually hidden until focused, then slides in top-left.
+.skip-link {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 2000;
+  padding: 0.6rem 1rem;
+  font-family: $font-mono;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: $bg;
+  background: $accent;
+  border-radius: 0 0 6px 0;
+  transform: translateY(-120%);
+  transition: transform 0.15s ease;
+  &:focus {
+    transform: translateY(0);
+    color: $bg;
+  }
+}
+
+// Clear, consistent keyboard-focus indicator. Mouse clicks stay clean.
+:focus-visible {
+  outline: 2px solid $accent;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+[tabindex]:focus-visible,
+.nav-logo:focus-visible,
+.nav-links a:focus-visible,
+.nav-toggle:focus-visible,
+.search-trigger:focus-visible,
+.nav-github:focus-visible,
+.nav-sponsor:focus-visible,
+.nav-gh-sponsor:focus-visible {
+  outline: 2px solid $accent;
+  outline-offset: 2px;
+}
+
+// Respect users who prefer reduced motion.
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
 
 // =============================================================================
 // Navigation
@@ -1354,23 +1410,55 @@ img { max-width: 100%; height: auto; }
 // =============================================================================
 
 .error-page {
+  max-width: 560px;
+  margin: 0 auto;
   text-align: center;
   padding: 8rem 1.5rem;
 
-  h1 {
+  .error-code {
     font-family: $font-mono;
-    font-size: 5rem;
+    font-size: clamp(4rem, 14vw, 7rem);
     font-weight: 700;
     color: $accent;
     line-height: 1;
-    margin-bottom: 1rem;
+    letter-spacing: -0.04em;
+    margin-bottom: 0.5rem;
+  }
+
+  .error-prompt {
+    display: inline-block;
+    font-family: $font-mono;
+    font-size: 0.95rem;
+    color: $code-green;
+    background: $surface;
+    border: 1px solid $border;
+    border-radius: 8px;
+    padding: 0.6rem 1rem;
+    margin-bottom: 1.75rem;
+
+    .error-sigil { color: $accent; margin-right: 0.5rem; }
+    .error-cursor {
+      display: inline-block;
+      width: 0.55em;
+      height: 1.05em;
+      margin-left: 0.15em;
+      vertical-align: text-bottom;
+      background: $code-green;
+      animation: error-blink 1.1s step-end infinite;
+    }
   }
 
   p {
     font-size: 1.1rem;
     color: $text-dim;
+    line-height: 1.6;
     margin-bottom: 2rem;
   }
+}
+
+@keyframes error-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
 }
 
 // =============================================================================

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -1771,7 +1771,8 @@ input:focus-visible,
   .metrics-grid { grid-template-columns: repeat(3, 1fr); }
 }
 
-@media (max-width: 768px) {
+// Collapse the (wide) nav into the hamburger before it can clip the right-side actions.
+@media (max-width: 1200px) {
   .nav-links {
     display: none;
     position: absolute;
@@ -1794,6 +1795,9 @@ input:focus-visible,
 
   .nav-toggle { display: flex; }
 
+}
+
+@media (max-width: 768px) {
   .hero { padding: 4rem 1.25rem 2rem; }
 
   // Tighter vertical rhythm on small screens (sections use 5.5rem on desktop).

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -952,106 +952,208 @@ img { max-width: 100%; height: auto; }
 // Doc layout (single-column + floating TOC)
 // =============================================================================
 
+// =============================================================================
+// Documentation
+// =============================================================================
+
 .doc-layout {
   max-width: $max-width;
   margin: 0 auto;
-  padding: 2rem 1.5rem 4rem;
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: flex-start;
-  gap: 3rem;
+  padding: 2.5rem 1.5rem 5rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) $toc-width;
+  align-items: start;
+  gap: 3.5rem;
 }
 
 .doc-content {
-  flex: 1;
   min-width: 0;
   max-width: $doc-width;
-  overflow: hidden;
+  font-size: 1rem;
 
   // Heading anchors: offset for sticky nav
   h1, h2, h3, h4 {
-    scroll-margin-top: 80px;
+    scroll-margin-top: calc(#{$nav-height} + 1.25rem);
+  }
+
+  // -- Document header --
+  .doc-header {
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.75rem;
+    border-bottom: 1px solid $border;
+  }
+
+  .doc-kicker {
+    font-family: $font-mono;
+    font-size: 0.72rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: $accent;
+    margin: 0 0 0.6rem;
+  }
+
+  .doc-lead {
+    margin: 0.9rem 0 0;
+    max-width: 64ch;
+    font-size: 1.075rem;
+    line-height: 1.6;
+    color: $text-dim;
+  }
+
+  .doc-header h1 { margin: 0; }
+
+  // -- Body measure --
+  .doc-body {
+    p, ul, ol, blockquote, table, .table-wrapper {
+      max-width: 70ch;
+    }
   }
 
   // kbd styling for keybindings
   kbd {
     display: inline-block;
     font-family: $font-mono;
-    font-size: 0.8em;
+    font-size: 0.78em;
     background: $surface-2;
     color: $text;
     border: 1px solid $border-light;
     border-bottom-width: 2px;
-    border-radius: 4px;
-    padding: 0.1em 0.45em;
+    border-radius: 5px;
+    padding: 0.12em 0.5em;
     line-height: 1.4;
+    white-space: nowrap;
   }
 
+  // -- Headings --
   h1 {
-    font-size: 2rem;
+    font-size: clamp(1.9rem, 1.4rem + 1.8vw, 2.4rem);
     font-weight: 700;
-    color: $text;
-    margin-bottom: 1.5rem;
-    line-height: 1.2;
+    color: lighten($text, 6%);
+    line-height: 1.15;
+    letter-spacing: -0.02em;
   }
 
   h2 {
-    font-size: 1.35rem;
+    font-size: 1.5rem;
     font-weight: 700;
-    color: $text;
-    margin: 2.5rem 0 1rem;
-    padding-bottom: 0.4rem;
+    color: lighten($text, 6%);
+    line-height: 1.25;
+    letter-spacing: -0.01em;
+    margin: 3rem 0 1.1rem;
+    padding-bottom: 0.5rem;
     border-bottom: 1px solid $border;
   }
 
   h3 {
-    font-size: 1.1rem;
+    font-size: 1.2rem;
     font-weight: 600;
-    color: $text;
-    margin: 2rem 0 0.75rem;
+    color: lighten($text, 4%);
+    line-height: 1.3;
+    margin: 2.25rem 0 0.85rem;
   }
 
   h4 {
-    font-size: 0.95rem;
+    font-size: 1rem;
     font-weight: 600;
     color: $text;
-    margin: 1.5rem 0 0.5rem;
+    margin: 1.75rem 0 0.6rem;
+  }
+
+  // Anchor links inside headings (Zola inserts these when configured)
+  h2 a, h3 a, h4 a {
+    color: inherit;
+    &:hover { color: $accent; }
   }
 
   p {
-    margin-bottom: 1rem;
+    margin-bottom: 1.15rem;
+    line-height: 1.75;
   }
 
-  ul, ol {
-    margin-bottom: 1rem;
-    padding-left: 1.5rem;
-
-    li {
-      margin-bottom: 0.25rem;
+  a {
+    color: $link;
+    text-decoration: none;
+    border-bottom: 1px solid rgba($link, 0.28);
+    transition: color 0.15s ease, border-color 0.15s ease;
+    &:hover {
+      color: lighten($link, 10%);
+      border-bottom-color: rgba($link, 0.7);
     }
   }
 
-  // Inline code
-  code {
-    font-family: $font-mono;
-    font-size: 0.85em;
-    background: $surface;
-    color: $code-green;
-    padding: 0.15em 0.4em;
-    border-radius: 4px;
-    border: 1px solid $border;
+  ul, ol {
+    margin-bottom: 1.15rem;
+    padding-left: 1.4rem;
+    line-height: 1.75;
+
+    li {
+      margin-bottom: 0.4rem;
+      padding-left: 0.25rem;
+
+      &::marker { color: $text-dim; }
+    }
+
+    ul, ol {
+      margin: 0.4rem 0 0.5rem;
+    }
   }
 
-  // Code blocks
+  ul li::marker { color: $border-light; }
+
+  // -- Inline code --
+  code {
+    font-family: $font-mono;
+    font-size: 0.84em;
+    background: rgba($code-green, 0.08);
+    color: $code-green;
+    padding: 0.16em 0.42em;
+    border-radius: 5px;
+    border: 1px solid rgba($code-green, 0.16);
+    word-break: break-word;
+  }
+
+  a code {
+    color: inherit;
+    background: rgba($link, 0.1);
+    border-color: rgba($link, 0.18);
+  }
+
+  // -- Code blocks --
   pre {
-    background: $surface;
+    position: relative;
+    background: $bg;
     border: 1px solid $border;
-    border-radius: 8px;
-    padding: 1rem 1.25rem;
+    border-radius: 10px;
+    padding: 1.1rem 1.25rem;
     overflow-x: auto;
-    margin-bottom: 1.5rem;
-    font-size: 0.85rem;
-    line-height: 1.6;
+    margin: 0 0 1.6rem;
+    font-size: 0.86rem;
+    line-height: 1.7;
+    -webkit-overflow-scrolling: touch;
+    tab-size: 2;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+
+    // Language badge from Zola's data-lang
+    &[data-lang]::before {
+      content: attr(data-lang);
+      position: absolute;
+      top: 0;
+      right: 0;
+      font-family: $font-mono;
+      font-size: 0.66rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: $text-dim;
+      background: $surface;
+      border-left: 1px solid $border;
+      border-bottom: 1px solid $border;
+      border-radius: 0 10px 0 8px;
+      padding: 0.25rem 0.65rem;
+      pointer-events: none;
+    }
+
+    &[data-lang="text"]::before,
+    &[data-lang=""]::before { content: none; }
 
     code {
       background: none;
@@ -1059,43 +1161,68 @@ img { max-width: 100%; height: auto; }
       padding: 0;
       color: $text;
       font-size: inherit;
+      word-break: normal;
+      // Ensure ayu-dark token spans (when present) keep their colors
+      span { background: transparent !important; }
     }
+
+    // Custom scrollbar
+    &::-webkit-scrollbar { height: 9px; }
+    &::-webkit-scrollbar-track { background: transparent; }
+    &::-webkit-scrollbar-thumb {
+      background: $border-light;
+      border-radius: 6px;
+    }
+    &::-webkit-scrollbar-thumb:hover { background: lighten($border-light, 10%); }
   }
 
-  // Tables
+  // -- Tables --
   table {
     width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 1.5rem;
+    border-collapse: separate;
+    border-spacing: 0;
+    margin-bottom: 1.6rem;
     font-size: 0.875rem;
-    display: block;
-    overflow-x: auto;
+    line-height: 1.6;
+    border: 1px solid $border;
+    border-radius: 10px;
+    overflow: hidden;
 
-    th, td {
-      padding: 0.6rem 0.75rem;
-      text-align: left;
-      border: 1px solid $border;
+    thead th {
+      font-weight: 600;
+      color: lighten($text, 6%);
+      background: $surface;
+      white-space: nowrap;
     }
 
-    th {
-      font-weight: 600;
-      color: $text;
-      background: darken($surface, 2%);
+    th, td {
+      padding: 0.65rem 0.9rem;
+      text-align: left;
+      border-bottom: 1px solid $border;
+      border-right: 1px solid $border;
+      vertical-align: top;
+
+      &:last-child { border-right: none; }
+    }
+
+    tbody tr:last-child td { border-bottom: none; }
+
+    tbody tr {
+      transition: background 0.12s ease;
+      &:hover { background: rgba($surface, 0.5); }
     }
 
     td {
       color: $text-dim;
-
-      code {
-        font-size: 0.8em;
-      }
+      code { font-size: 0.82em; white-space: nowrap; }
     }
   }
 
-  // Overflow wrapper for wide tables
+  // Overflow wrapper for wide tables (scrolls without breaking radius)
   .table-wrapper {
     overflow-x: auto;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.6rem;
+    border-radius: 10px;
     -webkit-overflow-scrolling: touch;
 
     table {
@@ -1103,41 +1230,56 @@ img { max-width: 100%; height: auto; }
     }
   }
 
-  // Blockquote
+  // -- Blockquote --
   blockquote {
     border-left: 3px solid $accent;
-    padding: 0.5rem 1rem;
-    margin: 1rem 0 1.5rem;
-    background: rgba($accent, 0.04);
-    border-radius: 0 6px 6px 0;
-    color: $text-dim;
-    font-size: 0.925rem;
+    padding: 0.85rem 1.1rem;
+    margin: 0 0 1.6rem;
+    background: rgba($accent, 0.05);
+    border-radius: 0 8px 8px 0;
+    color: $text;
 
-    p { margin-bottom: 0.5rem; }
-    p:last-child { margin-bottom: 0; }
+    p {
+      margin-bottom: 0.6rem;
+      color: $text-dim;
+      &:last-child { margin-bottom: 0; }
+    }
     strong { color: $accent; }
+    code { background: rgba($accent, 0.1); color: $accent; border-color: rgba($accent, 0.2); }
   }
 
-  // Horizontal rule
+  // -- Horizontal rule --
   hr {
     border: none;
     border-top: 1px solid $border;
-    margin: 2rem 0;
+    margin: 2.5rem 0;
   }
 
-  // Strong
-  strong { color: lighten($text, 8%); }
+  // -- Images --
+  img {
+    border-radius: 8px;
+    border: 1px solid $border;
+  }
+
+  strong { color: lighten($text, 10%); font-weight: 650; }
+
+  // Tighten the first heading after the header divider
+  .doc-body > h2:first-child,
+  .doc-body > h3:first-child { margin-top: 0; }
 }
 
-// -- Mini TOC --
+// -- Mini TOC (sticky sidebar) --
 .doc-toc {
-  width: $toc-width;
-  flex-shrink: 0;
   position: sticky;
-  top: calc($nav-height + 2rem);
-  align-self: flex-start;
-  max-height: calc(100vh - $nav-height - 4rem);
+  top: calc(#{$nav-height} + 2rem);
+  align-self: start;
+  max-height: calc(100vh - #{$nav-height} - 4rem);
   overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+
+  &::-webkit-scrollbar { width: 6px; }
+  &::-webkit-scrollbar-thumb { background: $border; border-radius: 6px; }
 }
 
 .doc-toc-inner {
@@ -1147,12 +1289,12 @@ img { max-width: 100%; height: auto; }
 
 .doc-toc-title {
   display: block;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 600;
   color: $text-dim;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 0.75rem;
+  letter-spacing: 0.09em;
+  margin-bottom: 0.9rem;
 }
 
 .doc-toc ul {
@@ -1160,84 +1302,143 @@ img { max-width: 100%; height: auto; }
   padding: 0;
   margin: 0;
 
-  li {
-    margin-bottom: 0.125rem;
-  }
+  li { margin: 0; }
 
   a {
     display: block;
-    font-size: 0.8rem;
+    font-size: 0.82rem;
     color: $text-dim;
-    padding: 0.2rem 0 0.2rem 0.5rem;
+    padding: 0.32rem 0 0.32rem 0.85rem;
     margin-left: -1rem;
     border-left: 2px solid transparent;
-    line-height: 1.4;
-    transition: color 0.15s, border-color 0.15s;
+    line-height: 1.45;
+    transition: color 0.15s ease, border-color 0.15s ease;
+
     &:hover {
+      color: $text;
+      border-left-color: $border-light;
+    }
+
+    &.active {
       color: $accent;
       border-left-color: $accent;
+      font-weight: 500;
     }
   }
 
   ul {
-    padding-left: 0.75rem;
-    a { font-size: 0.75rem; }
+    a {
+      font-size: 0.78rem;
+      padding-left: 1.7rem;
+    }
   }
 }
 
 // -- Doc index (section listing) --
 .doc-index {
   display: grid;
-  gap: 1rem;
-  margin-top: 2rem;
+  gap: 0.85rem;
+  margin-top: 2.5rem;
 }
 
 .doc-index-item {
-  display: block;
-  padding: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.15rem 1.35rem;
   background: $surface;
   border: 1px solid $border;
-  border-radius: 8px;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  border-radius: 10px;
+  transition: border-color 0.18s ease, background 0.18s ease, transform 0.18s ease;
 
   &:hover {
     border-color: $accent;
-    box-shadow: 0 2px 12px rgba($accent, 0.08);
+    background: lighten($surface, 2%);
+    transform: translateY(-2px);
+
+    .doc-index-arrow {
+      color: $accent;
+      transform: translateX(3px);
+    }
+    .doc-index-title { color: $accent; }
   }
 
-  h3 {
+  .doc-index-text { flex: 1; min-width: 0; }
+
+  .doc-index-title {
+    display: block;
     font-size: 1rem;
     font-weight: 600;
     color: $text;
-    margin-bottom: 0.25rem;
+    line-height: 1.3;
+    transition: color 0.18s ease;
   }
 
-  p {
-    font-size: 0.85rem;
+  .doc-index-desc {
+    display: block;
+    font-size: 0.875rem;
     color: $text-dim;
-    margin: 0;
+    margin-top: 0.3rem;
     line-height: 1.5;
+  }
+
+  .doc-index-arrow {
+    flex-shrink: 0;
+    color: $text-dim;
+    transition: color 0.18s ease, transform 0.18s ease;
+    svg { width: 18px; height: 18px; display: block; }
   }
 }
 
 // -- Prev/Next --
 .doc-prevnext {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 1rem;
-  margin-top: 3rem;
-  padding-top: 1.5rem;
+  margin-top: 3.5rem;
+  padding-top: 2rem;
   border-top: 1px solid $border;
-  font-size: 0.9rem;
+}
 
-  a {
-    color: $link;
-    font-weight: 500;
-    &:hover { color: $accent; }
+.doc-pn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1rem 1.15rem;
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: 10px;
+  transition: border-color 0.18s ease, background 0.18s ease;
+
+  &:hover {
+    border-color: $accent;
+    background: lighten($surface, 2%);
+    .doc-pn-title { color: $accent; }
   }
 
-  .doc-next { margin-left: auto; }
+  .doc-pn-dir {
+    font-family: $font-mono;
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    color: $text-dim;
+  }
+
+  .doc-pn-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: $text;
+    line-height: 1.35;
+    transition: color 0.18s ease;
+  }
 }
+
+.doc-next {
+  grid-column: 2;
+  text-align: right;
+  align-items: flex-end;
+}
+
+.doc-pn-spacer { display: block; }
 
 // =============================================================================
 // Animations
@@ -1387,14 +1588,18 @@ img { max-width: 100%; height: auto; }
 
   .doc-content {
     max-width: 100%;
+    .doc-kicker { color: #555; }
+    .doc-lead { color: #333; }
     h1, h2, h3, h4 { color: #111; }
     code { border-color: #ddd; background: #f5f5f5; color: #333; }
-    pre { border-color: #ddd; background: #f5f5f5; }
+    pre { border-color: #ddd; background: #f5f5f5; box-shadow: none; }
     pre code { color: #333; }
+    pre[data-lang]::before { color: #888; background: #eee; border-color: #ddd; }
     table th, table td { border-color: #ccc; }
-    table th { background: #eee; }
-    a { color: #111; text-decoration: underline; }
-    blockquote { border-left-color: #ccc; background: #f9f9f9; }
+    table th { background: #eee; color: #111; }
+    table td { color: #333; }
+    a { color: #111; text-decoration: underline; border-bottom: none; }
+    blockquote { border-left-color: #ccc; background: #f9f9f9; p { color: #333; } }
   }
 }
 
@@ -1404,7 +1609,11 @@ img { max-width: 100%; height: auto; }
 
 @media (max-width: 1140px) {
   .doc-toc { display: none; }
-  .doc-layout { max-width: $doc-width; }
+  .doc-layout {
+    grid-template-columns: minmax(0, 1fr);
+    max-width: $doc-width;
+  }
+  .doc-content { max-width: none; }
   .arch-grid { grid-template-columns: repeat(3, 1fr); }
   .metrics-grid { grid-template-columns: repeat(3, 1fr); }
 }
@@ -1440,18 +1649,28 @@ img { max-width: 100%; height: auto; }
   .arch-grid { grid-template-columns: repeat(2, 1fr); }
   .metrics-grid { grid-template-columns: repeat(2, 1fr); }
 
-  .doc-layout { padding: 1.5rem 1rem 3rem; }
+  .doc-layout { padding: 1.75rem 1rem 3.5rem; gap: 2rem; }
   .doc-content {
-    h1 { font-size: 1.5rem; }
-    h2 { font-size: 1.15rem; }
+    font-size: 0.96rem;
 
-    // Allow tables to scroll
+    .doc-header { margin-bottom: 1.75rem; padding-bottom: 1.25rem; }
+    .doc-lead { font-size: 1rem; }
+
+    h2 { margin-top: 2.25rem; }
+
+    // Allow tables to scroll on narrow screens
     table {
       display: block;
       overflow-x: auto;
+      white-space: nowrap;
       -webkit-overflow-scrolling: touch;
     }
+
+    pre { border-radius: 8px; font-size: 0.8rem; }
   }
+
+  .doc-prevnext { grid-template-columns: 1fr; }
+  .doc-next { grid-column: 1; text-align: left; align-items: flex-start; }
 
   .footer-inner { flex-direction: column; text-align: center; }
   .footer-col { justify-content: center; }

--- a/website/static/css/analyze.css
+++ b/website/static/css/analyze.css
@@ -66,7 +66,7 @@
 }
 
 /* =============================================================================
-   Drop Zone -- terminal style
+   Drop Zone -- terminal style, polished
    ============================================================================= */
 
 .analyze-dropzone {
@@ -75,76 +75,133 @@
   align-items: center;
   justify-content: center;
   padding: 2rem;
-  background: var(--bg);
+  background:
+    radial-gradient(60% 55% at 50% 38%, rgba(255, 204, 102, 0.05), transparent 70%),
+    var(--bg);
 }
 
 .dropzone-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-align: center;
-  padding: 0;
-  border: none;
-  border-radius: 0;
-  max-width: 560px;
+  max-width: 520px;
   width: 100%;
   cursor: pointer;
-  transition: border-color 0.2s;
 }
 
-.dropzone-inner:hover .dropzone-box,
-.analyze-dropzone.drag-over .dropzone-box {
-  border-color: var(--accent);
+.dropzone-kicker {
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 1.1rem;
 }
 
-.analyze-dropzone.drag-over .dropzone-box {
-  border-color: var(--accent);
-}
-
-/* The ASCII box drawn inside the dropzone */
+/* The drop target box */
 .dropzone-box {
-  border: 1px dashed var(--text-dim);
-  padding: 2.5rem 2rem;
-  display: inline-block;
+  position: relative;
   width: 100%;
-  transition: border-color 0.2s;
+  padding: 3rem 2rem 2.6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent);
+  border: 1px dashed var(--border-light);
+  border-radius: 14px;
+  transition: border-color 0.2s, background 0.2s, transform 0.2s, box-shadow 0.2s;
 }
 
-/* Hide the old SVG icon */
+.dropzone-inner:hover .dropzone-box {
+  border-color: var(--accent);
+  background: linear-gradient(180deg, rgba(255, 204, 102, 0.05), transparent);
+}
+
+.analyze-dropzone.drag-over .dropzone-box {
+  border-color: var(--accent);
+  border-style: solid;
+  background: linear-gradient(180deg, rgba(255, 204, 102, 0.09), transparent);
+  transform: translateY(-2px);
+  box-shadow: 0 20px 50px -22px rgba(0, 0, 0, 0.75);
+}
+
 .dropzone-icon {
-  display: none;
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  margin-bottom: 1.1rem;
+  border-radius: 16px;
+  color: var(--accent);
+  background: rgba(255, 204, 102, 0.1);
+  border: 1px solid rgba(255, 204, 102, 0.22);
+  transition: transform 0.2s, background 0.2s;
+}
+
+.dropzone-icon svg {
+  width: 30px;
+  height: 30px;
+}
+
+.dropzone-inner:hover .dropzone-icon,
+.analyze-dropzone.drag-over .dropzone-icon {
+  transform: translateY(-2px);
+  background: rgba(255, 204, 102, 0.16);
 }
 
 .dropzone-title {
-  font-size: 1rem;
-  font-weight: 400;
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   color: var(--text);
-  margin-bottom: 0.25rem;
+  margin: 0 0 0.35rem;
 }
 
 .dropzone-sub {
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   color: var(--text-dim);
-  margin-bottom: 1rem;
+  margin: 0 0 1.5rem;
+}
+
+.dropzone-browse {
+  color: var(--accent);
+  border-bottom: 1px solid rgba(255, 204, 102, 0.35);
 }
 
 .dropzone-formats {
-  font-size: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.45rem;
+}
+
+.dropzone-fmt {
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
   color: var(--text-dim);
-  margin-bottom: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.18rem 0.5rem;
 }
 
 .dropzone-privacy {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.75rem;
+  margin-top: 1.4rem;
+  font-size: 0.78rem;
   color: var(--good);
-  background: none;
-  border: none;
-  border-radius: 0;
-  padding: 0;
+  background: rgba(186, 230, 126, 0.06);
+  border: 1px solid rgba(186, 230, 126, 0.22);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
 }
 
 .dropzone-privacy svg {
-  display: none;
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
 }
 
 /* =============================================================================
@@ -157,7 +214,7 @@
   height: calc(100vh - 60px);
   overflow: hidden;
   /* Room for the F-key bar at bottom */
-  padding-bottom: 24px;
+  padding-bottom: 25px;
 }
 
 /* =============================================================================
@@ -169,7 +226,7 @@
   flex-direction: column;
   padding: 0;
   background: var(--status-bg);
-  border-bottom: none;
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
   min-height: auto;
   gap: 0;
@@ -179,12 +236,12 @@
   display: flex;
   align-items: center;
   gap: 0;
-  padding: 1px 8px;
+  padding: 5px 10px;
   font-size: 12px;
   color: var(--text);
   white-space: nowrap;
   overflow: visible;
-  min-height: 20px;
+  min-height: 26px;
 }
 
 .topbar-status-line .tui-label {
@@ -200,13 +257,13 @@
 }
 
 .topbar-status-line .tui-sep {
-  color: var(--text-dim);
+  color: var(--border-light);
   margin: 0 10px;
 }
 
 .topbar-filename {
   font-size: 12px;
-  font-weight: 400;
+  font-weight: 500;
   color: var(--accent);
   max-width: 300px;
   overflow: hidden;
@@ -221,36 +278,41 @@
 
 .topbar-stat strong {
   color: var(--text);
-  font-weight: 400;
+  font-weight: 600;
 }
 
 /* Second status line: filter */
 .topbar-filter-line {
   display: flex;
   align-items: center;
-  padding: 1px 8px;
+  padding: 5px 10px 7px;
   font-size: 12px;
-  min-height: 20px;
-  gap: 0;
+  min-height: 24px;
+  gap: 6px;
   background: var(--status-bg);
+}
+
+.topbar-filter-line .tui-label {
+  color: var(--text-dim);
+  flex-shrink: 0;
 }
 
 .topbar-filter {
   font-size: 12px;
-  background: transparent;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  border-radius: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
   color: var(--text);
-  padding: 0 4px;
+  padding: 4px 9px;
   flex: 1;
-  max-width: 400px;
+  max-width: 460px;
   outline: none;
-  transition: border-color 0.15s;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .topbar-filter:focus {
-  border-bottom-color: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(255, 204, 102, 0.12);
 }
 
 .topbar-filter::placeholder {
@@ -261,7 +323,7 @@
 .topbar-actions {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   margin-left: auto;
 }
 
@@ -270,25 +332,27 @@
   align-items: center;
   gap: 4px;
   font-size: 11px;
-  font-weight: 400;
-  background: transparent;
+  font-weight: 500;
+  background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 0;
+  border-radius: 6px;
   color: var(--text-dim);
-  padding: 1px 8px;
+  padding: 3px 11px;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
   white-space: nowrap;
 }
 
 .topbar-btn:hover {
   color: var(--text);
-  border-color: var(--text-dim);
+  border-color: var(--border-light);
+  background: var(--surface-2);
 }
 
 .topbar-btn--clear:hover {
   color: var(--bad);
-  border-color: var(--bad);
+  border-color: rgba(255, 102, 102, 0.5);
+  background: rgba(255, 102, 102, 0.08);
 }
 
 .topbar-btn svg {
@@ -303,15 +367,16 @@
 .export-dropdown {
   display: none;
   position: absolute;
-  top: calc(100% + 2px);
+  top: calc(100% + 5px);
   right: 0;
-  background: var(--status-bg);
-  border: 1px solid var(--border);
-  border-radius: 0;
+  background: var(--surface);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  padding: 4px;
   overflow: hidden;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 12px 30px -10px rgba(0, 0, 0, 0.7);
   z-index: 50;
-  min-width: 110px;
+  min-width: 128px;
 }
 
 .export-dropdown.open {
@@ -326,7 +391,8 @@
   color: var(--text-dim);
   background: none;
   border: none;
-  padding: 4px 8px;
+  border-radius: 5px;
+  padding: 5px 10px;
   cursor: pointer;
   transition: background 0.1s, color 0.1s;
 }
@@ -334,10 +400,6 @@
 .export-dropdown button:hover {
   background: var(--accent-glow);
   color: var(--text);
-}
-
-.export-dropdown button + button {
-  border-top: 1px solid var(--border);
 }
 
 /* =============================================================================
@@ -354,13 +416,12 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid var(--border);
+  background: var(--bg);
 }
 
 .panel-left {
   width: 45%;
   min-width: 280px;
-  border-right: 1px solid var(--border);
 }
 
 .panel-right {
@@ -388,33 +449,65 @@
 }
 
 .panel-header {
-  font-size: 11px;
-  font-weight: 600;
+  display: flex;
+  align-items: center;
+  font-size: 10.5px;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--bg);
-  background: var(--tui-cyan);
-  padding: 1px 8px;
-  border-bottom: none;
+  letter-spacing: 0.09em;
+  color: var(--text-dim);
+  background: var(--surface);
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
-/* Resize handles */
+.panel-header::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-right: 8px;
+  background: var(--tui-teal);
+}
+
+#panel-raw-header::before {
+  background: var(--accent);
+}
+
+/* Resize handles -- thin visible seam, wide invisible grab area */
 .panel-resize {
   flex-shrink: 0;
-  background: transparent;
+  position: relative;
+  background: var(--border);
   transition: background 0.15s;
   z-index: 10;
 }
 
+.panel-resize::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
 .panel-resize[data-direction="horizontal"] {
-  width: 3px;
+  width: 1px;
   cursor: col-resize;
 }
 
+.panel-resize[data-direction="horizontal"]::after {
+  left: -4px;
+  right: -4px;
+}
+
 .panel-resize[data-direction="vertical"] {
-  height: 3px;
+  height: 1px;
   cursor: row-resize;
+}
+
+.panel-resize[data-direction="vertical"]::after {
+  top: -4px;
+  bottom: -4px;
 }
 
 .panel-resize:hover,
@@ -444,30 +537,31 @@
 }
 
 .call-list th {
-  font-size: 11px;
-  font-weight: bold;
+  font-size: 10px;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0;
-  color: var(--bg);
-  background: var(--tui-cyan);
-  padding: 1px 6px;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  background: var(--surface);
+  padding: 6px 8px;
   text-align: left;
-  border-bottom: none;
+  border-bottom: 1px solid var(--border);
   white-space: nowrap;
   user-select: none;
 }
 
 .call-list th.sortable {
   cursor: pointer;
-  transition: background 0.15s;
+  transition: color 0.15s, background 0.15s;
 }
 
 .call-list th.sortable:hover {
-  background: #6fbfbf;
+  color: var(--text);
+  background: var(--surface-2);
 }
 
 .call-list th.sort-active {
-  color: var(--bg);
+  color: var(--accent);
 }
 
 .call-list th.sort-active::after {
@@ -475,33 +569,38 @@
   display: inline-block;
   width: 0;
   height: 0;
-  margin-left: 4px;
+  margin-left: 5px;
   vertical-align: middle;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
 }
 
 .call-list th.sort-active.sort-asc::after {
-  border-bottom: 5px solid var(--bg);
+  border-bottom: 5px solid var(--accent);
 }
 
 .call-list th.sort-active.sort-desc::after {
-  border-top: 5px solid var(--bg);
+  border-top: 5px solid var(--accent);
 }
 
 .call-list td {
-  padding: 1px 6px;
+  padding: 4px 8px;
   color: var(--text-dim);
-  border-bottom: none;
+  border-bottom: 1px solid rgba(45, 54, 64, 0.5);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 160px;
 }
 
+/* Accent rail anchored on the first cell for the selected row */
+.call-list td:first-child {
+  box-shadow: inset 2px 0 0 transparent;
+}
+
 .call-list tbody tr {
   cursor: pointer;
-  transition: background 0.05s;
+  transition: background 0.08s;
 }
 
 .call-list tbody tr:hover {
@@ -509,11 +608,15 @@
 }
 
 .call-list tbody tr.selected {
-  background: var(--surface);
+  background: var(--accent-glow);
 }
 
 .call-list tbody tr.selected td {
   color: var(--text);
+}
+
+.call-list tbody tr.selected td:first-child {
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 /* Method cell coloring */
@@ -558,8 +661,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  text-align: center;
   color: var(--text-dim);
   font-size: 12px;
+  padding: 1.5rem;
+  opacity: 0.8;
 }
 
 .flow-container {
@@ -575,10 +681,10 @@
   position: sticky;
   top: 0;
   z-index: 5;
-  background: var(--bg);
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
-  padding: 4px 0;
-  min-height: 24px;
+  padding: 6px 0;
+  min-height: 26px;
 }
 
 .flow-endpoint {
@@ -624,11 +730,12 @@
 }
 
 .flow-msg.selected {
-  background: var(--surface);
+  background: var(--accent-glow);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 .flow-msg.retransmission {
-  opacity: 0.5;
+  opacity: 0.45;
 }
 
 /* Timestamp */
@@ -745,9 +852,9 @@
 .raw-message {
   flex: 1;
   margin: 0;
-  padding: 4px 8px;
+  padding: 10px 12px;
   font-size: 12px;
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--text);
   background: var(--bg);
   overflow: auto;
@@ -776,7 +883,8 @@
 
 .fkey-bar {
   background: var(--status-bg);
-  padding: 2px 8px;
+  border-top: 1px solid var(--border);
+  padding: 0 10px;
   font-size: 11px;
   color: var(--text-dim);
   position: fixed;
@@ -786,18 +894,29 @@
   z-index: 100;
   display: flex;
   align-items: center;
-  gap: 16px;
-  min-height: 22px;
+  flex-wrap: wrap;
+  gap: 2px 14px;
+  min-height: 24px;
 }
 
 .fkey-bar .fkey {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   white-space: nowrap;
 }
 
 .fkey-bar .fkey b {
+  display: inline-block;
   color: var(--text);
   font-weight: 600;
-  margin-right: 4px;
+  font-size: 10.5px;
+  background: var(--surface);
+  border: 1px solid var(--border-light);
+  border-radius: 4px;
+  padding: 0 5px;
+  line-height: 16px;
+  margin-right: 0;
 }
 
 /* =============================================================================
@@ -857,31 +976,63 @@
 
   .panel-resize[data-direction="horizontal"] {
     width: 100%;
-    height: 3px;
+    height: 1px;
     cursor: row-resize;
   }
 
+  .panel-resize[data-direction="horizontal"]::after {
+    left: 0;
+    right: 0;
+    top: -4px;
+    bottom: -4px;
+  }
+
   .topbar-filter {
-    max-width: 200px;
+    max-width: 260px;
   }
 }
 
 @media (max-width: 600px) {
   .topbar-status-line {
     flex-wrap: wrap;
-    gap: 4px;
+    gap: 2px 6px;
+    min-height: auto;
+  }
+
+  .topbar-status-line .tui-sep {
+    margin: 0 6px;
+  }
+
+  .topbar-actions {
+    width: 100%;
+    margin-left: 0;
+    margin-top: 4px;
+  }
+
+  .topbar-filter-line {
+    flex-wrap: wrap;
   }
 
   .topbar-filter {
     max-width: 100%;
   }
 
-  .dropzone-title {
-    font-size: 0.9rem;
+  .dropzone-box {
+    padding: 2rem 1.25rem 1.75rem;
   }
 
-  .dropzone-box {
-    padding: 1.5rem 1rem;
+  .dropzone-title {
+    font-size: 1.02rem;
+  }
+
+  .dropzone-icon {
+    width: 54px;
+    height: 54px;
+  }
+
+  .dropzone-icon svg {
+    width: 26px;
+    height: 26px;
   }
 }
 
@@ -890,40 +1041,57 @@
   position: fixed;
   inset: 0;
   z-index: 200;
-  background: rgba(0, 0, 0, 0.7);
+  background: rgba(5, 8, 12, 0.72);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 1.5rem;
+  animation: helpFade 0.15s ease both;
 }
 
 .help-popup-inner {
-  background: #1f2430;
-  border: 1px solid #3d4754;
-  padding: 20px 24px;
-  max-width: 520px;
-  width: 90%;
+  background: var(--surface);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 22px 26px;
+  max-width: 540px;
+  width: 100%;
   position: relative;
   font-family: 'JetBrains Mono', monospace;
   font-size: 12px;
-  color: #cbccc6;
+  color: var(--text);
+  box-shadow: 0 28px 70px -20px rgba(0, 0, 0, 0.85);
+  animation: helpPop 0.2s cubic-bezier(0.2, 0.8, 0.3, 1.1) both;
 }
 
 .help-popup-title {
   font-size: 14px;
   font-weight: 700;
-  color: #ffcc66;
-  margin-bottom: 12px;
+  letter-spacing: 0.01em;
+  color: var(--accent);
+  margin-bottom: 14px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
 }
 
 .help-popup-close {
   position: absolute;
-  top: 8px;
-  right: 12px;
+  top: 14px;
+  right: 16px;
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
   font-size: 18px;
-  color: #707a8c;
+  line-height: 1;
+  color: var(--text-dim);
+  border-radius: 6px;
   cursor: pointer;
+  transition: color 0.15s, background 0.15s;
 }
-.help-popup-close:hover { color: #cbccc6; }
+.help-popup-close:hover { color: var(--text); background: var(--surface-2); }
 
 .help-popup-table {
   width: 100%;
@@ -932,51 +1100,64 @@
 
 .help-popup-table th {
   text-align: left;
-  padding: 8px 0 4px;
-  color: #5fafaf;
-  font-size: 11px;
+  padding: 12px 0 5px;
+  color: var(--tui-cyan);
+  font-size: 10px;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  border-bottom: 1px solid #2d3640;
+  letter-spacing: 0.08em;
+  border-bottom: 1px solid var(--border);
+}
+
+.help-popup-table tr:first-child th {
+  padding-top: 0;
 }
 
 .help-popup-table td {
-  padding: 3px 0;
+  padding: 5px 0;
   vertical-align: top;
+  color: var(--text-dim);
 }
 
 .help-popup-table td:first-child {
-  width: 140px;
-  color: #ffcc66;
+  width: 150px;
   white-space: nowrap;
 }
 
 .help-popup-table kbd {
   display: inline-block;
-  background: #0a0e14;
-  border: 1px solid #3d4754;
+  background: var(--bg);
+  border: 1px solid var(--border-light);
   border-bottom-width: 2px;
-  padding: 1px 5px;
+  border-radius: 4px;
+  padding: 1px 6px;
   font-family: 'JetBrains Mono', monospace;
   font-size: 11px;
-  color: #cbccc6;
+  color: var(--text);
 }
 
 .help-popup-table code {
-  background: #0a0e14;
-  border: 1px solid #2d3640;
-  padding: 1px 4px;
-  color: #bae67e;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: var(--good);
   font-size: 11px;
 }
 
 .help-popup-footer {
-  margin-top: 12px;
-  padding-top: 8px;
-  border-top: 1px solid #2d3640;
-  color: #707a8c;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  color: var(--text-dim);
   font-size: 11px;
   text-align: center;
+}
+
+@keyframes helpFade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes helpPop {
+  from { opacity: 0; transform: translateY(10px) scale(0.98); }
+  to { opacity: 1; transform: none; }
 }
 
 /* =============================================================================
@@ -992,7 +1173,7 @@
 
 .panel-tab {
   flex: 1;
-  padding: 5px 12px;
+  padding: 7px 12px;
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
@@ -1002,16 +1183,18 @@
   border: none;
   border-bottom: 2px solid transparent;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
 }
 
 .panel-tab:hover {
   color: var(--text);
+  background: rgba(255, 255, 255, 0.02);
 }
 
 .panel-tab.active {
   color: var(--accent);
   border-bottom-color: var(--accent);
+  background: var(--accent-glow);
 }
 
 .tab-content {
@@ -1045,6 +1228,16 @@
 .stream-sortable {
   cursor: pointer;
   user-select: none;
+  transition: color 0.15s, background 0.15s;
+}
+
+.stream-sortable:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}
+
+.stream-sortable.sort-active {
+  color: var(--accent);
 }
 
 .stream-sortable::after {
@@ -1052,7 +1245,7 @@
   display: inline-block;
   width: 0;
   height: 0;
-  margin-left: 4px;
+  margin-left: 5px;
   vertical-align: middle;
 }
 
@@ -1087,16 +1280,16 @@
 .stream-detail-card {
   background: var(--surface-2);
   border: 1px solid var(--border);
-  padding: 8px 10px;
-  border-radius: 2px;
+  padding: 9px 11px;
+  border-radius: 7px;
 }
 
 .stream-detail-card .label {
   font-size: 10px;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   color: var(--text-dim);
-  margin-bottom: 2px;
+  margin-bottom: 3px;
 }
 
 .stream-detail-card .value {
@@ -1147,14 +1340,16 @@
 .burst-gap-card {
   background: var(--surface-2);
   border: 1px solid var(--border);
-  padding: 6px 8px;
-  border-radius: 2px;
+  padding: 7px 9px;
+  border-radius: 7px;
 }
 
 .burst-gap-card .label {
   font-size: 10px;
   text-transform: uppercase;
+  letter-spacing: 0.04em;
   color: var(--text-dim);
+  margin-bottom: 2px;
 }
 
 .burst-gap-card .value {

--- a/website/templates/404.html
+++ b/website/templates/404.html
@@ -4,8 +4,9 @@
 
 {% block content %}
 <div class="error-page">
-  <h1>404</h1>
-  <p>This page doesn't exist. Maybe it was a phantom INVITE.</p>
+  <div class="error-code">404</div>
+  <div class="error-prompt"><span class="error-sigil">$</span>sipnab /this/page<span class="error-cursor"></span></div>
+  <p>No match for this route. Maybe it was a phantom INVITE &mdash; the page never sent a 200&nbsp;OK.</p>
   <a href="{{ config.base_url }}" class="btn btn-primary">Back to Home</a>
 </div>
 {% endblock content %}

--- a/website/templates/analyze.html
+++ b/website/templates/analyze.html
@@ -4,7 +4,7 @@
 {% block description %}{{ section.description }}{% endblock description %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ get_url(path='css/analyze.css') }}?v=9">
+<link rel="stylesheet" href="{{ get_url(path='css/analyze.css') }}?v=10">
 {% endblock head_extra %}
 
 {% block content %}
@@ -13,14 +13,31 @@
   <!-- Drop zone (initial view) -->
   <div class="analyze-dropzone" id="dropzone">
     <div class="dropzone-inner">
+      <span class="dropzone-kicker">sipnab &middot; in-browser analyzer</span>
       <div class="dropzone-box">
-        <h1 class="dropzone-title">Drop a .pcap file here to analyze</h1>
-        <p class="dropzone-sub">or click to browse</p>
-        <input type="file" id="file-input" accept=".pcap,.pcapng,.cap" hidden>
-        <div class="dropzone-formats">Supports .pcap, .pcapng, .cap</div>
-        <div class="dropzone-privacy">
-          All processing in your browser -- nothing is uploaded
+        <div class="dropzone-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 3v4a1 1 0 0 0 1 1h4"/>
+            <path d="M5 12V5a2 2 0 0 1 2-2h7l5 5v4"/>
+            <path d="M12 13v8"/>
+            <path d="m8.5 17.5 3.5 3.5 3.5-3.5"/>
+          </svg>
         </div>
+        <h1 class="dropzone-title">Drop a .pcap here to analyze</h1>
+        <p class="dropzone-sub">or <span class="dropzone-browse">click to browse</span></p>
+        <input type="file" id="file-input" accept=".pcap,.pcapng,.cap" hidden>
+        <div class="dropzone-formats">
+          <span class="dropzone-fmt">.pcap</span>
+          <span class="dropzone-fmt">.pcapng</span>
+          <span class="dropzone-fmt">.cap</span>
+        </div>
+      </div>
+      <div class="dropzone-privacy">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M12 3l7 3v5c0 4.4-3 7.6-7 9-4-1.4-7-4.6-7-9V6l7-3z"/>
+          <path d="m9 12 2 2 4-4"/>
+        </svg>
+        <span>All processing happens in your browser &mdash; nothing is uploaded</span>
       </div>
     </div>
   </div>

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0a0e14">
   <title>{% block title %}{{ config.title }}{% endblock title %}</title>
   <meta name="description" content="{% block description %}{{ config.description }}{% endblock description %}">
 
@@ -39,9 +40,30 @@
   <script src="{{ get_url(path='elasticlunr.min.js') }}" defer></script>
   {% endif %}
 
+  <!-- Structured data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": {{ config.title | json_encode | safe }},
+    "applicationCategory": "DeveloperApplication",
+    "applicationSubCategory": "SecurityApplication",
+    "operatingSystem": "macOS, Linux",
+    "url": {{ config.base_url | json_encode | safe }},
+    "description": {{ config.description | json_encode | safe }},
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    }
+  }
+  </script>
+
   {% block head_extra %}{% endblock head_extra %}
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
   {% block nav %}
   <nav class="topnav" id="topnav">
     <div class="nav-inner">
@@ -93,7 +115,7 @@
     </div>
   </div>
 
-  <main>
+  <main id="main">
     {% block content %}{% endblock content %}
   </main>
 

--- a/website/templates/download.html
+++ b/website/templates/download.html
@@ -51,15 +51,8 @@
   <!-- Debian / Ubuntu -->
   <div class="dl-panel" data-os="debian" role="tabpanel">
     <div class="dl-method-head"><h2>Debian / Ubuntu package</h2><span class="dl-rec">recommended</span></div>
-    <div class="dl-term">
-      <div class="dl-term-head"><span class="dl-dots"><i></i><i></i><i></i></span><span class="dl-term-title">apt &middot; resolves libpcap automatically</span></div>
-      <div class="dl-term-body">
-        <code><span class="dl-prompt">$</span>sudo apt install ./sipnab_{{ v }}_amd64.deb</code>
-        <button class="dl-copy" data-copy="sudo apt install ./sipnab_{{ v }}_amd64.deb" aria-label="Copy command"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
-      </div>
-    </div>
     <div class="dl-direct">
-      <span class="dl-direct-label">Download the .deb</span>
+      <span class="dl-direct-label">1 &middot; Download the .deb</span>
       <div class="dl-tiles">
         <a class="dl-tile" href="{{ rel }}/sipnab_{{ v }}_amd64.deb">
           <span class="dl-tile-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span>
@@ -71,6 +64,16 @@
           <span class="dl-tile-txt"><span class="dl-tile-name">ARM64</span><span class="dl-tile-sub">arm64 &middot; .deb</span></span>
           <span class="dl-tile-dl"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></span>
         </a>
+      </div>
+    </div>
+    <div class="dl-direct">
+      <span class="dl-direct-label">2 &middot; Install &mdash; apt resolves libpcap</span>
+      <div class="dl-term">
+        <div class="dl-term-head"><span class="dl-dots"><i></i><i></i><i></i></span><span class="dl-term-title">run in your download folder</span></div>
+        <div class="dl-term-body">
+          <code><span class="dl-prompt">$</span>sudo apt install ./sipnab_{{ v }}_amd64.deb</code>
+          <button class="dl-copy" data-copy="sudo apt install ./sipnab_{{ v }}_amd64.deb" aria-label="Copy command"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
+        </div>
       </div>
     </div>
   </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -7,7 +7,9 @@
 {% block content %}
 <!-- Hero -->
 <section class="hero">
+  <div class="hero-bg" aria-hidden="true"></div>
   <div class="hero-inner">
+    <p class="hero-kicker">SIP &middot; RTP &middot; built in Rust</p>
     <h1 class="hero-title">sipnab <span class="version-badge">v{{ config.extra.version }}</span></h1>
     <p class="hero-tagline">The <a class="std-ref" href="https://www.rfc-editor.org/rfc/rfc3261" target="_blank" rel="noopener noreferrer">SIP</a> &amp; <a class="std-ref" href="https://www.rfc-editor.org/rfc/rfc3550" target="_blank" rel="noopener noreferrer">RTP</a> analysis tool for people who ship voice infrastructure.</p>
     <p class="hero-sub">One binary. One dependency (libpcap). Interactive TUI + CLI + REST API.<br>Built in Rust for speed, safety, and correctness.</p>
@@ -26,6 +28,7 @@
 <!-- Demo Video -->
 <section class="demos" id="demos">
   <div class="demos-inner">
+    <p class="section-kicker">Demos</p>
     <h2>See It In Action</h2>
     <div class="demo-tabs">
       <button class="demo-tab active" onclick="showDemo(0, this)">Interactive TUI</button>
@@ -62,26 +65,32 @@
 <!-- Why sipnab -->
 <section class="features" id="features">
   <div class="features-inner">
-    <div class="feature-card feature-card--amber fade-in-up">
-      <div class="feature-icon">
-        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+    <header class="section-head">
+      <p class="section-kicker">Capabilities</p>
+      <h2>Everything, in one binary</h2>
+    </header>
+    <div class="features-grid">
+      <div class="feature-card feature-card--amber fade-in-up">
+        <div class="feature-icon">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+        </div>
+        <h3>See Everything</h3>
+        <p>Interactive TUI with multi-participant ladder diagrams, auth collapse, retransmit folding, mark+delta timing. Four timestamp modes, message diff, split view with resizable panels.</p>
       </div>
-      <h3>See Everything</h3>
-      <p>Interactive TUI with multi-participant ladder diagrams, auth collapse, retransmit folding, mark+delta timing. Four timestamp modes, message diff, split view with resizable panels.</p>
-    </div>
-    <div class="feature-card feature-card--green fade-in-up">
-      <div class="feature-icon">
-        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+      <div class="feature-card feature-card--green fade-in-up">
+        <div class="feature-icon">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+        </div>
+        <h3>Analyze Everything</h3>
+        <p>First-class RTP: jitter, loss, MOS per stream. RTCP XR. Comfort noise detection. One-way audio diagnosis. NAT mismatch detection. SDP offer/answer timeline. Post-dial delay and setup time measurement.</p>
       </div>
-      <h3>Analyze Everything</h3>
-      <p>First-class RTP: jitter, loss, MOS per stream. RTCP XR. Comfort noise detection. One-way audio diagnosis. NAT mismatch detection. SDP offer/answer timeline. Post-dial delay and setup time measurement.</p>
-    </div>
-    <div class="feature-card feature-card--blue fade-in-up">
-      <div class="feature-icon">
-        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+      <div class="feature-card feature-card--blue fade-in-up">
+        <div class="feature-icon">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        </div>
+        <h3>Export Everything</h3>
+        <p>PCAP, PCAP-NG, TXT, Mermaid sequence diagrams, JSON, NDJSON, Markdown call reports, fail2ban format, Wireshark filters, tshark display filters. Pipe NDJSON to jq for custom pipelines.</p>
       </div>
-      <h3>Export Everything</h3>
-      <p>PCAP, PCAP-NG, TXT, Mermaid sequence diagrams, JSON, NDJSON, Markdown call reports, fail2ban format, Wireshark filters, tshark display filters. Pipe NDJSON to jq for custom pipelines.</p>
     </div>
   </div>
 </section>
@@ -89,12 +98,19 @@
 <!-- Quick Start -->
 <section class="quickstart" id="quickstart">
   <div class="quickstart-inner">
-    <h2>Quick Start</h2>
+    <header class="section-head">
+      <p class="section-kicker">Quick Start</p>
+      <h2>Up and running in one command</h2>
+    </header>
     <div class="code-block-wrap">
-      <button class="copy-btn" onclick="copyCode(this)" aria-label="Copy to clipboard">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
-        <span>Copy</span>
-      </button>
+      <div class="code-block-head">
+        <span class="code-block-dots"><i></i><i></i><i></i></span>
+        <span class="code-block-title">bash</span>
+        <button class="copy-btn" onclick="copyCode(this)" aria-label="Copy to clipboard">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+          <span>Copy</span>
+        </button>
+      </div>
       <pre class="line-numbers"><code class="language-bash"><span class="t-comment"># Build from source</span>
 git clone https://github.com/NormB/sipnab.git
 cd sipnab && cargo build --release
@@ -123,7 +139,10 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
 <!-- sipnab features (no competitor comparison — only claim what we can prove) -->
 <section class="comparison" id="features-list">
   <div class="comparison-inner">
-    <h2>What sipnab Does</h2>
+    <header class="section-head">
+      <p class="section-kicker">Reference</p>
+      <h2>What sipnab Does</h2>
+    </header>
     <div class="comparison-table-wrap">
       <table class="comparison-table">
         <thead>
@@ -154,8 +173,11 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
 <!-- Standards-based quality metrics -->
 <section class="metrics" id="metrics">
   <div class="metrics-inner">
-    <h2>Standards-Based Quality Metrics</h2>
-    <p class="metrics-sub">sipnab reports the metrics VoIP engineers already work in &mdash; grounded in the relevant ITU-T and IETF standards. Every figure is computed from the packets, never guessed.</p>
+    <header class="section-head">
+      <p class="section-kicker">Standards-based</p>
+      <h2>Quality Metrics</h2>
+      <p class="metrics-sub">sipnab reports the metrics VoIP engineers already work in &mdash; grounded in the relevant ITU-T and IETF standards. Every figure is computed from the packets, never guessed.</p>
+    </header>
     <div class="metrics-grid">
       <div class="metric-card fade-in-up">
         <a class="metric-std" href="https://www.itu.int/rec/T-REC-G.107" target="_blank" rel="noopener noreferrer">ITU-T G.107</a>
@@ -194,7 +216,10 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
 <!-- Architecture callout -->
 <section class="arch-callout">
   <div class="arch-inner">
-    <h2>Engineered for Production</h2>
+    <header class="section-head">
+      <p class="section-kicker">Production-ready</p>
+      <h2>Engineered for Production</h2>
+    </header>
     <div class="arch-grid">
       <div class="arch-item fade-in-up">
         <span class="arch-stat" data-count="5" data-suffix=" MB">5 MB</span>
@@ -256,7 +281,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 // Copy code button
 function copyCode(btn) {
-  var pre = btn.parentElement.querySelector('pre');
+  var pre = btn.closest('.code-block-wrap').querySelector('pre');
   var text = pre.textContent;
   navigator.clipboard.writeText(text).then(function() {
     btn.querySelector('span').textContent = 'Copied!';

--- a/website/templates/page.html
+++ b/website/templates/page.html
@@ -6,21 +6,36 @@
 {% block content %}
 <div class="doc-layout">
   <article class="doc-content">
-    <h1>{{ page.title }}</h1>
-    {{ page.content | safe }}
+    <header class="doc-header">
+      <p class="doc-kicker">Documentation</p>
+      <h1>{{ page.title }}</h1>
+      {% if page.description %}
+      <p class="doc-lead">{{ page.description }}</p>
+      {% endif %}
+    </header>
+
+    <div class="doc-body">
+      {{ page.content | safe }}
+    </div>
 
     <!-- Prev/Next nav -->
     {% if page.lower or page.higher %}
-    <nav class="doc-prevnext">
+    <nav class="doc-prevnext" aria-label="Documentation pages">
       {% if page.lower %}
-      <a href="{{ page.lower.permalink }}" class="doc-prev">&larr; {{ page.lower.title }}</a>
+      <a href="{{ page.lower.permalink }}" class="doc-pn doc-prev">
+        <span class="doc-pn-dir">&larr; Previous</span>
+        <span class="doc-pn-title">{{ page.lower.title }}</span>
+      </a>
       {% else %}
-      <span></span>
+      <span class="doc-pn-spacer"></span>
       {% endif %}
       {% if page.higher %}
-      <a href="{{ page.higher.permalink }}" class="doc-next">{{ page.higher.title }} &rarr;</a>
+      <a href="{{ page.higher.permalink }}" class="doc-pn doc-next">
+        <span class="doc-pn-dir">Next &rarr;</span>
+        <span class="doc-pn-title">{{ page.higher.title }}</span>
+      </a>
       {% else %}
-      <span></span>
+      <span class="doc-pn-spacer"></span>
       {% endif %}
     </nav>
     {% endif %}
@@ -28,24 +43,57 @@
 
   <!-- Mini TOC -->
   {% if page.toc | length > 0 %}
-  <aside class="doc-toc">
-    <div class="doc-toc-inner">
+  <aside class="doc-toc" aria-label="Table of contents">
+    <nav class="doc-toc-inner">
       <span class="doc-toc-title">On this page</span>
       <ul>
         {% for h2 in page.toc %}
-        <li><a href="#{{ h2.id }}">{{ h2.title }}</a>
+        <li><a href="#{{ h2.id }}" class="doc-toc-link">{{ h2.title }}</a>
           {% if h2.children | length > 0 %}
           <ul>
             {% for h3 in h2.children %}
-            <li><a href="#{{ h3.id }}">{{ h3.title }}</a></li>
+            <li><a href="#{{ h3.id }}" class="doc-toc-link">{{ h3.title }}</a></li>
             {% endfor %}
           </ul>
           {% endif %}
         </li>
         {% endfor %}
       </ul>
-    </div>
+    </nav>
   </aside>
   {% endif %}
 </div>
+
+{% if page.toc | length > 0 %}
+<script>
+(function () {
+  var links = Array.prototype.slice.call(document.querySelectorAll(".doc-toc-link"));
+  if (!links.length) return;
+  var map = {};
+  var targets = [];
+  links.forEach(function (link) {
+    var id = decodeURIComponent((link.getAttribute("href") || "").slice(1));
+    var el = id && document.getElementById(id);
+    if (el) { map[id] = link; targets.push(el); }
+  });
+  if (!targets.length) return;
+
+  var current = null;
+  function setActive(id) {
+    if (id === current) return;
+    current = id;
+    links.forEach(function (l) { l.classList.remove("active"); });
+    if (map[id]) map[id].classList.add("active");
+  }
+
+  var observer = new IntersectionObserver(function (entries) {
+    entries.forEach(function (entry) {
+      if (entry.isIntersecting) setActive(entry.target.id);
+    });
+  }, { rootMargin: "-80px 0px -70% 0px", threshold: 0 });
+
+  targets.forEach(function (t) { observer.observe(t); });
+})();
+</script>
+{% endif %}
 {% endblock content %}

--- a/website/templates/section.html
+++ b/website/templates/section.html
@@ -4,22 +4,36 @@
 {% block description %}{{ section.description | default(value=config.description) }}{% endblock description %}
 
 {% block content %}
-<div class="doc-layout">
+<div class="doc-layout doc-layout--section">
   <article class="doc-content">
-    <h1>{{ section.title }}</h1>
-    {{ section.content | safe }}
+    <header class="doc-header">
+      <p class="doc-kicker">Documentation</p>
+      <h1>{{ section.title }}</h1>
+      {% if section.description %}
+      <p class="doc-lead">{{ section.description }}</p>
+      {% endif %}
+    </header>
+
+    <div class="doc-body">
+      {{ section.content | safe }}
+    </div>
 
     {% if section.pages | length > 0 %}
-    <div class="doc-index">
+    <nav class="doc-index" aria-label="Documentation sections">
       {% for page in section.pages %}
       <a href="{{ page.permalink }}" class="doc-index-item">
-        <h3>{{ page.title }}</h3>
-        {% if page.description %}
-        <p>{{ page.description }}</p>
-        {% endif %}
+        <span class="doc-index-text">
+          <span class="doc-index-title">{{ page.title }}</span>
+          {% if page.description %}
+          <span class="doc-index-desc">{{ page.description }}</span>
+          {% endif %}
+        </span>
+        <span class="doc-index-arrow" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+        </span>
       </a>
       {% endfor %}
-    </div>
+    </nav>
     {% endif %}
   </article>
 </div>


### PR DESCRIPTION
Integrates the four design workstreams (foundation/a11y, homepage, docs, analyze) plus follow-up fixes.

**Accessibility / foundation:** fixes 36 WCAG contrast failures, adds :focus-visible, prefers-reduced-motion, skip-to-content, theme-color, JSON-LD structured data; polished 404.
**Homepage / Docs / Analyze:** consistent rhythm, stronger hero, framed code blocks, sticky TOC scroll-spy, refined analyze chrome — all JS/WASM DOM contracts preserved.

**Follow-up fixes:**
- Download page: Debian shows **download (1) before install (2)**.
- Nav collapses to hamburger at **≤1200px** (fixes right-side clipping).
- ci.yml: no cancel-in-progress on main.

Integration builds clean (zola: 11 pages, 0 orphans).