### PR TITLE
docs: verification spec + execution plan

### DIFF
--- a/tasks/verification-plan.md
+++ b/tasks/verification-plan.md
@@ -1,0 +1,326 @@
+# sipnab Verification — Execution Plan
+
+Derived from [`verification-spec.md`](./verification-spec.md). The spec defines *what/why*;
+this plan defines *what to build, in what order, and how we know it's done*.
+
+**How to use:** each task has an ID, concrete deliverable files, dependencies, a **success
+(pass) criterion**, and a size (S ≈ ½ day, M ≈ 1 day, L ≈ 2–3 days). Work top-down; a task is
+`done` only when it clears the **Validation protocol** below *and* its per-task success criterion
+is green in CI. Status: `[ ]` todo · `[~]` in progress · `[x]` done.
+
+---
+
+## Validation protocol (applies to EVERY task)
+
+How each task is validated — run locally, reproduced in CI, evidence captured. A task is **DONE**
+only when **all** of these pass:
+
+1. **TDD red→green** (repo rule): write the test first; show it **failing** against unfixed code
+   (red), then **passing** after the change (green). Capture both outputs.
+2. **Targeted test green:** the task's own test(s) pass — `cargo nextest run -E '<selector>'`.
+3. **No regression:** full suite green — `cargo nextest run --all-features` → `0 failed`.
+4. **Lint/format clean:** `cargo fmt --all -- --check` **and**
+   `cargo clippy --all-targets --all-features -- -D warnings` both clean.
+5. **No flake / determinism:** the task's test passes **3× consecutively** with no retries; any
+   nondeterminism (timestamp, ordering, locale, color) = fail. PTY/E2E additionally pass under the
+   nextest `e2e` profile.
+6. **Coverage non-regression:** `cargo llvm-cov` line% ≥ prior run (tracked in
+   `tasks/test-coverage-todo.md`).
+7. **Evidence captured:** the exact command + trimmed output recorded in the PR description.
+
+**Universal FAILURE criteria** — the task fails and does **not** merge if **any** hold:
+compile error · its test is red · a previously-green test goes red · fmt/clippy regress · the test
+is flaky or order-dependent · a golden/schema differs from expected without an approved, reviewed
+update · coverage drops below target without written justification.
+
+**Validation-effort meta-criteria** — how I know *my own validation* is trustworthy:
+- **SUCCESS:** every milestone exit-gate command returns green, evidence is logged, and a
+  **clean-tree reproduction** (`cargo clean --manifest-path ~/sipnab/Cargo.toml` → full build →
+  test) reproduces the result; coverage ≥ target.
+- **FAILURE:** any gate red · any non-reproducible "pass" · any "passed" claim lacking captured
+  command output · any assertion-less test counted as coverage.
+
+The per-task **Success (pass) criteria** column below is the task-specific *addition* to this
+universal gate, and the per-milestone **Validate / Fails-if** lines give the concrete command(s)
+and the layer-specific failure modes.
+
+---
+
+## Completeness mandate (hard gate — spec §15)
+
+The bar is **100%**, not "representative": every CLI parameter, every UI option/control/button, and
+every API request/response (incl. the full **bearer-token lifecycle**) must map to ≥1 passing test,
+tracked in `tests/registry/surface.toml` and enforced by a CI gate that fails red on any uncovered
+atom (T6.5/T6.6). These four classes contain **no** hardware/root waivers — they are fully automatable.
+
+**Bearer-token expiration is CRITICAL and not yet implemented.** It must be **implemented →
+documented → tested → validated** before its surface class can be marked done. That work is milestone
+**M3b** below; until all four states are true it is an open **security gap**, never a waiver.
+
+---
+
+## Operating principles (apply to every task — spec §16–§17)
+
+- **Industry best practices, always:** use established, well-maintained tools/patterns; no bespoke
+  mechanism without written justification; when an area isn't already grounded here, **research the
+  current standard and cite it** before building (append it to the spec §16 table).
+- **Every documented example is proven (milestone M-Docs):** all examples in `README`, `docs/`,
+  `--help`, config samples, and API/MCP docs are executed in CI; an example that no longer matches
+  reality **fails the build**.
+
+**Milestone → phase map**
+
+| Milestone | Phase (spec §12) | Theme | Exit gate |
+|---|---|---|---|
+| **M1** | 1 | Foundations / unblock | shared harness + nextest + first goldens green |
+| **M2** | 2 | Output-format goldens | all 12 formats have a golden (+schema where JSON) |
+| **M3** | 3 | Service layer (API/MCP/HEP/metrics) | every L4 surface has a test |
+| **M3b** | 3 | **Bearer-token lifecycle (CRITICAL feature)** | expiry/rotation/revocation implemented + documented + tested + validated |
+| **M4** | 4 | TUI breadth | all views/dialogs/modes snapshotted; PTY E2E green w/o `continue-on-error` |
+| **M5** | 5 | Crypto + live E2E | TLS/SRTP tests; docker harness nightly; perf gate |
+| **M-Docs** | 5–6 | **Documentation & examples** | every documented example executed & proven in CI |
+| **M6** | 6 | Governance | 100% surface registry enforced; no-untested-flag/control/example CI gate |
+
+**Critical path:** `M1 → (M2 ∥ M3 → M3b ∥ M4) → (M5 ∥ M-Docs) → M6`. M2/M3/M4 are largely
+independent once M1 lands and can run in parallel; **M3b** depends on M3's API/MCP harness; **M-Docs**
+depends on M1 + the API harness and runs alongside M2–M5; **M6**'s 100% completeness gate depends on
+M1–M5, M3b, and M-Docs being substantially done.
+
+---
+
+## M0 — Prerequisites & decisions (do first, ~½ day)
+
+- [ ] **D0.1** Confirm tooling choices (defaults from spec; change here if desired):
+  CLI goldens = **`trycmd`/`snapbox`**; API client = **`reqwest`** (blocking, `rustls-tls`);
+  schema = **`jsonschema`**; runner = **`cargo-nextest`**. *(Decision owner: maintainer.)*
+- [ ] **D0.2** Pick PR granularity: **one PR per task** (recommended) vs one per milestone.
+- [ ] **D0.3** Clock-seam discovery (S): grep the TUI/report render paths for `Utc::now()` /
+  `Instant::now()` called *inside* rendering. If any view computes "now" internally (not via
+  injected timestamps), file a small task to add a `Clock` seam. Output: yes/no + list.
+  - Deliverable: note appended to this file under M1.
+
+---
+
+## M1 — Foundations (Phase 1)
+
+> Unblocks every other milestone. Low risk, high leverage.
+
+| ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
+|---|---|---|---|---|---|
+| [ ] **T1.1** | Shared test-support module | `tests/support/mod.rs` (+ `tests/support/normalize.rs`) | — | M | `normalize()` scrubs timestamps, durations, RFC3339, temp paths, PIDs, ports; unit-tested; reused by ≥2 existing tests (start with `parse_path_test.rs`) |
+| [ ] **T1.2** | Adopt `cargo-nextest` | `.config/nextest.toml`; CI step in `ci.yml` | — | S | `cargo nextest run --all-features` green; an `e2e` profile with `retries = 2` for PTY tests |
+| [ ] **T1.3** | JSON Schemas + validator | `tests/schemas/{message,dialog,stream,call_report}.schema.json`; `tests/support/schema.rs`; `jsonschema` dev-dep | T1.1 | M | Each schema (versioned, `schema_version:1`) validates current `--json`/report output on `sip_call.pcap`; an intentionally-broken field fails the test |
+| [ ] **T1.4** | CLI golden harness + first cases | `Cargo.toml` (`trycmd` dev-dep); `tests/cli_goldens.rs`; `tests/cli/cmd/{help,version,dump-config}.trycmd` | T1.1 | M | `--help`/`--version`/`--dump-config` goldens pass under `TZ=UTC NO_COLOR=1`; doc-drift still green |
+| [ ] **T1.5** | Determinism env contract | `tests/support/env.rs` (fixed `COLUMNS/LINES`, `TZ`, `NO_COLOR`); CONTRIBUTING note | — | S | Helper used by golden + TUI harnesses; documented |
+
+**M1 exit gate:** T1.1–T1.5 merged; `cargo nextest run --all-features` and the new golden/schema
+tests green in CI.
+- **Validate with:** `TZ=UTC NO_COLOR=1 cargo nextest run --all-features` (support+schema+golden
+  suites), repeated 3×; plus `cargo insta test` / `trycmd` in check mode.
+- **Fails if:** `normalize()` leaves any volatile token in a fixture's output · a schema **accepts**
+  a doc with a required field removed (negative test must fail-closed) · the `--help`/`--version`
+  goldens differ across two machines or locales · `.config/nextest.toml` retries/profile are ignored.
+
+---
+
+## M2 — Output-format goldens (Phase 2)
+
+> One golden (and schema, where JSON) per output format. All run the binary against
+> `tests/fixtures/sip_call.pcap`, pipe through `normalize()`, and snapshot. Each is **S** unless noted.
+
+| ID | Format / flag | Deliverable | Deps | Success (pass) criteria |
+|---|---|---|---|---|
+| [ ] **T2.1** | text (default), `--delta-time`, `--payload-limit` | `tests/cli/out/text_*.trycmd` | T1.4 | golden stable; color stripped |
+| [ ] **T2.2** | `--json`, `--json-pretty`, NDJSON | goldens + reuse T1.3 schema | T1.3 | every line validates against `message.schema.json` |
+| [ ] **T2.3** | `--report` | golden | T1.4 | dialog table columns present & ordered |
+| [ ] **T2.4** | `--call-report` (+`--markdown`, json) | goldens + `call_report.schema.json` check | T1.3 | all three formats; media-diagnosis section present |
+| [ ] **T2.5** | CSV export | golden + header-row assert | T1.4 | **GAP closed**; column set pinned |
+| [ ] **T2.6** | pcap / pcapng (`-O`, `--pcapng`) roundtrip (M) | extend `tests/capture_test.rs` | T1.1 | write→reread via `pcap`; packet count + linktype match; pcapng magic asserted |
+| [ ] **T2.7** | `--hexdump` | golden | T1.4 | **GAP closed** |
+| [ ] **T2.8** | `--fail2ban` | golden + shape assert | T1.4 | **GAP closed**; parses as fail2ban json lines |
+| [ ] **T2.9** | `--wireshark`, `--tshark-filter` | golden | T1.4 | **GAP closed**; filter syntax for known Call-IDs |
+| [ ] **T2.10** | mermaid/ladder export | golden | T1.4 | **GAP closed**; valid mermaid `sequenceDiagram` |
+| [ ] **T2.11** | `--group-by` | golden | T1.4 | grouping by call-id/from |
+
+**M2 exit gate:** every row in the spec's "Output formats" inventory has ≥1 green golden;
+JSON-bearing formats also pass schema validation.
+- **Validate each format with:** `sipnab -N <flag> -I tests/fixtures/sip_call.pcap | normalize`
+  diffed against its committed golden; JSON/NDJSON formats additionally validated by `jsonschema`;
+  pcap/pcapng by write→reread packet-count + linktype assertion. Run each 3×.
+- **Fails if:** a golden drifts without a reviewed `cargo insta accept` · a JSON line fails its
+  schema · pcap roundtrip count/linktype mismatches · output is nondeterministic across runs ·
+  a documented format has **no** golden (coverage hole).
+
+---
+
+## M3 — Service / protocol layer (Phase 3)
+
+> Spawn on ephemeral ports; feature-gated to each build. Biggest current gap area.
+
+| ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
+|---|---|---|---|---|---|
+| [ ] **T3.1** | API spawn harness | `tests/support/server.rs` (spawn `--api 127.0.0.1:0`, read bound port, `reqwest` client); `reqwest` dev-dep | T1.1 | M | helper returns base URL + client; tears down cleanly |
+| [ ] **T3.2** | API endpoint coverage | `tests/api_test.rs` | T3.1, T1.3 | M | GET `/health`,`/v1/dialogs`,`/v1/dialogs/{id}`,`/report`,`/v1/streams`,`/v1/streams/{id}`,`/v1/stats`,`/metrics` → 200 + schema-valid |
+| [ ] **T3.3** | API auth / limits / TLS | `tests/api_test.rs` | T3.1 | M | bearer accept(200)/reject(401); `--api-max-conn` enforced; `--api-tls-cert/key` serves HTTPS |
+| [ ] **T3.4** | Prometheus `/metrics` scrape | `tests/metrics_test.rs` | T3.1 | S | text-format parses; expected metric families/labels present |
+| [ ] **T3.5** | MCP 12-tool round-trips | extend `tests/mcp_stdio_test.rs`, `tests/mcp_http_test.rs` | T1.3 | M | each of the 12 tools invoked; output schema-validated; http bearer + host-rebind retained |
+| [ ] **T3.6** | HEP ingest/forward | `tests/hep_test.rs`; `tests/support/hep.rs` (HEP3 datagram builder) | T1.1 | M | **GAP closed**; `-L` ingests synthetic HEP3; CIDR allowlist + rate-limit honored; `--hep-send` forwards |
+
+**M3 exit gate:** API, Prometheus, MCP (all 12 tools), and HEP each have a green automated test.
+- **Validate with:** spawn the server on `127.0.0.1:0`, read the bound port, drive it with the
+  `reqwest`/JSON-RPC/HEP client, assert **status + schema + auth**; tear down and confirm the port
+  is released (no leak/hang). Run 3×.
+- **Fails if:** any endpoint returns an unexpected status · a response fails its JSON schema · an
+  auth **reject** path returns 2xx (auth bypass) · `--api-max-conn` is not enforced · the process
+  hangs or leaks the port · any of the 12 MCP tools errors or returns a schema-invalid result ·
+  HEP CIDR allowlist or rate-limit is not honored.
+
+---
+
+## M3b — Bearer-token lifecycle (CRITICAL feature: implement → document → test → validate)
+
+> Tokens are static shared secrets today (`src/output/api.rs:287`, `src/mcp/transport.rs`). Maintainer
+> direction: **expiration is critical**. This milestone *builds the feature* (production code), then
+> documents, tests, and validates it. Not a test-only milestone. Blocks the spec §15 mandate.
+
+| ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
+|---|---|---|---|---|---|
+| [ ] **T3b.1** | Design the token lifecycle model (decision) | design note appended here | — | S | settles: TTL source (`--api-token-ttl`/`--mcp-token-ttl` + per-token `expires_at` in token file), rotation (N overlapping-valid tokens), revocation (revocation list / removal), and self-describing (signed) vs server-tracked tokens; constant-time compare preserved |
+| [ ] **T3b.2** | Implement expiry+rotation+revocation — **REST API** | `src/output/api.rs`, `src/cli.rs` (new flags), token store module | T3b.1 | L | TDD red→green; expired token → 401; rotation window accepts both; revoked → 401; non-loopback still requires a *valid* token; constant-time retained |
+| [ ] **T3b.3** | Implement expiry+rotation+revocation — **MCP** | `src/mcp/transport.rs`, `src/cli.rs` | T3b.1 | L | same lifecycle semantics as API; http + stdio paths covered |
+| [ ] **T3b.4** | Document the feature | `--help` text, `docs/` (security/auth page → wiki), `CONTRIBUTING.md` | T3b.2, T3b.3 | S | every new flag documented; token lifecycle (issue/use/expire/rotate/revoke) described; `docs_drift_test` green |
+| [ ] **T3b.5** | Validate full lifecycle + register | `tests/api_token_test.rs`, `tests/mcp_token_test.rs`; `tests/registry/surface.toml` entries | T3b.2, T3b.3 | M | issue→use(200)→**expire→401**→rotation-overlap(200 for both)→**revoke→401**; **negative tests mandatory**; constant-time asserted; registry rows green |
+
+**M3b exit gate:** token expiration/rotation/revocation are **implemented, documented, tested, and
+validated** for both API and MCP; the spec §15 token-lifecycle row flips from ❌ CRITICAL GAP to ✅.
+- **Validate with:** `cargo nextest run --all-features -E 'test(token)'` (3×); spawn API/MCP on `:0`,
+  issue a short-TTL token, assert 200 before expiry and **401 after**; rotate and assert overlap;
+  revoke and assert 401.
+- **Fails if:** an expired or revoked token is **accepted** (must fail-closed) · rotation drops a
+  still-valid token · TTL/clock handling is nondeterministic or flaky · constant-time comparison is
+  lost · any token state lacks a registry entry · the feature ships undocumented.
+
+---
+
+## M-Docs — Documentation & examples validation (spec §17)
+
+> Every example in the docs must be **executed and proven** in CI. Runs alongside M2–M5 as its surfaces
+> become available; gated complete with M6.
+
+| ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
+|---|---|---|---|---|---|
+| [ ] **MD.1** | Rustdoc doctests enabled + required | `cargo test --doc` CI step; examples on public API | M1 | M | doctests run in CI and pass; key public modules carry ≥1 runnable example |
+| [ ] **MD.2** | README/`docs/` CLI-block runner | `tests/doc_examples.rs` (`trycmd` over extracted ```` ``` ```` blocks) | T1.4 | M | every CLI command block in README/`docs/` executes with its documented output against a fixture |
+| [ ] **MD.3** | Help/usage goldens in docs | extends `tests/docs_drift_test.rs` | T1.4 | S | `--help`/usage shown in docs == actual output |
+| [ ] **MD.4** | Config-sample validation | `tests/config_examples_test.rs` | T1.3 | S | every documented config sample parses + schema-validates; samples marked invalid must fail |
+| [ ] **MD.5** | API/MCP example replay | `tests/doc_api_examples.rs` | T3.1, T3.5 | M | each documented API/MCP request replayed on `:0`; response schema-valid and matches the documented example |
+| [ ] **MD.6** | Doc-example registry + gate | rows in `tests/registry/surface.toml`; CI gate | T6.5 | S | 100% of documented examples have a runner; a new example without one fails CI |
+
+**M-Docs exit gate:** every documented example is executed and proven in CI; no untested example.
+- **Validate with:** `cargo test --doc` + `cargo nextest run -E 'test(doc_)'`; intentionally break one
+  documented example and confirm CI goes **red**, then revert.
+- **Fails if:** any documented example is unexecuted · output diverges from the doc without a reviewed
+  update · a new doc example merges without a runner entry.
+
+---
+
+## M4 — TUI breadth (Phase 4)
+
+> Primary = `TestBackend`+`insta` (L3a). Black-box PTY (L3b) stays thin. All under the §4d
+> determinism contract (T1.5).
+
+| ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
+|---|---|---|---|---|---|
+| [ ] **T4.1** | Key-sequence snapshot harness | extend `tests/tui_snapshot_test.rs` (table: `keys → golden`) | T1.5 | M | helper drives `App::on_key` over a key list, renders 120×40, snapshots via `buffer_to_string` |
+| [ ] **T4.2** | All 8 views × states | snapshots in `tests/snapshots/` | T4.1 | L | CallList/StreamList/CallFlow/RawMessage/MessageDiff/Help/Statistics/StreamDetail in empty + populated (+ failed-dialog where relevant) |
+| [ ] **T4.3** | 4 dialogs | snapshots | T4.1 | L | Save (each format selection), Filter (5 fields + 10 method checkboxes + built DSL string), Settings (6 toggles), FileOpen browser |
+| [ ] **T4.4** | Display-mode cycles | snapshots | T4.1 | M | SDP None/Summary/Full; Timestamp Absolute/Δprev/Δfirst/Scaled; Color method/call-id/cseq; split on/off; extended-flow; RTP-in-flow |
+| [ ] **T4.5** | Layout states | snapshots | T4.1 | S | narrow (e.g. 60×20) vs wide (120×40) |
+| [ ] **T4.6** | Keybinding coverage audit | `tests/tui_state_test.rs` additions | T4.1 | M | every key handled in `events.rs` has ≥1 asserting test (state or snapshot) |
+| [ ] **T4.7** | Stabilize PTY E2E | `tests/tui_e2e_test.rs`; `ci.yml` | T1.2 | M | runs under nextest `e2e` profile with retries; **drop `continue-on-error: true`**; launch/view-switch/dialog/quit assert real frames |
+| [ ] **T4.8** | Audio decode/error path | snapshot in `tests/tui_snapshot_test.rs` | T4.1 | S | `audio` feature: decode + cached-error message path covered; real device waived (§10) |
+
+**M4 exit gate:** all 8 views, 4 dialogs, and display-mode cycles have deterministic snapshots;
+PTY E2E green without `continue-on-error`; keybinding audit passes.
+- **Validate with:** drive a key sequence through `App::on_key` → render to a fixed `TestBackend`
+  (120×40) → `buffer_to_string` → `insta` compare (`cargo insta test`); each frame rendered 3× must
+  be byte-identical. PTY tests via `cargo nextest run -E 'test(tui_e2e)'` under the `e2e` profile.
+- **Fails if:** a snapshot diff is unreviewed · a frame is nondeterministic across the 3 renders ·
+  a key handled in `events.rs` has **no** asserting test (the keybinding audit lists it) · the PTY
+  suite only passes with `continue-on-error` or fails its no-retry stability check.
+
+---
+
+## M5 — Crypto + live E2E (Phase 5)
+
+| ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
+|---|---|---|---|---|---|
+| [ ] **T5.1** | Crypto/edge fixtures + generator | `tests/pcap-samples/*` (TLS+keylog, SRTP+keys, HEP3, codec-reject, auth-fail, DTMF rfc2833+info); `make fixtures` | — | M | fixtures checked in; regenerable via sipp/harness; documented provenance |
+| [ ] **T5.2** | TLS decryption test | `tests/tls_decrypt_test.rs` (feature `tls`) | T5.1, T1.1 | M | offline pcap + `--keylog` → decrypted SIP in `--json`; **GAP closed** |
+| [ ] **T5.3** | SRTP decryption test | `tests/srtp_test.rs` (feature `tls`) | T5.1 | M | `--srtp-keys` decrypts RTP payload; **GAP closed** |
+| [ ] **T5.4** | STIR/SHAKEN verify | `tests/stir_shaken_test.rs` (feature `tls`) | T5.1 | M | valid Identity header verifies; tampered one rejected; **GAP closed** (fuzz-only today) |
+| [ ] **T5.5** | Docker harness → nightly CI | `.github/workflows/e2e-docker.yml` | — | M | scheduled job drives opensips+sipp+rtpengine; asserts sipnab `--json`/API on live traffic |
+| [ ] **T5.6** | Perf regression gate | `ci.yml` nightly; criterion compare | — | S | criterion baseline stored; >X% regression on parser/store benches flags the run |
+
+**M5 exit gate:** TLS/SRTP/STIR-SHAKEN tests green; nightly docker E2E and perf jobs running.
+- **Validate with:** offline decrypt → assert expected plaintext SIP fields / RTP payload in
+  `--json`; a **tampered** STIR/SHAKEN Identity must be **rejected**; docker harness asserts ≥1 live
+  dialog + expected fields; `criterion` compares against a stored baseline.
+- **Fails if:** decryption yields no/garbled SIP or RTP · a tampered Identity header is **accepted**
+  (must fail-closed) · the harness cannot assert at least one live dialog with expected fields ·
+  a parser/store bench regresses beyond the agreed threshold (e.g. >10%).
+
+---
+
+## M6 — Governance (Phase 6)
+
+| ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
+|---|---|---|---|---|---|
+| [ ] **T6.1** | Living traceability matrix | `tasks/verification-matrix.md` | M2–M4 | M | one row per surface (every flag, format, view, dialog, MCP tool, endpoint) → layer → test → status; seeded from spec §9 |
+| [ ] **T6.2** | "No untested flag" CI gate | extend `tests/docs_drift_test.rs` | T1.4, T6.1 | M | test fails if a CLI flag in `cli.rs` is referenced by zero tests/goldens |
+| [ ] **T6.3** | CI job wiring | `.github/workflows/ci.yml`, `quality.yml` | M1–M5 | M | jobs `cli-goldens`, `service`, `tui-e2e` (nextest), `e2e-docker`, `perf`; global `TZ=UTC NO_COLOR=1 COLUMNS=120 LINES=40` |
+| [ ] **T6.4** | Docs: test architecture | `CONTRIBUTING.md` / `docs/` | M1–M4 | S | "how to add a test at each layer" + the determinism contract documented |
+| [ ] **T6.5** | Surface registry (all 4 classes) | `tests/registry/surface.toml` | M2–M4, M3b | L | one row per CLI param, UI control/button, API request/response field, and token-lifecycle state → validating test(s) + status; **100%** of shipped atoms present |
+| [ ] **T6.6** | 100% completeness CI gate | extend `tests/docs_drift_test.rs` (or new `tests/registry_test.rs`) | T6.5 | M | build **fails red** if any registry atom has zero passing tests, or a new flag/endpoint/control/token-state ships without a registry entry; proven by a negative meta-test |
+
+**M6 exit gate:** traceability matrix complete and CI-enforced; a new flag cannot merge untested.
+- **Validate with:** run the extended `docs_drift_test`; as a **negative/meta-test**, add a throwaway
+  flag with no referencing test and confirm the gate goes **red** (proving it actually guards), then
+  revert; verify the matrix has a filled row for every shipped surface.
+- **Fails if:** a real CLI flag escapes the gate (gate stays green when it shouldn't) · the matrix
+  has an empty/`❌` row for a surface that is actually shipping · any milestone's exit gate is not
+  reproducible from a clean tree.
+
+---
+
+## Effort summary (rough)
+
+| Milestone | Tasks | Est. |
+|---|---|---|
+| M0 | 3 | ½ d |
+| M1 | 5 | ~3 d |
+| M2 | 11 | ~3–4 d |
+| M3 | 6 | ~4 d |
+| **M3b (token lifecycle — CRITICAL feature)** | 5 | ~4–5 d |
+| M4 | 8 | ~5–6 d |
+| M5 | 6 | ~4 d |
+| **M-Docs (documentation & examples)** | 6 | ~3 d |
+| M6 | 6 | ~3–4 d |
+| **Total** | **56** | **~5–6 weeks** of focused work (parallelizable across M2/M3/M4/M-Docs; M3b gates the §15 mandate) |
+
+## Definition of done (whole effort)
+
+Mirrors spec §14 + the §15 mandate: every traceability-matrix row is `✅` or a documented `waiver`;
+all output formats have goldens (+schema for JSON); all TUI views/dialogs/modes have deterministic
+snapshots and PTY E2E is green without `continue-on-error`; REST/MCP/HEP/Prometheus each have an L4
+test; **bearer-token expiration/rotation/revocation is implemented, documented, tested, and validated
+(M3b)**; the **100% surface registry** is complete and CI-enforced (T6.5/T6.6); **every documented
+example is executed and proved correct in CI (M-Docs)**; all work follows the **industry-best-practice
+mandate (§16)**; CI green across the feature matrix; coverage held at/above target; no CLI flag — and
+no UI control, token state, or documented example — can merge untested.
+
+## Suggested first slice
+
+**M0 + M1** in one focused pass (it's the unblock layer and ~3 days): shared `normalize()`,
+nextest, JSON schemas, the `trycmd` harness with the first three goldens. Everything else fans out
+from there.

--- a/tasks/verification-spec.md
+++ b/tasks/verification-spec.md
@@ -1,0 +1,450 @@
+# sipnab Verification Spec / Plan
+
+Status: **draft** · Author: maintainer-assisted · Scope: full automated verification of
+every user-facing function across CLI, text/batch mode, and the interactive TUI, plus the
+service surfaces (REST API, MCP, HEP, Prometheus).
+
+The goal is a **layered, deterministic, industry-standard** test architecture in which
+*every surface in the traceability matrix (§9) has at least one automated check* — or an
+explicit, justified waiver for hardware/root-only paths.
+
+---
+
+## 1. Goals & non-goals
+
+**Goals**
+- Verify all 4 runtime modes: interactive **TUI**, **batch/CLI**, **MCP server**, **HEP listener**.
+- Verify all 12 output formats and the REST/Prometheus/MCP protocol surfaces.
+- Make the **TUI** testable with industry-standard techniques (virtual-terminal snapshots + PTY E2E).
+- Be **deterministic and CI-friendly**: no live NICs, no audio device, no root, no wall-clock flakiness.
+- Maintain a **traceability matrix** so coverage gaps are visible and new flags can't ship untested.
+- **100% surface validation (hard gate, §15):** *every* CLI parameter, *every* UI option/control/button,
+  and *every* API request/response — including the full **bearer-token lifecycle** — maps to ≥1 passing
+  test, enforced by a surface registry in CI. Bearer-token **expiration** is **critical** per maintainer
+  direction and must be *implemented* before its class can be marked validated (it does not exist today).
+- **Industry best practices + proven docs (§16–§17):** every tool, pattern, and mechanism follows a
+  current, cited industry standard (research it if not already grounded); and **every example in the
+  documentation is executed and proven correct in CI** — no example ships unverified.
+
+**Non-goals**
+- Re-testing pure logic already covered by the ~1079 existing unit tests (we build on them).
+- Verifying genuinely hardware/OS-bound paths in unit CI (live `pcap` device, real audio output,
+  `setuid`/`chroot` as root) — these get a thin harness/manual waiver instead (§7, §10).
+
+---
+
+## 2. Current state (baseline, from codebase audit)
+
+Already in place — we extend, not replace:
+
+| Capability | Tool | Where |
+|---|---|---|
+| Unit tests (~1079 `#[test]`) | std | `src/**/*.rs` `#[cfg(test)]` |
+| Integration tests (22 files) | std + helpers | `tests/*.rs` |
+| TUI snapshot rendering | **ratatui `TestBackend` + `insta`** (43 goldens) | `tests/tui_snapshot_test.rs`, `tests/snapshots/` |
+| TUI state machine (no render) | std | `tests/tui_state_test.rs` |
+| TUI black-box E2E | **`expectrl`** PTY (5 `#[ignore]` tests) | `tests/tui_e2e_test.rs` |
+| CLI process tests | inline `std::process::Command` | `tests/cli_*.rs` |
+| JSON output schema asserts | `serde_json` inline | `tests/integration_test.rs`, `config_wiring_test.rs` |
+| MCP stdio/http | `tokio`, raw JSON-RPC | `tests/mcp_*_test.rs` |
+| Fuzzing (10 targets) | `cargo-fuzz` | `fuzz/` |
+| Benchmarks | `criterion` | `benches/` |
+| Coverage (~90% lines) | `cargo-llvm-cov` | `quality.yml`, `tasks/test-coverage-todo.md` |
+| Live E2E harness | docker-compose (opensips+sipp+rtpengine) | `harness/` |
+| Docs/CLI drift guard | std | `tests/docs_drift_test.rs` |
+
+Dev-deps present: `criterion`, `insta`, `tempfile`, `tokio`, `expectrl`, `libc`.
+
+---
+
+## 3. Test architecture — the pyramid
+
+```
+        ┌─────────────────────────────────────────────┐
+  L6    │ Fuzz · property · perf-regression (nightly)  │
+        ├─────────────────────────────────────────────┤
+  L5    │ E2E live: docker harness (opensips+sipp+rtp) │   slow / nightly
+        ├─────────────────────────────────────────────┤
+  L4    │ Service/protocol: REST API · MCP · HEP · /metrics │
+        ├─────────────────────────────────────────────┤
+  L3    │ TUI:  3a TestBackend snapshots (primary)     │
+        │       3b PTY E2E via expectrl (smoke)        │
+        ├─────────────────────────────────────────────┤
+  L2    │ CLI process goldens (trycmd/snapbox)         │
+        ├─────────────────────────────────────────────┤
+  L1    │ Component goldens: output formatters, parsers│
+        ├─────────────────────────────────────────────┤
+  L0    │ Unit (pure fns) — already strong             │   fast / every commit
+        └─────────────────────────────────────────────┘
+```
+
+Principle: push each check to the **lowest layer that can prove it**. A formatter is proven at
+L1 with a golden string; a key-binding at L3a with a rendered frame; only true integration
+(crossterm raw-mode init, real resize, process exit) needs L3b/L5.
+
+---
+
+## 4. TUI verification — industry-standard approach (the core ask)
+
+TUIs are hard to test because they are **stateful, time-dependent, and terminal-dependent**.
+The industry answer is two complementary layers plus a hard determinism contract.
+
+### 4a. In-process virtual-terminal snapshots (primary)
+
+The Rust-ecosystem standard, already used here: render the app to an **in-memory
+`ratatui::backend::TestBackend`** buffer, serialize the buffer to text, and assert it against
+an `insta` golden. This is the TUI analogue of Jest/React snapshot testing and Go Bubble Tea's
+`teatest` harness.
+
+- **Drive** the app by feeding synthetic `KeyEvent`s through the existing event handler
+  (`App::on_key` / `handle_key_event`) — no PTY, no real terminal.
+- **Capture** via the existing `buffer_to_string()` helper (`tests/tui_snapshot_test.rs`).
+- **Assert** with `insta::assert_snapshot!`; review/accept with `cargo insta review`.
+- **Fast, hermetic, debuggable** — runs in the normal `cargo test`/`nextest` pass.
+
+Pattern — a table-driven "key-sequence → expected frame" harness (extends what exists):
+
+```rust
+// (sequence of keys)  ->  (named golden)
+case("call_list → Enter → CallFlow",          &[Enter],                 "call_flow_basic");
+case("CallFlow → 'V' toggles preview split",  &[Enter, Char('V')],      "call_flow_no_split");
+case("FilterDialog open + tab nav",           &[Key::F(3), Tab, Tab],   "filter_dialog_focus");
+```
+
+### 4b. PTY black-box E2E (smoke / integration)
+
+`TestBackend` can't catch crossterm init, raw-mode, alternate-screen, real terminal resize, or
+clean process exit. For those, spawn the **real binary in a pseudo-terminal** — the
+industry-standard technique (Tcl `expect`, Python `pexpect`, Node `node-pty`); here via
+`expectrl` (already a dev-dep).
+
+- Keep these **few and shallow** (launch, switch views, open a dialog, quit cleanly).
+- Run under `cargo-nextest` with **retries** to absorb PTY timing flakiness (replaces the current
+  `continue-on-error: true`, which hides real failures).
+- Pin terminal size and timing (see §4d).
+
+### 4c. Optional: VHS visual goldens
+
+charmbracelet **`vhs`** scripts render a fixed key-sequence to a deterministic text/GIF artifact
+for golden diffing and for docs. Nice-to-have for headline screens; not load-bearing.
+
+### 4d. Determinism contract (mandatory for 4a/4b)
+
+A TUI test is only meaningful if the frame is reproducible. Enforce all of:
+
+1. **Fixed terminal size** — e.g. `TestBackend::new(120, 40)`; for PTY, export `COLUMNS=120 LINES=40`.
+2. **Frozen time** — never snapshot `Utc::now()`. Inject timestamps at construction
+   (`App::with_processed_messages(msgs)` with fixed `ts`), and **normalize** any residual
+   volatile fields (durations, "age", `created/updated`) before asserting. *(Prereq: keep using
+   constructor-injected time; if any view computes `now()` internally, add a `Clock` seam.)*
+3. **Offline input only** — pcap fixtures; never a live device in CI.
+4. **No animation/adaptive-refresh nondeterminism** — drive frames explicitly; don't sleep-and-hope.
+5. **Locale/timezone pinned** — `TZ=UTC`, stable unicode width.
+6. **Color pinned** — `--color never` / `NO_COLOR=1`, or a fixed theme, so ANSI doesn't leak into goldens.
+7. **Normalization helper** — one shared function that scrubs timestamps/paths/PIDs/durations from
+   both rendered frames and process output (generalize the canonicalizer in `parse_path_test.rs`).
+
+### 4e. TUI coverage matrix (what 4a must exhaustively hit)
+
+- **8 views**: CallList, StreamList, CallFlow, RawMessage, MessageDiff, Help, Statistics, StreamDetail.
+- **4 dialogs**: Save (all formats), Filter (5 fields + 10 method checkboxes + DSL build), Settings (6 toggles), FileOpen (browser).
+- **Display-mode cycles**: SDP None/Summary/Full; Timestamp Absolute/Δprev/Δfirst/Scaled; Color method/call-id/cseq; split-view on/off; extended-flow; RTP-in-flow.
+- **Layout states**: narrow vs wide terminal; empty vs populated vs failed-dialog.
+- **Every keybinding** in `events.rs` (navigation, search `/`, select `Space`, marks, folds, play `p`).
+- **Audio (`audio` feature)**: cover the decode/error-message path with `TestBackend`; the real device path stays waived (§10).
+
+---
+
+## 5. CLI / text-mode verification
+
+### 5a. Process goldens
+
+Adopt **`trycmd`/`snapbox`** (the cargo-ecosystem standard for CLI golden tests) — or
+`assert_cmd` + `insta` — to replace ad-hoc `Command::new` assertions. Each case pins
+`args + stdin → stdout + stderr + exit-code`.
+
+Cover, against a fixed fixture pcap (`tests/fixtures/sip_call.pcap`):
+- `--help`, `--version`, `--dump-config` → goldens (also guards docs drift).
+- **Every output format**: text, `--json`, `--json-pretty`, `--report`, `--call-report` (+`--markdown`),
+  `--hexdump`, `--fail2ban`, `-T/--text-dump`, `--wireshark`, `--tshark-filter`, `--group-by`,
+  CSV, NDJSON, pcap/pcapng (`-O`).
+- **Flag-conflict / validation**: mutually exclusive flags, out-of-range values, feature-gated
+  flags without the feature → assert exit code **2** and the right message.
+- **Env-var precedence**: `SIPNAB_API_KEY`, `SIPNAB_MCP_TOKEN` vs flags.
+
+### 5b. Output contracts (schema validation)
+
+Define versioned **JSON Schemas** (the message object, dialog, stream, call-report — all already
+carry `schema_version`) and validate emitted JSON with the `jsonschema` crate. Schema files live in
+`tests/schemas/` and double as documentation. This catches field drift that golden strings miss.
+
+### 5c. Normalization
+
+Reuse the §4d.7 scrubber so goldens are stable: strip timestamps, durations, hostnames, temp
+paths, PIDs; sort where emission order is legitimately nondeterministic; force `--color never`.
+
+---
+
+## 6. Service / protocol verification (currently the biggest gaps)
+
+| Surface | Plan | Status |
+|---|---|---|
+| **REST API** (`--api 127.0.0.1:0`) | Spawn on ephemeral port; `reqwest` GET every endpoint (`/health`, `/v1/dialogs`, `/v1/dialogs/{id}`, `/report`, `/v1/streams`, `/v1/streams/{id}`, `/v1/stats`, `/metrics`); assert status + JSON-Schema; bearer accept/reject; `--api-max-conn`; TLS cert/key path | **GAP** |
+| **Prometheus** `/metrics` | Scrape, parse with prometheus text-format parser, assert metric families/labels present | **GAP** |
+| **MCP** (stdio + http) | Extend existing round-trip tests to invoke **all 12 tools**, validate each output schema; http bearer + host-rebind already partly covered | partial |
+| **HEP listener** (`-L`) | Send synthetic HEP3 datagrams; assert ingestion, CIDR allowlist, rate-limit, `--hep-send` forward | **GAP** |
+
+All L4 tests use ephemeral ports (`:0`) and are feature-gated to their build.
+
+---
+
+## 7. End-to-end live (docker harness)
+
+Promote `harness/` (opensips + sipp + rtpengine + sipnab) to a **scheduled/nightly CI job**:
+drive real SIP+RTP with sipp scenarios, then assert sipnab's `--json`/`--report`/API output and
+(optionally) a TUI PTY smoke against the live stream. This is the only layer that exercises live
+capture + decode end-to-end; it is slow and is **not** a per-commit gate.
+
+---
+
+## 8. Fixtures & determinism infrastructure
+
+- **Pcap corpus** (have 20+). Add the missing-format fixtures to close gaps: TLS-encrypted SIP +
+  `--keylog`, SRTP + `--srtp-keys`, a HEP3 capture, codec-reject/auth-fail, DTMF (info + RFC2833).
+- **Reproducible generation**: keep sipp scenarios + a `make fixtures` target so captures are regenerable.
+- **Shared test util crate/module**: the normalization scrubber, the TUI key-sequence harness, the
+  API spawn-on-`:0` helper, and JSON-Schema loaders — one place, used by all layers.
+
+---
+
+## 9. Traceability matrix (living document)
+
+The spec's backbone: one row per surface → owning layer → test file → status. Seed (excerpt; the
+full matrix is maintained here and checked in CI):
+
+| Surface | Layer | Test artifact | Status |
+|---|---|---|---|
+| CLI parse / `--help` / `--version` | L2 | `cli_*`, trycmd goldens | ✅ / extend |
+| Output: text/json/ndjson/report/call-report | L1/L2 | goldens + schema | ✅ / extend |
+| Output: CSV / pcapng / hexdump / fail2ban / wireshark / mermaid | L1/L2 | **add goldens** | ❌ GAP |
+| SIP/SDP/RTP parse | L0/L6 | unit + fuzz | ✅ |
+| Dialog/stream tracking & bounds | L0/L2 | unit, `resource_bounds_test` | ✅ |
+| TUI 8 views | L3a | snapshots | ◐ partial → exhaustive |
+| TUI 4 dialogs + display-mode cycles | L3a | **add snapshots** | ◐ GAP |
+| TUI launch/quit/resize | L3b | `tui_e2e_test` (nextest+retry) | ✅ / stabilize |
+| REST API endpoints + auth + TLS | L4 | **add** | ❌ GAP |
+| Bearer-token lifecycle: use + **expiry** + rotation + revocation (API + MCP) | feat + L4 | **implement + document + test + validate** (M3b) | ❌ CRITICAL GAP — not implemented |
+| Prometheus `/metrics` scrape | L4 | **add** | ❌ GAP |
+| MCP 12 tools round-trip | L4 | extend `mcp_*` | ◐ partial |
+| HEP ingest/forward/limit | L4 | **add** | ❌ GAP |
+| TLS/SRTP decryption | L1/L5 | **add fixtures+tests** | ❌ GAP |
+| STIR/SHAKEN verify | L1 | **add** (fuzz only today) | ◐ GAP |
+| Privilege drop / chroot | L2/L7 | `privilege_drop_test` (+waiver) | ✅ partial |
+| Live capture / audio device | L5/waiver | harness / manual | waiver |
+
+(`✅` covered · `◐` partial · `❌` no automated check · `waiver` = hardware/root-only)
+
+---
+
+## 10. Tooling additions (all industry-standard)
+
+| Need | Tool | Why |
+|---|---|---|
+| CLI goldens | **`trycmd`** / `snapbox` (or `assert_cmd`+`predicates`) | cargo-ecosystem standard; declarative cases |
+| JSON contract | **`jsonschema`** | versioned output schemas |
+| API client | **`reqwest`** (or `ureq`) | drive REST/metrics endpoints |
+| Test runner | **`cargo-nextest`** | parallel isolation + **retries** for PTY flakiness |
+| Snapshot review | **`cargo-insta`** | already implied by `insta`; formal review workflow |
+| Visual TUI goldens (opt) | **`vhs`** | deterministic terminal recordings for docs+regression |
+| Coverage gate | **`cargo-llvm-cov`** (have it) | per-surface coverage tracking |
+
+Waivers (documented, not silently skipped): live `pcap` device, real audio output, `setuid`/`chroot`
+as root. Each is covered indirectly (offline pcap, decode-path unit test, `privilege_drop_test`) and
+fully only in the docker harness or by manual checklist.
+
+---
+
+## 11. CI integration
+
+Jobs (extending current `ci.yml`/`quality.yml`), all with `TZ=UTC`, `NO_COLOR=1`, fixed `COLUMNS/LINES`:
+
+- `test` — unit + integration, **feature matrix** (existing).
+- `cli-goldens` — trycmd/snapbox over all formats (new).
+- `tui-snapshots` — L3a (existing, expand).
+- `tui-e2e` — L3b under nextest **with retries**, drop `continue-on-error` once stable (change).
+- `service` — API/MCP/HEP/metrics L4 (new).
+- `coverage` — llvm-cov informational gate (existing).
+- `fuzz` / `perf` — nightly (existing fuzz; add criterion compare).
+- `e2e-docker` — nightly harness L5 (new).
+- Extend **`docs_drift_test`** into a "every CLI flag has ≥1 referencing test" check so new flags can't merge untested.
+
+---
+
+## 12. Phased rollout
+
+1. **Foundations** — shared normalization scrubber + JSON schemas + CLI golden harness (`trycmd`);
+   adopt `nextest`. *(Unblocks everything; low risk.)*
+2. **Output formats** — close the L1/L2 format gaps (CSV, pcapng, hexdump, fail2ban, wireshark, mermaid, prometheus).
+3. **Service layer** — REST API + `/metrics` + HEP tests; finish MCP 12-tool round-trips.
+4. **TUI breadth** — exhaustive L3a snapshots for all views/dialogs/display-modes; stabilize L3b PTY E2E.
+5. **Crypto + live** — TLS/SRTP fixtures & decryption tests; promote docker harness to nightly L5; perf gate.
+6. **Governance** — traceability matrix kept current; CI "no untested flag" check enforced.
+
+---
+
+## 13. Validation methodology & success / failure criteria
+
+How each layer's tasks are *validated*, and the explicit pass/fail bar. The execution plan
+([`verification-plan.md`](./verification-plan.md)) turns this into per-task commands.
+
+### 13.1 Universal gate (applies to every task)
+
+A task is validated only when **all** hold, run locally and reproduced in CI:
+**TDD red→green** (test written first, shown failing then passing) · targeted test green ·
+**full suite green** (`cargo nextest run --all-features` → `0 failed`) · `cargo fmt --check` and
+`cargo clippy --all-targets --all-features -D warnings` clean · **3× no-flake** ·
+**coverage non-regression** · **evidence captured** (command + output in the PR).
+
+### 13.2 Per-layer validation & criteria
+
+| Layer | Validated by | SUCCESS (pass) | FAILURE |
+|---|---|---|---|
+| **L0 unit** | `cargo nextest run --lib` | green, 3× stable | red · flaky · order-dependent |
+| **L1 component golden** | output → `normalize()` → compare golden | byte-equal to golden | drift without reviewed `insta accept` · volatile field leaks |
+| **L2 CLI process** | `trycmd`: `args+stdin → stdout/stderr/exit` | all three match | wrong exit code · stdout/stderr mismatch · nondeterministic |
+| **L3a TUI snapshot** | `TestBackend`(120×40) → buffer → `insta` | frame == golden, 3× identical | unreviewed diff · nondeterministic frame |
+| **L3b TUI PTY E2E** | `expectrl` screen-scrape under nextest `e2e` | expected screen within timeout | timeout · wrong screen · needs `continue-on-error` |
+| **L4 service** | spawn on `:0` + client; assert status+schema+auth | 2xx · schema-valid · auth enforced | wrong status · schema invalid · **auth bypass** · port leak/hang |
+| **L5 e2e docker** | live sipp traffic → assert sipnab output | ≥1 dialog + expected fields | no capture · missing/incorrect fields |
+| **L6 fuzz / perf** | `cargo fuzz` (no crash) · `criterion` compare | no new crash · within threshold | crash/panic · regression beyond threshold |
+
+### 13.3 Negative tests are mandatory
+
+Every guard is proven by a failing case, not just a passing one: schemas must **reject** a
+field-dropped document; auth must **reject** a bad token (non-2xx); tampered STIR/SHAKEN must be
+**rejected**; the "no-untested-flag" gate must go **red** for a deliberately untested flag. A guard
+that only ever sees the happy path is treated as **unvalidated**.
+
+### 13.4 Evidence, reproducibility & flake policy
+
+Every "done" claim carries the exact command and trimmed output, and must reproduce from a **clean
+tree** (`cargo clean` → build → test). Tests must pass **3× consecutively** with no retries;
+PTY/E2E may use nextest `retries=2` but must *also* clear a no-retry stability check. An
+assertion-less test is never counted as coverage.
+
+### 13.5 Validation-effort meta-criteria (is my validation itself trustworthy?)
+
+- **SUCCESS:** every milestone exit-gate command returns green · evidence logged · clean-tree
+  reproduction matches · coverage ≥ target.
+- **FAILURE:** any gate red · any non-reproducible "pass" · any "passed" claim without captured
+  output · any unreviewed golden/schema change · any undocumented coverage drop.
+
+---
+
+## 14. Definition of done
+
+- Every traceability-matrix row is `✅` or a documented `waiver`.
+- All output formats have a golden + (where JSON) a schema check.
+- All 8 TUI views, 4 dialogs, and display-mode cycles have deterministic snapshots; PTY E2E is
+  green without `continue-on-error`.
+- REST/MCP/HEP/Prometheus surfaces each have an automated L4 test.
+- CI is green across the full feature matrix; coverage held at/above current target.
+- A new CLI flag cannot merge without a referencing test.
+- The §15 completeness mandate is satisfied: 100% of CLI params, UI controls, and API
+  requests/responses (incl. the full bearer-token lifecycle) are registry-tracked and validated.
+
+---
+
+## 15. Completeness mandate — 100% surface validation (hard requirement)
+
+This is a **gating requirement**, not an aspiration: *every* atom in the four user-facing surface
+classes below must map to ≥1 passing automated test, enforced in CI. "Representative" or "most"
+coverage is insufficient — the bar is **100%**, because every atom here is fully automatable (none
+are hardware/root-bound).
+
+**Surface classes & what "validated" means**
+
+1. **Every CLI parameter** (~87 flags in `cli.rs`): for each — parsed value, default, validation
+   (accept valid; reject invalid with exit code 2), and its observable effect on output. Enumerated
+   from the clap `Args` structs.
+2. **Every UI option / control / button** (TUI): every keybinding in `events.rs`; every dialog field,
+   checkbox, and button (Filter / Settings / Save / FileOpen); every view toggle and display-mode
+   cycle — each asserted by an L3a snapshot or state test with its activating key/event exercised.
+3. **Every API request and response**: each endpoint × method, validated for request handling **and
+   every response field** (JSON-Schema), success and error status codes — likewise each MCP tool
+   (request → schema-valid response).
+4. **Bearer-token lifecycle — CRITICAL, and currently a security gap**: config/issuance (flag/file/env
+   precedence) · accepted use (2xx) · reject when missing/wrong/malformed/non-Bearer (401) ·
+   non-loopback-requires-token · constant-time comparison · **expiration** (expired → 401) ·
+   **rotation** (overlapping-validity window) · **revocation** (revoked → 401).
+   > Expiry/rotation/revocation are **not implemented today** (tokens are static shared secrets).
+   > Per maintainer direction this feature is **critical**: it **must be implemented, documented,
+   > tested, and validated** (plan **M3b**). It is an open **security gap**, never a waiver. The
+   > class is "validated" only once all four states — implemented · documented · tested · validated —
+   > are true.
+
+**Enforcement (CI hard gate)**
+
+- A machine-readable **surface registry** (`tests/registry/surface.toml`) enumerates every atom in
+  classes 1–4 with the validating test(s) and a status.
+- CI fails **red** if any atom has **zero** passing tests, or if a new flag / endpoint / control /
+  token-state ships without a registry entry. This generalizes the §11 "no untested flag" gate to
+  all four classes.
+- This 100% surface gate **fails the build** (distinct from line-coverage, which stays informational).
+
+**"Successfully validated" (per atom):** ≥1 test that clears the §13 universal gate (including a
+**negative** case where applicable — e.g. expired/revoked token → 401), is non-flaky (3×), and is
+listed green in the registry.
+
+---
+
+## 16. Industry-best-practices mandate
+
+**Principle — applies to everything (code, tests, CI, security, docs):** every choice follows a
+*current, established industry best practice*. Bespoke mechanisms require written justification in the
+PR. Where a practice is **not already grounded** in this repo, the author **researches the current
+industry standard and cites it** before adopting — do not invent. Prefer well-maintained, widely-used
+tools and patterns over hand-rolled ones.
+
+**Grounded baselines (researched, June 2026):**
+
+| Area | Best practice adopted | Reference |
+|---|---|---|
+| TUI render tests | golden/snapshot via ratatui `TestBackend` + `insta`; **fixed terminal size** for reproducibility; headless in CI | [Ratatui testing recipe](https://ratatui.rs/recipes/testing/snapshots/), [ratatui-testlib](https://github.com/raibid-labs/ratatui-testlib) |
+| TUI E2E | real PTY emulation + screen capture | [ratatui-testlib (PTY)](https://github.com/raibid-labs/ratatui-testlib) |
+| CLI tests | declarative process goldens (`trycmd`/`snapbox`), `assert_cmd`+`predicates` | cargo-ecosystem standard |
+| Output/API contracts | JSON-Schema validation | JSON Schema |
+| Executable docs | "literate testing" / doctest — examples carry expected output and run in CI so code+tests+docs evolve together | [Python `doctest`](https://docs.python.org/3/library/doctest.html), Rust `cargo test --doc` |
+| Test runner | parallel isolation + retries (`cargo-nextest`) | nextest |
+
+**Best-practice review gate:** each PR names the established practice/tool it follows for any new test
+or mechanism; a reviewer (or a CI lint, §11) rejects undocumented bespoke approaches. When a new area
+arises that this table doesn't cover, the author researches + cites the standard and **appends a row
+here**, keeping the mandate grounded rather than assumed.
+
+## 17. Documentation & examples validation (every example must be proven)
+
+**Requirement:** *every example that appears in any documentation is executed and proven correct in
+CI.* No example ships unverified. "Documentation" includes `README.md`, everything under `docs/` (the
+source of truth that auto-syncs to the Wiki), `--help`/usage text, config samples, every **API/MCP
+request+response example**, and rustdoc code examples.
+
+**Mechanisms — lowest layer that proves the example:**
+
+| Example kind | Proven by |
+|---|---|
+| rustdoc code snippets | `cargo test --doc` (Rust doctests) |
+| CLI command blocks in README/`docs/` | extracted + run via `trycmd` (args+stdin → stdout/exit) against fixtures |
+| `--help`/usage shown in docs | golden-compared to actual `--help` (extends `docs_drift_test`) |
+| config-file samples | parsed + schema-validated; samples documented as invalid must fail |
+| API/MCP request/response examples | replayed against a spawned server (`:0`); response JSON-Schema-checked and diffed to the documented example |
+| TUI screenshots / asciicasts | regenerated deterministically (VHS) and diffed |
+
+**Anti-drift:** because `docs/` is the source of truth (→ Wiki), tested examples are what keep the docs
+honest — a doc example that no longer matches reality **fails CI** instead of silently rotting.
+
+**Success / failure**
+- **PASS:** every documented example has an executing test that clears the §13 gate; the doc-example
+  portion of the surface registry (§15) is 100% green.
+- **FAIL:** any documented example is unexecuted · its output diverges from the doc without a reviewed
+  update · a new doc example merges without a runner entry.

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,407 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,758 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1407" data-suffix="">1407</span>
+        <span class="arch-stat" data-count="1758" data-suffix="">1758</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Adds the verification **spec** (`tasks/verification-spec.md`) and **execution plan** (`tasks/verification-plan.md`).

- Layered, deterministic, industry-standard validation of every sipnab function: CLI, text/batch, TUI, and service surfaces (REST/MCP/HEP/Prometheus).
- Per-layer validation methodology with explicit **success/failure criteria** (spec §13).
- **100% surface-validation mandate** (§15): every CLI param, UI control/button, API request/response, token state, and documented example is registry-tracked and CI-enforced.
- **Industry-best-practices mandate** (§16, researched + cited) and **documentation/example validation** (§17 — every documented example proven in CI).
- **CRITICAL** bearer-token expiration/rotation/revocation feature epic (plan **M3b**): implement → document → test → validate.

Also syncs `website/templates/index.html` automated-test count 1407 → 1758 (was stale; required by the pre-commit homepage gate).