### PR TITLE
fix(website): collapsed nav alignment + phone overflow

### DIFF
--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -1793,7 +1793,8 @@ input:focus-visible,
     }
   }
 
-  .nav-toggle { display: flex; }
+  .nav-toggle { display: flex; order: 10; }
+  .nav-right { margin-left: auto; }
 
 }
 
@@ -1843,6 +1844,9 @@ input:focus-visible,
 }
 
 @media (max-width: 480px) {
+  .nav-sponsor-text { display: none; }
+  .nav-sponsor { padding: 0.375rem 0.5rem; }
+  .nav-right { gap: 0.5rem; }
   .hero { padding: 3.25rem 1rem 1.5rem; }
   .hero-kicker { font-size: 0.66rem; letter-spacing: 0.18em; }
   .hero-actions { flex-direction: column; align-items: stretch; }

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -88,7 +88,7 @@
       </div>
 
       <div class="nav-right">
-        <a href="{{ config.extra.patreon_url }}" class="nav-sponsor" aria-label="Sponsor sipnab on Patreon">Sponsor <span class="heart">&#9829;</span></a>
+        <a href="{{ config.extra.patreon_url }}" class="nav-sponsor" aria-label="Sponsor sipnab on Patreon"><span class="nav-sponsor-text">Sponsor</span> <span class="heart">&#9829;</span></a>
         <a href="{{ config.extra.github_sponsors_url }}" class="nav-gh-sponsor" aria-label="Sponsor sipnab on GitHub Sponsors" title="GitHub Sponsors" target="_blank" rel="noopener">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
         </a>


### PR DESCRIPTION
Follow-up to the UI overhaul: right-aligns the actions when the nav collapses to the hamburger (was bunching left), makes the hamburger the rightmost item, and hides the Sponsor word on phones so nav-right no longer overflows at ~375px. Verified ranges: full nav fits ≤1210, collapses ≤1200, no overflow at 375.