### PR TITLE
Code-quality sweep: rustfmt + clippy alerts + pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,73 @@
+#!/bin/sh
+# sipnab pre-push hook (portable POSIX sh).
+#
+# Hard gate: refuse to push code that fails `cargo fmt --all -- --check`.
+# This is the exact gap that broke CI -- unformatted Rust must never reach the
+# remote. Clippy runs as a soft warning only.
+#
+# Bypass for emergencies (use sparingly):
+#   SKIP_FMT_HOOK=1 git push ...
+#
+# Activate once per clone:
+#   git config core.hooksPath .githooks
+
+set -eu
+
+# Colors only when stdout is a TTY (keeps CI logs / pipes clean).
+if [ -t 1 ]; then
+	RED='\033[0;31m'
+	GREEN='\033[0;32m'
+	YELLOW='\033[1;33m'
+	NC='\033[0m'
+else
+	RED=''
+	GREEN=''
+	YELLOW=''
+	NC=''
+fi
+
+printf '%bRunning pre-push checks...%b\n' "$YELLOW" "$NC"
+
+# Emergency bypass.
+if [ "${SKIP_FMT_HOOK:-0}" = "1" ]; then
+	printf '%bSKIP_FMT_HOOK=1 set -- skipping format/lint gate.%b\n' "$YELLOW" "$NC"
+	exit 0
+fi
+
+# cargo must be available; if it is not, fail closed (better to block than to
+# let unformatted code slip past unchecked).
+if ! command -v cargo >/dev/null 2>&1; then
+	printf '%bcargo not found on PATH -- cannot verify formatting.%b\n' "$RED" "$NC"
+	printf 'Install Rust (https://rustup.rs) or bypass with SKIP_FMT_HOOK=1.\n'
+	exit 1
+fi
+
+# -- Hard gate: rustfmt -------------------------------------------------------
+printf '  cargo fmt --all -- --check ... '
+if cargo fmt --all -- --check; then
+	printf '%bOK%b\n' "$GREEN" "$NC"
+else
+	printf '%bFAIL%b\n' "$RED" "$NC"
+	printf '\n'
+	printf '%bPush blocked: code is not formatted.%b\n' "$RED" "$NC"
+	printf 'Fix it with:\n'
+	printf '    cargo fmt --all\n'
+	printf 'then stage, commit, and push again.\n'
+	printf '\n'
+	printf 'Emergency bypass (discouraged): SKIP_FMT_HOOK=1 git push\n'
+	exit 1
+fi
+
+# -- Soft warning: clippy -----------------------------------------------------
+# Non-blocking by design: a clippy regression should be visible but must not
+# stop an otherwise-formatted push. Promote to a hard gate later if desired.
+printf '  cargo clippy --all-targets -- -D warnings ... '
+if cargo clippy --all-targets -- -D warnings >/dev/null 2>&1; then
+	printf '%bOK%b\n' "$GREEN" "$NC"
+else
+	printf '%bWARN%b\n' "$YELLOW" "$NC"
+	printf '%bclippy reported warnings (not blocking). Run: cargo clippy --all-targets -- -D warnings%b\n' "$YELLOW" "$NC"
+fi
+
+printf '%bAll required pre-push checks passed.%b\n' "$GREEN" "$NC"
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,20 @@ cargo test
 cargo test --all-features
 ```
 
+## Git Hooks
+
+This repo ships hooks in `.githooks/`. Enable them once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+- **`pre-push`** runs `cargo fmt --all -- --check` as a hard gate and blocks the
+  push if any file is unformatted (this is the exact gap that has broken CI).
+  It also runs `cargo clippy --all-targets -- -D warnings` as a soft warning.
+  For genuine emergencies you can bypass it: `SKIP_FMT_HOOK=1 git push`.
+- Verify the hook itself with `scripts/test-pre-push.sh`.
+
 ## Code Style
 
 This project enforces consistent style through tooling and convention:

--- a/scripts/test-pre-push.sh
+++ b/scripts/test-pre-push.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# BDD test for .githooks/pre-push.
+#
+# SCENARIO: format gate
+#   Given a throwaway crate containing UNFORMATTED Rust,
+#     when the pre-push hook runs, then it BLOCKS the push (exit != 0).
+#   Given the same crate after `cargo fmt --all` (FORMATTED Rust),
+#     when the pre-push hook runs, then it ALLOWS the push (exit == 0).
+#   Given UNFORMATTED Rust but SKIP_FMT_HOOK=1,
+#     when the pre-push hook runs, then it ALLOWS the push (bypass).
+#
+# This test never performs a real `git push`. It builds an isolated temp crate,
+# invokes the hook from inside it, asserts exit codes, and cleans up on exit.
+
+set -eu
+
+# Resolve repo root and the hook under test (absolute paths).
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd -P)
+HOOK="$REPO_ROOT/.githooks/pre-push"
+
+PASS=0
+FAIL=0
+
+ok() {
+	PASS=$((PASS + 1))
+	printf 'PASS: %s\n' "$1"
+}
+
+bad() {
+	FAIL=$((FAIL + 1))
+	printf 'FAIL: %s\n' "$1"
+}
+
+# Throwaway workspace; removed on any exit.
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t prepush)
+cleanup() {
+	rm -rf "$TMP"
+}
+trap cleanup EXIT INT TERM
+
+# -- Preconditions ------------------------------------------------------------
+if [ ! -x "$HOOK" ]; then
+	bad "hook missing or not executable: $HOOK"
+	printf '\nRED: cannot test a hook that does not exist / is not executable.\n'
+	exit 1
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+	printf 'SKIP: cargo not on PATH; cannot exercise rustfmt gate.\n'
+	exit 0
+fi
+
+# -- Build an isolated minimal crate -----------------------------------------
+CRATE="$TMP/throwaway"
+mkdir -p "$CRATE/src"
+
+cat >"$CRATE/Cargo.toml" <<'EOF'
+[package]
+name = "throwaway"
+version = "0.0.0"
+edition = "2021"
+
+[[bin]]
+name = "throwaway"
+path = "src/main.rs"
+EOF
+
+# Deliberately UNFORMATTED: bad indentation + spacing rustfmt will rewrite.
+write_unformatted() {
+	cat >"$CRATE/src/main.rs" <<'EOF'
+fn   main( ) {
+let x=1   ;
+        let    y =2;
+println!("{}",x+y) ;
+}
+EOF
+}
+
+# Run the hook with cwd = throwaway crate. We deliberately do NOT pass through
+# the caller's SKIP_FMT_HOOK; each case sets it explicitly.
+run_hook() {
+	# $1 = value for SKIP_FMT_HOOK ("" means unset)
+	( cd "$CRATE" && env -u SKIP_FMT_HOOK ${1:+SKIP_FMT_HOOK="$1"} "$HOOK" ) >"$TMP/out.log" 2>&1
+}
+
+# -- GIVEN unformatted Rust, THEN hook blocks --------------------------------
+write_unformatted
+if run_hook ""; then
+	bad "unformatted Rust was ALLOWED (expected block)"
+	sed 's/^/    /' "$TMP/out.log"
+else
+	ok "unformatted Rust is BLOCKED (non-zero exit)"
+fi
+
+# Confirm the message is actionable (mentions cargo fmt).
+if grep -q "cargo fmt" "$TMP/out.log"; then
+	ok "failure message points to 'cargo fmt'"
+else
+	bad "failure message does not mention 'cargo fmt'"
+fi
+
+# -- GIVEN unformatted Rust + SKIP_FMT_HOOK=1, THEN bypass -------------------
+write_unformatted
+if run_hook "1"; then
+	ok "SKIP_FMT_HOOK=1 bypasses the gate (allowed)"
+else
+	bad "SKIP_FMT_HOOK=1 did not bypass (expected allow)"
+	sed 's/^/    /' "$TMP/out.log"
+fi
+
+# -- GIVEN formatted Rust, THEN hook allows ----------------------------------
+write_unformatted
+( cd "$CRATE" && cargo fmt --all ) >/dev/null 2>&1 || true
+if run_hook ""; then
+	ok "formatted Rust is ALLOWED (zero exit)"
+else
+	bad "formatted Rust was BLOCKED (expected allow)"
+	sed 's/^/    /' "$TMP/out.log"
+fi
+
+# -- Summary ------------------------------------------------------------------
+printf '\n--- test-pre-push summary: %d passed, %d failed ---\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+	exit 1
+fi
+printf 'GREEN: all pre-push BDD scenarios passed.\n'
+exit 0

--- a/src/capture/decrypt.rs
+++ b/src/capture/decrypt.rs
@@ -1245,7 +1245,14 @@ mod tests {
         let table = [
             (Aes128Gcm, 16, 12, 0, false, "TLS_AES_128_GCM_SHA256"),
             (Aes256Gcm, 32, 12, 0, false, "TLS_AES_256_GCM_SHA384"),
-            (Aes128CbcSha, 16, 16, 20, true, "TLS_RSA_WITH_AES_128_CBC_SHA"),
+            (
+                Aes128CbcSha,
+                16,
+                16,
+                20,
+                true,
+                "TLS_RSA_WITH_AES_128_CBC_SHA",
+            ),
             (
                 Aes256CbcSha256,
                 32,
@@ -1519,7 +1526,13 @@ mod tests {
     fn poll_keylog_loads_appended_entries() {
         use std::io::Write;
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
-        writeln!(tmp, "CLIENT_TRAFFIC_SECRET_0 {} {}", "aa".repeat(32), "bb".repeat(32)).unwrap();
+        writeln!(
+            tmp,
+            "CLIENT_TRAFFIC_SECRET_0 {} {}",
+            "aa".repeat(32),
+            "bb".repeat(32)
+        )
+        .unwrap();
         tmp.flush().unwrap();
 
         let mut d = TlsDecryptor::new(
@@ -1535,7 +1548,13 @@ mod tests {
         assert_eq!(d.poll_keylog_file().unwrap(), 0);
 
         // Append a valid line and a junk line (the junk is skipped).
-        writeln!(tmp, "SERVER_TRAFFIC_SECRET_0 {} {}", "aa".repeat(32), "cc".repeat(32)).unwrap();
+        writeln!(
+            tmp,
+            "SERVER_TRAFFIC_SECRET_0 {} {}",
+            "aa".repeat(32),
+            "cc".repeat(32)
+        )
+        .unwrap();
         writeln!(tmp, "this is not a valid keylog line").unwrap();
         tmp.flush().unwrap();
 
@@ -1579,10 +1598,20 @@ mod tests {
     #[test]
     fn build_aad_covers_content_types_and_versions() {
         let cases = [
-            (TlsContentType::ChangeCipherSpec, TlsVersion::Tls10, 20u8, 0x0301u16),
+            (
+                TlsContentType::ChangeCipherSpec,
+                TlsVersion::Tls10,
+                20u8,
+                0x0301u16,
+            ),
             (TlsContentType::Alert, TlsVersion::Tls11, 21, 0x0302),
             (TlsContentType::Handshake, TlsVersion::Tls13, 22, 0x0303),
-            (TlsContentType::Unknown(99), TlsVersion::Unknown(0x7F7F), 99, 0x7F7F),
+            (
+                TlsContentType::Unknown(99),
+                TlsVersion::Unknown(0x7F7F),
+                99,
+                0x7F7F,
+            ),
         ];
         for (ct, ver, want_ct, want_ver) in cases {
             let aad = build_record_aad(&TlsRecord {

--- a/src/capture/hep.rs
+++ b/src/capture/hep.rs
@@ -1488,12 +1488,7 @@ mod tests {
         let mut chunks = Vec::new();
         append_chunk(&mut chunks, 0, CHUNK_SRC_IPV4, &[10, 0, 0, 1]);
         append_chunk(&mut chunks, 0, CHUNK_DST_IPV4, &[10, 0, 0, 2]);
-        append_chunk(
-            &mut chunks,
-            0,
-            CHUNK_CORRELATION_ID,
-            b"call-abc-123\0\0\0",
-        );
+        append_chunk(&mut chunks, 0, CHUNK_CORRELATION_ID, b"call-abc-123\0\0\0");
         append_chunk(&mut chunks, 0, CHUNK_PAYLOAD, b"X");
         let data = assemble_v3(&chunks);
 
@@ -1662,9 +1657,7 @@ mod tests {
         // Search only the chunk region (after the 6-byte header) for the
         // IPv6 type marker; it must be absent for an IPv4 endpoint.
         assert!(
-            !built[HEP3_HEADER_LEN..]
-                .chunks(2)
-                .any(|w| w == v6_src),
+            !built[HEP3_HEADER_LEN..].chunks(2).any(|w| w == v6_src),
             "IPv6 src chunk type must be absent for IPv4 endpoint"
         );
     }
@@ -1678,7 +1671,10 @@ mod tests {
         assert_eq!(buf.len(), CHUNK_HEADER_LEN + 2);
         assert_eq!(u16::from_be_bytes([buf[0], buf[1]]), 0xabcd); // vendor
         assert_eq!(u16::from_be_bytes([buf[2], buf[3]]), 0x0011); // type
-        assert_eq!(u16::from_be_bytes([buf[4], buf[5]]) as usize, CHUNK_HEADER_LEN + 2);
+        assert_eq!(
+            u16::from_be_bytes([buf[4], buf[5]]) as usize,
+            CHUNK_HEADER_LEN + 2
+        );
         assert_eq!(&buf[6..], &[0xde, 0xad]);
     }
 

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -809,30 +809,18 @@ mod tests {
 
             // Raw mode never embeds key material -> early return.
             let raw_path = dir.path().join("raw.pcapng");
-            let mut w = PcapWriter::with_format(
-                &raw_path,
-                1,
-                None,
-                None,
-                true,
-                PcapExportMode::Raw,
-            )
-            .unwrap();
+            let mut w =
+                PcapWriter::with_format(&raw_path, 1, None, None, true, PcapExportMode::Raw)
+                    .unwrap();
             let keylog = dir.path().join("k.txt");
             std::fs::write(&keylog, b"CLIENT_RANDOM a b\n").unwrap();
             w.maybe_write_keylog_dsb(&keylog).unwrap();
 
             // EncryptedWithDsb but an empty keylog -> the "Ok(empty)" arm.
             let p2 = dir.path().join("e.pcapng");
-            let mut w2 = PcapWriter::with_format(
-                &p2,
-                1,
-                None,
-                None,
-                true,
-                PcapExportMode::EncryptedWithDsb,
-            )
-            .unwrap();
+            let mut w2 =
+                PcapWriter::with_format(&p2, 1, None, None, true, PcapExportMode::EncryptedWithDsb)
+                    .unwrap();
             let empty = dir.path().join("empty.txt");
             std::fs::write(&empty, b"").unwrap();
             w2.maybe_write_keylog_dsb(&empty).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2518,11 +2518,7 @@ mod tests {
         dialog_store.process_message(msg);
         assert!(dialog_store.get(call_id).is_some());
 
-        let formats: [fn(&mut Cli); 3] = [
-            |_c| {},
-            |c| c.json = true,
-            |c| c.markdown = true,
-        ];
+        let formats: [fn(&mut Cli); 3] = [|_c| {}, |c| c.json = true, |c| c.markdown = true];
         for setup in formats {
             let mut cli = base_cli();
             cli.call_report = Some(call_id.to_string());

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -898,8 +898,16 @@ mod tests {
     }
 
     fn parse_at(raw: &[u8], ts: chrono::DateTime<chrono::Utc>) -> crate::sip::SipMessage {
-        parse_sip(raw, ts, localhost(), localhost(), 5060, 5060, TransportProto::Udp)
-            .expect("should parse SIP")
+        parse_sip(
+            raw,
+            ts,
+            localhost(),
+            localhost(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("should parse SIP")
     }
 
     fn invite(call_id: &str, ts: chrono::DateTime<chrono::Utc>) -> crate::sip::SipMessage {
@@ -1051,7 +1059,10 @@ mod tests {
             .await
             .expect("list_dialogs should succeed");
         let raw = text_of(&result);
-        assert!(raw.contains("call-list@x"), "summary must name the dialog: {raw}");
+        assert!(
+            raw.contains("call-list@x"),
+            "summary must name the dialog: {raw}"
+        );
         assert!(raw.contains("alice"), "from_user should appear: {raw}");
     }
 
@@ -1247,7 +1258,10 @@ mod tests {
             }))
             .await
             .expect("render_ladder should succeed");
-        assert!(!text_of(&result).is_empty(), "ladder text must be non-empty");
+        assert!(
+            !text_of(&result).is_empty(),
+            "ladder text must be non-empty"
+        );
     }
 
     // ── rtp_stats ────────────────────────────────────────────────────
@@ -1324,7 +1338,13 @@ mod tests {
         let hits = v.as_array().expect("hits array");
         assert!(!hits.is_empty(), "should match the From header");
         assert_eq!(hits[0]["call_id"], "srch2@x");
-        assert!(hits[0]["snippet"].as_str().unwrap().to_lowercase().contains("alice"));
+        assert!(
+            hits[0]["snippet"]
+                .as_str()
+                .unwrap()
+                .to_lowercase()
+                .contains("alice")
+        );
     }
 
     // ── tail_dialogs ─────────────────────────────────────────────────
@@ -1352,7 +1372,10 @@ mod tests {
             .expect("tail should succeed");
         let v: serde_json::Value = serde_json::from_str(&text_of(&result)).unwrap();
         assert_eq!(v["dialogs"].as_array().unwrap().len(), 1);
-        assert!(v["next_cursor"].is_string(), "next_cursor set when dialogs returned");
+        assert!(
+            v["next_cursor"].is_string(),
+            "next_cursor set when dialogs returned"
+        );
         assert_eq!(v["source_exhausted"], false);
     }
 

--- a/src/output/api.rs
+++ b/src/output/api.rs
@@ -1519,10 +1519,7 @@ mod tests {
         let state = make_state_with_key("secret-key");
         let app = build_router(state);
 
-        let resp = app
-            .oneshot(test_request("/health"))
-            .await
-            .expect("oneshot");
+        let resp = app.oneshot(test_request("/health")).await.expect("oneshot");
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(body_to_string(resp.into_body()).await, "ok");
     }

--- a/src/output/prometheus_server.rs
+++ b/src/output/prometheus_server.rs
@@ -441,7 +441,10 @@ mod tests {
 
         // No credentials -> 401 with a challenge.
         let resp = http_request(addr, "GET /metrics HTTP/1.1\r\nHost: x\r\n\r\n");
-        assert!(resp.starts_with("HTTP/1.1 401 Unauthorized"), "got: {resp:?}");
+        assert!(
+            resp.starts_with("HTTP/1.1 401 Unauthorized"),
+            "got: {resp:?}"
+        );
         assert!(resp.contains("WWW-Authenticate: Basic"), "got: {resp:?}");
 
         // Wrong credentials -> still 401.
@@ -449,7 +452,10 @@ mod tests {
             addr,
             "GET /metrics HTTP/1.1\r\nHost: x\r\nAuthorization: Basic dXNlcjp3cm9uZw==\r\n\r\n",
         );
-        assert!(resp.starts_with("HTTP/1.1 401 Unauthorized"), "got: {resp:?}");
+        assert!(
+            resp.starts_with("HTTP/1.1 401 Unauthorized"),
+            "got: {resp:?}"
+        );
 
         // Correct credentials (base64 "user:pass") -> 200.
         let resp = http_request(

--- a/src/rtp/playback.rs
+++ b/src/rtp/playback.rs
@@ -311,7 +311,8 @@ mod tests {
         // Garbage payloads: each frame fails to decode and is skipped, but the
         // function still returns Ok (the error-skip branch).
         let mut s = stream(111);
-        s.payload_buffer.push_back((0, vec![0xDE, 0xAD, 0xBE, 0xEF]));
+        s.payload_buffer
+            .push_back((0, vec![0xDE, 0xAD, 0xBE, 0xEF]));
         s.payload_buffer.push_back((20, vec![0xFF; 8]));
         let pcm = decode_opus_to_f32(&s).expect("opus decode ok despite bad frames");
         // Undecodable frames produce no samples.

--- a/src/sip/dsl.rs
+++ b/src/sip/dsl.rs
@@ -1292,7 +1292,11 @@ mod tests {
 
     #[test]
     fn expand_alias_returns_exact_expansions() {
-        assert!(expand_alias("problems").unwrap().contains("state == 'Failed'"));
+        assert!(
+            expand_alias("problems")
+                .unwrap()
+                .contains("state == 'Failed'")
+        );
         assert_eq!(expand_alias("slow-setup"), Some("pdd > 3.0"));
         assert_eq!(
             expand_alias("short-calls"),
@@ -1327,19 +1331,11 @@ mod tests {
     #[test]
     fn nesting_depth_exactly_at_limit_ok() {
         // Exactly MAX_NESTING_DEPTH (50) open parens is allowed; 51 is not.
-        let expr = format!(
-            "{}from.user == '1001'{}",
-            "(".repeat(50),
-            ")".repeat(50)
-        );
+        let expr = format!("{}from.user == '1001'{}", "(".repeat(50), ")".repeat(50));
         // Nesting-depth check itself passes (no "nesting depth" error).
         assert!(check_nesting_depth(&expr).is_ok());
 
-        let too_deep = format!(
-            "{}from.user == '1001'{}",
-            "(".repeat(51),
-            ")".repeat(51)
-        );
+        let too_deep = format!("{}from.user == '1001'{}", "(".repeat(51), ")".repeat(51));
         let err = check_nesting_depth(&too_deep).unwrap_err().to_string();
         assert!(err.contains("nesting depth"), "got: {err}");
     }
@@ -1496,7 +1492,11 @@ mod tests {
     #[test]
     fn compare_bool_type_mismatch_is_false() {
         assert!(!compare_bool(true, &Operator::Eq, &Value::Num(1.0)));
-        assert!(!compare_bool(true, &Operator::Eq, &Value::Str("true".into())));
+        assert!(!compare_bool(
+            true,
+            &Operator::Eq,
+            &Value::Str("true".into())
+        ));
     }
 
     // ── state_to_str: all DialogState variants ──────────────────────────

--- a/src/tui/call_flow/prepare.rs
+++ b/src/tui/call_flow/prepare.rs
@@ -774,8 +774,7 @@ mod tests {
     }
 
     fn parse_resp(raw: &[u8], ts: DateTime<Utc>) -> SipMessage {
-        parse_sip(raw, ts, addr_b(), addr_a(), 5060, 5060, TransportProto::Udp)
-            .expect("parse resp")
+        parse_sip(raw, ts, addr_b(), addr_a(), 5060, 5060, TransportProto::Udp).expect("parse resp")
     }
 
     fn invite(cid: &str, cseq: u32, ts: DateTime<Utc>) -> SipMessage {
@@ -795,7 +794,13 @@ mod tests {
         )
     }
 
-    fn invite_with_sdp(cid: &str, cseq: u32, codecs_line: &str, rtpmaps: &[&str], ts: DateTime<Utc>) -> SipMessage {
+    fn invite_with_sdp(
+        cid: &str,
+        cseq: u32,
+        codecs_line: &str,
+        rtpmaps: &[&str],
+        ts: DateTime<Utc>,
+    ) -> SipMessage {
         let mut sdp = String::from(
             "v=0\r\n\
              o=- 1 1 IN IP4 10.0.0.1\r\n\
@@ -878,7 +883,14 @@ mod tests {
         )
     }
 
-    fn response(cid: &str, status: u16, reason: &str, cseq: u32, method: &str, ts: DateTime<Utc>) -> SipMessage {
+    fn response(
+        cid: &str,
+        status: u16,
+        reason: &str,
+        cseq: u32,
+        method: &str,
+        ts: DateTime<Utc>,
+    ) -> SipMessage {
         parse_resp(
             &build_raw(
                 &format!("SIP/2.0 {status} {reason}"),
@@ -984,7 +996,14 @@ mod tests {
         let o = opts(&theme);
         let msgs = vec![
             invite("c1", 1, t0()),
-            response("c1", 180, "Ringing", 1, "INVITE", t0() + TimeDelta::milliseconds(500)),
+            response(
+                "c1",
+                180,
+                "Ringing",
+                1,
+                "INVITE",
+                t0() + TimeDelta::milliseconds(500),
+            ),
             response("c1", 200, "OK", 1, "INVITE", t0() + TimeDelta::seconds(1)),
             ack("c1", 1, t0() + TimeDelta::seconds(1)),
             bye("c1", 2, t0() + TimeDelta::seconds(30)),
@@ -1073,7 +1092,10 @@ mod tests {
             ),
         ];
         let (_p, prepared) = prepare_messages(&msgs, t0(), None, &o, &HashSet::new());
-        let badge = prepared[1].sdp_badge.as_deref().expect("badge on re-INVITE");
+        let badge = prepared[1]
+            .sdp_badge
+            .as_deref()
+            .expect("badge on re-INVITE");
         assert!(badge.contains("+G722"), "expected codec add: {badge}");
         assert!(badge.contains("PCMU"), "expected codec removal: {badge}");
     }
@@ -1110,13 +1132,24 @@ mod tests {
         // Large gaps between messages → spacer rows inserted.
         let msgs = vec![
             invite("cscale", 1, t0()),
-            response("cscale", 200, "OK", 1, "INVITE", t0() + TimeDelta::seconds(5)),
+            response(
+                "cscale",
+                200,
+                "OK",
+                1,
+                "INVITE",
+                t0() + TimeDelta::seconds(5),
+            ),
             bye("cscale", 2, t0() + TimeDelta::seconds(30)),
         ];
         let (_p, prepared) = prepare_messages(&msgs, t0(), None, &o, &HashSet::new());
         assert!(prepared.iter().any(|m| m.is_spacer), "no spacers inserted");
         // More rows than raw messages because of spacers.
-        assert!(prepared.len() > 3, "expected spacer expansion, got {}", prepared.len());
+        assert!(
+            prepared.len() > 3,
+            "expected spacer expansion, got {}",
+            prepared.len()
+        );
     }
 
     // ── fold_messages: retransmit folding ─────────────────────────────
@@ -1125,11 +1158,25 @@ mod tests {
     fn prepare_folds_retransmissions() {
         let theme = Theme::default();
         let o = opts(&theme);
-        let mut retx = response("cretx", 200, "OK", 1, "INVITE", t0() + TimeDelta::seconds(2));
+        let mut retx = response(
+            "cretx",
+            200,
+            "OK",
+            1,
+            "INVITE",
+            t0() + TimeDelta::seconds(2),
+        );
         retx.is_retransmission = true;
         let msgs = vec![
             invite("cretx", 1, t0()),
-            response("cretx", 200, "OK", 1, "INVITE", t0() + TimeDelta::seconds(1)),
+            response(
+                "cretx",
+                200,
+                "OK",
+                1,
+                "INVITE",
+                t0() + TimeDelta::seconds(1),
+            ),
             retx,
         ];
         // Not expanded → the retransmission folds into the prior 200 OK.
@@ -1153,16 +1200,35 @@ mod tests {
         let cid = "cauth";
         let msgs = vec![
             register(cid, 1, None, t0()),
-            response(cid, 401, "Unauthorized", 1, "REGISTER", t0() + TimeDelta::milliseconds(10)),
+            response(
+                cid,
+                401,
+                "Unauthorized",
+                1,
+                "REGISTER",
+                t0() + TimeDelta::milliseconds(10),
+            ),
             ack_register(cid, 1, t0() + TimeDelta::milliseconds(20)),
-            register(cid, 2, Some("Digest username=\"alice\""), t0() + TimeDelta::milliseconds(30)),
+            register(
+                cid,
+                2,
+                Some("Digest username=\"alice\""),
+                t0() + TimeDelta::milliseconds(30),
+            ),
         ];
         assert_eq!(detect_auth_sequence(&msgs, 0), Some(4));
 
         // Without the Authorization header on the retry, it is not an auth seq.
         let no_auth = vec![
             register(cid, 1, None, t0()),
-            response(cid, 401, "Unauthorized", 1, "REGISTER", t0() + TimeDelta::milliseconds(10)),
+            response(
+                cid,
+                401,
+                "Unauthorized",
+                1,
+                "REGISTER",
+                t0() + TimeDelta::milliseconds(10),
+            ),
             ack_register(cid, 1, t0() + TimeDelta::milliseconds(20)),
             register(cid, 2, None, t0() + TimeDelta::milliseconds(30)),
         ];
@@ -1179,17 +1245,37 @@ mod tests {
         let cid = "cauth2";
         let msgs = vec![
             register(cid, 1, None, t0()),
-            response(cid, 401, "Unauthorized", 1, "REGISTER", t0() + TimeDelta::milliseconds(10)),
+            response(
+                cid,
+                401,
+                "Unauthorized",
+                1,
+                "REGISTER",
+                t0() + TimeDelta::milliseconds(10),
+            ),
             ack_register(cid, 1, t0() + TimeDelta::milliseconds(20)),
-            register(cid, 2, Some("Digest username=\"alice\""), t0() + TimeDelta::milliseconds(30)),
+            register(
+                cid,
+                2,
+                Some("Digest username=\"alice\""),
+                t0() + TimeDelta::milliseconds(30),
+            ),
         ];
         // Collapsed: the 4-message auth handshake folds into one header row.
         let (_p, folded) = prepare_messages(&msgs, t0(), None, &o, &HashSet::new());
         assert_eq!(folded.len(), 1, "auth sequence should collapse to one row");
         assert_eq!(folded[0].folded_count, 4);
-        assert!(folded[0].label.contains("(auth retry)"), "got: {}", folded[0].label);
         assert!(
-            folded[0].fold_label.as_deref().unwrap().contains("auth retry"),
+            folded[0].label.contains("(auth retry)"),
+            "got: {}",
+            folded[0].label
+        );
+        assert!(
+            folded[0]
+                .fold_label
+                .as_deref()
+                .unwrap()
+                .contains("auth retry"),
             "missing auth fold label"
         );
 
@@ -1197,7 +1283,11 @@ mod tests {
         let mut expanded = HashSet::new();
         expanded.insert(0usize);
         let (_p2, shown) = prepare_messages(&msgs, t0(), None, &o, &expanded);
-        assert_eq!(shown.len(), 4, "expanded auth sequence should show all rows");
+        assert_eq!(
+            shown.len(),
+            4,
+            "expanded auth sequence should show all rows"
+        );
     }
 
     // ── extract_codec_list: rtpmap and static-PT fallback ─────────────

--- a/src/tui/call_flow/prepare.rs
+++ b/src/tui/call_flow/prepare.rs
@@ -731,6 +731,34 @@ pub fn message_style(msg: &SipMessage, theme: &Theme) -> Style {
     }
 }
 
+/// Format SDP codec list from an SDP session for the summary display.
+pub fn format_sdp_codecs(session: &sdp::SdpSession) -> String {
+    let mut codecs = Vec::new();
+    for media in &session.media {
+        for rm in &media.rtpmap {
+            codecs.push(rm.encoding.clone());
+        }
+        if media.rtpmap.is_empty() {
+            for f in &media.formats {
+                codecs.push(
+                    match f.as_str() {
+                        "0" => "PCMU",
+                        "8" => "PCMA",
+                        "9" => "G722",
+                        "18" => "G729",
+                        "4" => "G723",
+                        "3" => "GSM",
+                        "101" => "telephone-event",
+                        o => o,
+                    }
+                    .to_string(),
+                );
+            }
+        }
+    }
+    codecs.join(", ")
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
@@ -1350,32 +1378,32 @@ mod tests {
         // DeltaPrev timestamps are right-aligned "+x.xxxs" strings.
         assert!(prepared2[1].timestamp.contains('+'));
     }
-}
 
-/// Format SDP codec list from an SDP session for the summary display.
-pub fn format_sdp_codecs(session: &sdp::SdpSession) -> String {
-    let mut codecs = Vec::new();
-    for media in &session.media {
-        for rm in &media.rtpmap {
-            codecs.push(rm.encoding.clone());
-        }
-        if media.rtpmap.is_empty() {
-            for f in &media.formats {
-                codecs.push(
-                    match f.as_str() {
-                        "0" => "PCMU",
-                        "8" => "PCMA",
-                        "9" => "G722",
-                        "18" => "G729",
-                        "4" => "G723",
-                        "3" => "GSM",
-                        "101" => "telephone-event",
-                        o => o,
-                    }
-                    .to_string(),
-                );
-            }
-        }
+    // ── format_sdp_codecs ────────────────────────────────────────────
+
+    #[test]
+    fn format_sdp_codecs_prefers_rtpmap_encodings() {
+        // When a=rtpmap is present, the encoding names are used verbatim.
+        let body = b"v=0\r\n\
+            m=audio 5004 RTP/AVP 0 8 96\r\n\
+            a=rtpmap:0 PCMU/8000\r\n\
+            a=rtpmap:8 PCMA/8000\r\n\
+            a=rtpmap:96 opus/48000/2\r\n";
+        let session = sdp::parse_sdp(body).expect("valid sdp");
+        assert_eq!(format_sdp_codecs(&session), "PCMU, PCMA, opus");
     }
-    codecs.join(", ")
+
+    #[test]
+    fn format_sdp_codecs_maps_bare_payload_types_and_passes_through_unknown() {
+        // No a=rtpmap → fall back to static payload-type numbers. This is the
+        // branch covering the numeric→name table and the `o => o` pass-through
+        // for an unrecognised dynamic type (99).
+        let body = b"v=0\r\n\
+            m=audio 5004 RTP/AVP 0 8 9 18 4 3 101 99\r\n";
+        let session = sdp::parse_sdp(body).expect("valid sdp");
+        assert_eq!(
+            format_sdp_codecs(&session),
+            "PCMU, PCMA, G722, G729, G723, GSM, telephone-event, 99"
+        );
+    }
 }

--- a/src/tui/call_flow/render.rs
+++ b/src/tui/call_flow/render.rs
@@ -1153,18 +1153,11 @@ mod tests {
             ],
             "",
         );
-        parse_sip(&raw, ts, ip_a(), ip_b(), 5060, 5060, TransportProto::Udp)
-            .expect("parse request")
+        parse_sip(&raw, ts, ip_a(), ip_b(), 5060, 5060, TransportProto::Udp).expect("parse request")
     }
 
     /// B->A response message.
-    fn resp(
-        status: u16,
-        reason: &str,
-        cseq: &str,
-        call_id: &str,
-        ts: DateTime<Utc>,
-    ) -> SipMessage {
+    fn resp(status: u16, reason: &str, cseq: &str, call_id: &str, ts: DateTime<Utc>) -> SipMessage {
         let raw = build_raw(
             &format!("SIP/2.0 {status} {reason}"),
             &[
@@ -1222,7 +1215,11 @@ mod tests {
     }
 
     fn lines_to_string(lines: &[Line<'_>]) -> String {
-        lines.iter().map(line_to_string).collect::<Vec<_>>().join("\n")
+        lines
+            .iter()
+            .map(line_to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// Store with a complete INVITE/180/200/ACK/BYE/200 dialog.
@@ -1230,11 +1227,34 @@ mod tests {
         let t = base_ts();
         let mut store = DialogStore::new(100, false);
         store.process_message(req("INVITE", "1 INVITE", call_id, t));
-        store.process_message(resp(180, "Ringing", "1 INVITE", call_id, t + TimeDelta::seconds(1)));
-        store.process_message(resp(200, "OK", "1 INVITE", call_id, t + TimeDelta::seconds(2)));
-        store.process_message(req("ACK", "1 ACK", call_id, t + TimeDelta::milliseconds(2100)));
+        store.process_message(resp(
+            180,
+            "Ringing",
+            "1 INVITE",
+            call_id,
+            t + TimeDelta::seconds(1),
+        ));
+        store.process_message(resp(
+            200,
+            "OK",
+            "1 INVITE",
+            call_id,
+            t + TimeDelta::seconds(2),
+        ));
+        store.process_message(req(
+            "ACK",
+            "1 ACK",
+            call_id,
+            t + TimeDelta::milliseconds(2100),
+        ));
         store.process_message(req("BYE", "2 BYE", call_id, t + TimeDelta::seconds(30)));
-        store.process_message(resp(200, "OK", "2 BYE", call_id, t + TimeDelta::seconds(30)));
+        store.process_message(resp(
+            200,
+            "OK",
+            "2 BYE",
+            call_id,
+            t + TimeDelta::seconds(30),
+        ));
         store
     }
 
@@ -1326,8 +1346,20 @@ mod tests {
         let t = base_ts();
         let mut store = DialogStore::new(100, false);
         store.process_message(req("INVITE", "1 INVITE", "err@test", t));
-        store.process_message(resp(100, "Trying", "1 INVITE", "err@test", t + TimeDelta::milliseconds(50)));
-        store.process_message(resp(480, "Temporarily Unavailable", "1 INVITE", "err@test", t + TimeDelta::seconds(1)));
+        store.process_message(resp(
+            100,
+            "Trying",
+            "1 INVITE",
+            "err@test",
+            t + TimeDelta::milliseconds(50),
+        ));
+        store.process_message(resp(
+            480,
+            "Temporarily Unavailable",
+            "1 INVITE",
+            "err@test",
+            t + TimeDelta::seconds(1),
+        ));
         let (count, lines) = build_call_flow_lines(&store, "err@test", &theme).expect("some");
         assert_eq!(count, 3);
         let text = lines_to_string(&lines);
@@ -1343,8 +1375,8 @@ mod tests {
         let store = store_full_dialog("opt@test");
         let mut o = opts(&theme);
         o.selected_msg = Some(2);
-        let (_c, lines) = build_call_flow_lines_with_options(&store, "opt@test", 120, &o)
-            .expect("some");
+        let (_c, lines) =
+            build_call_flow_lines_with_options(&store, "opt@test", 120, &o).expect("some");
         assert!(lines_to_string(&lines).contains("[SELECTED]"));
     }
 
@@ -1354,18 +1386,35 @@ mod tests {
         let t = base_ts();
         let mut store = DialogStore::new(100, false);
         store.process_message(invite_with_sdp("sdp@test", t));
-        store.process_message(resp(200, "OK", "1 INVITE", "sdp@test", t + TimeDelta::seconds(1)));
-        store.process_message(req("ACK", "1 ACK", "sdp@test", t + TimeDelta::milliseconds(1100)));
+        store.process_message(resp(
+            200,
+            "OK",
+            "1 INVITE",
+            "sdp@test",
+            t + TimeDelta::seconds(1),
+        ));
+        store.process_message(req(
+            "ACK",
+            "1 ACK",
+            "sdp@test",
+            t + TimeDelta::milliseconds(1100),
+        ));
         store.process_message(req("BYE", "2 BYE", "sdp@test", t + TimeDelta::seconds(10)));
         let mut o = opts(&theme);
         o.sdp_mode = SdpDisplayMode::Summary;
         o.show_rtp = true;
-        let (_c, lines) = build_call_flow_lines_with_options(&store, "sdp@test", 120, &o)
-            .expect("some");
+        let (_c, lines) =
+            build_call_flow_lines_with_options(&store, "sdp@test", 120, &o).expect("some");
         let text = lines_to_string(&lines);
         // SDP summary lists codecs; show_rtp draws an "RTP stream active" bar at BYE.
-        assert!(text.contains("Codecs:"), "expected codec summary in:\n{text}");
-        assert!(text.contains("RTP stream active"), "expected RTP bar in:\n{text}");
+        assert!(
+            text.contains("Codecs:"),
+            "expected codec summary in:\n{text}"
+        );
+        assert!(
+            text.contains("RTP stream active"),
+            "expected RTP bar in:\n{text}"
+        );
     }
 
     #[test]
@@ -1375,10 +1424,13 @@ mod tests {
         store.process_message(invite_with_sdp("sdpfull@test", base_ts()));
         let mut o = opts(&theme);
         o.sdp_mode = SdpDisplayMode::Full;
-        let (_c, lines) = build_call_flow_lines_with_options(&store, "sdpfull@test", 120, &o)
-            .expect("some");
+        let (_c, lines) =
+            build_call_flow_lines_with_options(&store, "sdpfull@test", 120, &o).expect("some");
         let text = lines_to_string(&lines);
-        assert!(text.contains("m=audio 20000"), "expected raw SDP body in:\n{text}");
+        assert!(
+            text.contains("m=audio 20000"),
+            "expected raw SDP body in:\n{text}"
+        );
         assert!(text.contains("a=rtpmap:0 PCMU/8000"));
     }
 
@@ -1388,8 +1440,8 @@ mod tests {
         let store = store_full_dialog("delta@test");
         let mut o = opts(&theme);
         o.ts_mode = TimestampMode::DeltaPrev;
-        let (_c, lines) = build_call_flow_lines_with_options(&store, "delta@test", 120, &o)
-            .expect("some");
+        let (_c, lines) =
+            build_call_flow_lines_with_options(&store, "delta@test", 120, &o).expect("some");
         // Delta-prev renders "+<n>s" relative timestamps.
         assert!(lines_to_string(&lines).contains("+"));
     }
@@ -1409,11 +1461,13 @@ mod tests {
         let theme = Theme::default();
         let store = store_full_dialog("ext@test");
         let o = opts(&theme);
-        let (count, lines) = build_extended_flow_lines(&store, "ext@test", 120, &o)
-            .expect("some");
+        let (count, lines) = build_extended_flow_lines(&store, "ext@test", 120, &o).expect("some");
         assert_eq!(count, 6);
         let text = lines_to_string(&lines);
-        assert!(text.contains("Extended Flow:"), "missing header in:\n{text}");
+        assert!(
+            text.contains("Extended Flow:"),
+            "missing header in:\n{text}"
+        );
         assert!(text.contains("correlated leg(s)"));
         assert!(text.contains("INVITE"));
     }
@@ -1463,7 +1517,10 @@ mod tests {
             .unwrap();
         // Still renders the wrapped ladder without panicking; some content present.
         let text = buffer_text(&term);
-        assert!(text.contains("INVITE") || text.contains("10.0.0.1"), "buffer:\n{text}");
+        assert!(
+            text.contains("INVITE") || text.contains("10.0.0.1"),
+            "buffer:\n{text}"
+        );
     }
 
     #[test]
@@ -1481,7 +1538,10 @@ mod tests {
         .unwrap();
         let text = buffer_text(&term);
         // With offset 4 (header+bar+INVITE+180 scrolled away) the 200/ACK/BYE show.
-        assert!(text.contains("BYE") || text.contains("ACK") || text.contains("200"), "buffer:\n{text}");
+        assert!(
+            text.contains("BYE") || text.contains("ACK") || text.contains("200"),
+            "buffer:\n{text}"
+        );
     }
 
     #[test]
@@ -1489,10 +1549,8 @@ mod tests {
         let theme = Theme::default();
         let mut term = terminal(60, 8);
         let area = Rect::new(0, 0, 60, 8);
-        term.draw(|f| {
-            render_call_flow_lines(f, area, "x@test", 0, &theme, || None)
-        })
-        .unwrap();
+        term.draw(|f| render_call_flow_lines(f, area, "x@test", 0, &theme, || None))
+            .unwrap();
         assert!(buffer_text(&term).contains("Dialog not found or empty"));
     }
 }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1645,8 +1645,16 @@ mod tests {
                 "Content-Length: 0",
             ],
         );
-        parse_sip(&raw, ts, addr_a(), addr_b(), 5060, 5060, TransportProto::Udp)
-            .expect("parse INVITE")
+        parse_sip(
+            &raw,
+            ts,
+            addr_a(),
+            addr_b(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("parse INVITE")
     }
 
     fn make_ok(call_id: &str, ts: DateTime<Utc>) -> SipMessage {
@@ -1660,8 +1668,16 @@ mod tests {
                 "Content-Length: 0",
             ],
         );
-        parse_sip(&raw, ts, addr_b(), addr_a(), 5060, 5060, TransportProto::Udp)
-            .expect("parse 200")
+        parse_sip(
+            &raw,
+            ts,
+            addr_b(),
+            addr_a(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("parse 200")
     }
 
     fn app_with_dialogs() -> App {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1381,12 +1381,14 @@ mod tests {
 
     #[test]
     fn filter_dialog_text_field_accessors() {
-        let mut st = FilterDialogState::default();
-        st.sip_from = "a".to_string();
-        st.sip_to = "b".to_string();
-        st.source = "c".to_string();
-        st.destination = "d".to_string();
-        st.payload = "e".to_string();
+        let mut st = FilterDialogState {
+            sip_from: "a".to_string(),
+            sip_to: "b".to_string(),
+            source: "c".to_string(),
+            destination: "d".to_string(),
+            payload: "e".to_string(),
+            ..Default::default()
+        };
         assert_eq!(st.text_field(0), "a");
         assert_eq!(st.text_field(1), "b");
         assert_eq!(st.text_field(2), "c");
@@ -1413,9 +1415,11 @@ mod tests {
 
     #[test]
     fn filter_dialog_focus_classification() {
-        let mut st = FilterDialogState::default();
+        let mut st = FilterDialogState {
+            focused_field: 0,
+            ..Default::default()
+        };
         // text fields 0..5
-        st.focused_field = 0;
         assert!(st.is_text_field_focused());
         assert!(!st.is_checkbox_focused());
         assert!(st.checkbox_index().is_none());
@@ -1431,9 +1435,11 @@ mod tests {
 
     #[test]
     fn filter_dialog_checkbox_grid_navigation() {
-        let mut st = FilterDialogState::default();
+        let mut st = FilterDialogState {
+            focused_field: FILTER_TEXT_FIELD_COUNT,
+            ..Default::default()
+        };
         // Focus first checkbox (index 0).
-        st.focused_field = FILTER_TEXT_FIELD_COUNT;
         st.checkbox_right(); // 0 -> 1
         assert_eq!(st.checkbox_index(), Some(1));
         st.checkbox_left(); // 1 -> 0
@@ -1450,10 +1456,12 @@ mod tests {
 
     #[test]
     fn filter_dialog_checkbox_down_to_buttons() {
-        let mut st = FilterDialogState::default();
+        let mut st = FilterDialogState {
+            focused_field: FILTER_TEXT_FIELD_COUNT + 8,
+            ..Default::default()
+        };
         // Last reachable checkbox in a column → down goes to buttons.
         // index 8 (INFO) -> +2 = 10 (out of range) -> Filter button.
-        st.focused_field = FILTER_TEXT_FIELD_COUNT + 8;
         st.checkbox_down();
         assert_eq!(st.focused_field(), FILTER_BUTTON_IDX);
     }
@@ -1483,17 +1491,21 @@ mod tests {
 
     #[test]
     fn filter_dialog_all_methods_checked_yields_no_method_filter() {
-        let mut st = FilterDialogState::default();
-        st.methods = [true; 10];
+        let st = FilterDialogState {
+            methods: [true; 10],
+            ..Default::default()
+        };
         // All checked → method filter omitted; with no text fields → None.
         assert!(st.build_filter_expression().is_none());
     }
 
     #[test]
     fn filter_dialog_clear_resets_everything() {
-        let mut st = FilterDialogState::default();
-        st.sip_from = "x".to_string();
-        st.sip_to = "y".to_string();
+        let mut st = FilterDialogState {
+            sip_from: "x".to_string(),
+            sip_to: "y".to_string(),
+            ..Default::default()
+        };
         st.methods[0] = true;
         st.focused_field = 7;
         st.cursor_pos = 3;
@@ -1505,10 +1517,12 @@ mod tests {
 
     #[test]
     fn filter_dialog_sync_cursor_to_field_end() {
-        let mut st = FilterDialogState::default();
-        st.sip_to = "hello".to_string();
-        st.focused_field = 1; // SIP To
-        st.cursor_pos = 0;
+        let mut st = FilterDialogState {
+            sip_to: "hello".to_string(),
+            focused_field: 1, // SIP To
+            cursor_pos: 0,
+            ..Default::default()
+        };
         st.sync_cursor();
         assert_eq!(st.cursor_pos, 5);
     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1590,10 +1590,10 @@ pub(super) fn render_message_diff(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{DateTime, TimeDelta, TimeZone, Utc};
     use crate::capture::parse::TransportProto;
     use crate::sip::SipMessage;
     use crate::sip::parser::parse_sip;
+    use chrono::{DateTime, TimeDelta, TimeZone, Utc};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use std::net::{IpAddr, Ipv4Addr};
@@ -1633,16 +1633,19 @@ mod tests {
                 "Content-Length: 0",
             ],
         );
-        parse_sip(&raw, ts, addr_a(), addr_b(), 5060, 5060, TransportProto::Udp)
-            .expect("parse INVITE")
+        parse_sip(
+            &raw,
+            ts,
+            addr_a(),
+            addr_b(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("parse INVITE")
     }
 
-    fn make_response(
-        call_id: &str,
-        status: u16,
-        reason: &str,
-        ts: DateTime<Utc>,
-    ) -> SipMessage {
+    fn make_response(call_id: &str, status: u16, reason: &str, ts: DateTime<Utc>) -> SipMessage {
         let raw = build_sip(
             &format!("SIP/2.0 {status} {reason}"),
             &[
@@ -1653,8 +1656,16 @@ mod tests {
                 "Content-Length: 0",
             ],
         );
-        parse_sip(&raw, ts, addr_b(), addr_a(), 5060, 5060, TransportProto::Udp)
-            .expect("parse response")
+        parse_sip(
+            &raw,
+            ts,
+            addr_b(),
+            addr_a(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("parse response")
     }
 
     fn make_bye(call_id: &str, ts: DateTime<Utc>) -> SipMessage {
@@ -1668,8 +1679,16 @@ mod tests {
                 "Content-Length: 0",
             ],
         );
-        parse_sip(&raw, ts, addr_a(), addr_b(), 5060, 5060, TransportProto::Udp)
-            .expect("parse BYE")
+        parse_sip(
+            &raw,
+            ts,
+            addr_a(),
+            addr_b(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("parse BYE")
     }
 
     /// App with one populated, completed dialog (INVITE/180/200/BYE).
@@ -1686,9 +1705,7 @@ mod tests {
     /// Render `app` at the given size and return the buffer as a string.
     fn render_to_string(app: &mut App, w: u16, h: u16) -> String {
         let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
-        terminal
-            .draw(|frame| render_app(frame, app))
-            .unwrap();
+        terminal.draw(|frame| render_app(frame, app)).unwrap();
         let buf = terminal.backend().buffer();
         let area = buf.area;
         let mut out = String::new();
@@ -2105,7 +2122,10 @@ mod tests {
             for x in 0..buf.area.width {
                 row.push_str(buf.cell((x, 0)).unwrap().symbol());
             }
-            assert!(row.contains("Esc"), "view {view:?} bar missing Esc: {row:?}");
+            assert!(
+                row.contains("Esc"),
+                "view {view:?} bar missing Esc: {row:?}"
+            );
         }
     }
 

--- a/src/tui/save.rs
+++ b/src/tui/save.rs
@@ -741,8 +741,16 @@ mod tests {
                 "Content-Length: 0",
             ],
         );
-        parse_sip(&raw, ts, addr_a(), addr_b(), 5060, 5060, TransportProto::Udp)
-            .expect("parse INVITE")
+        parse_sip(
+            &raw,
+            ts,
+            addr_a(),
+            addr_b(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("parse INVITE")
     }
 
     fn make_ok(call_id: &str, ts: DateTime<Utc>) -> SipMessage {
@@ -756,8 +764,16 @@ mod tests {
                 "Content-Length: 0",
             ],
         );
-        parse_sip(&raw, ts, addr_b(), addr_a(), 5060, 5060, TransportProto::Udp)
-            .expect("parse 200")
+        parse_sip(
+            &raw,
+            ts,
+            addr_b(),
+            addr_a(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("parse 200")
     }
 
     fn app_with_dialogs() -> App {
@@ -926,25 +942,40 @@ mod tests {
     #[test]
     fn empty_store_messages() {
         let app = App::new_test();
-        assert_eq!(save_to_pcap_path(&app, "/tmp/x.pcap", false), "No messages to save");
+        assert_eq!(
+            save_to_pcap_path(&app, "/tmp/x.pcap", false),
+            "No messages to save"
+        );
         assert_eq!(save_to_txt_path(&app, "/tmp/x.txt"), "No messages to save");
-        assert_eq!(save_to_mermaid_path(&app, "/tmp/x.html"), "No messages to export");
+        assert_eq!(
+            save_to_mermaid_path(&app, "/tmp/x.html"),
+            "No messages to export"
+        );
     }
 
     #[test]
     fn empty_store_dialogs() {
         let app = App::new_test();
         assert_eq!(save_to_json_path(&app, "/tmp/x.json"), "No dialogs to save");
-        assert_eq!(save_to_ndjson_path(&app, "/tmp/x.ndjson"), "No dialogs to save");
+        assert_eq!(
+            save_to_ndjson_path(&app, "/tmp/x.ndjson"),
+            "No dialogs to save"
+        );
         assert_eq!(save_to_csv_path(&app, "/tmp/x.csv"), "No dialogs to save");
-        assert_eq!(save_to_markdown_path(&app, "/tmp/x.md"), "No dialogs to save");
+        assert_eq!(
+            save_to_markdown_path(&app, "/tmp/x.md"),
+            "No dialogs to save"
+        );
         assert_eq!(save_to_sipp_path(&app, "/tmp/x.xml"), "No dialog to export");
     }
 
     #[test]
     fn empty_store_rtp_and_wav() {
         let app = App::new_test();
-        assert_eq!(save_to_rtp_json_path(&app, "/tmp/x.json"), "No RTP streams to save");
+        assert_eq!(
+            save_to_rtp_json_path(&app, "/tmp/x.json"),
+            "No RTP streams to save"
+        );
         // No call flow + no selected dialog -> "No RTP streams captured"
         let msg = save_to_wav_path(&app, "/tmp/x.wav");
         assert!(msg.contains("No RTP streams"), "got: {msg}");


### PR DESCRIPTION
Stacks three related fixes on top of the original CI-failure fix.

## 1. rustfmt the test code (original)
The P0-P4 coverage tests were never run through rustfmt, so CI's **Format** step failed on macOS + Ubuntu. `cargo fmt --all`, reflow only.

## 2. Clippy code-scanning alerts (9 -> 0)
Resolves all 9 open clippy alerts (test code only, no behavior change):
- 7x `field_reassign_with_default` in `src/tui/mod.rs` -> struct-literal init
- 2x `items_after_test_module` in `call_flow/prepare.rs` -> moved `format_sdp_codecs` above the test module

Also adds two tests for `format_sdp_codecs`, closing the 2-line patch-coverage gap Codecov flagged.

## 3. Pre-push rustfmt gate (BDD-tested)
`.githooks/pre-push` hard-gates on `cargo fmt --all -- --check` so this class of failure can't recur, with `scripts/test-pre-push.sh` proving the behavior red->green. Enable via `git config core.hooksPath .githooks`.

## Verification
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features`: 0 failures
- `scripts/test-pre-push.sh`: 4/4 pass
