### PR TITLE
feat(audio): lazy-dlopen ALSA via cdylib plugin (libasound now optional)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,19 @@ jobs:
               ;;
           esac
 
+          # The audio plugin (libsipnab_audio cdylib) ships only on dynamic
+          # builds that include audio: gnu + macOS with audio == "full".
+          # musl (static, no-audio) and -noaudio builds skip the plugin.
+          audio_plugin="no"
+          case "${{ matrix.target }}" in
+            *-linux-musl) audio_plugin="no" ;;
+            *) [ "$features" = "full" ] && audio_plugin="yes" ;;
+          esac
+
           echo "features=$features" >> "$GITHUB_OUTPUT"
           echo "suffix=$suffix" >> "$GITHUB_OUTPUT"
-          echo "Target ${{ matrix.target }} -> features=$features suffix='$suffix'"
+          echo "audio_plugin=$audio_plugin" >> "$GITHUB_OUTPUT"
+          echo "Target ${{ matrix.target }} -> features=$features suffix='$suffix' audio_plugin=$audio_plugin"
 
       - name: Build (cross)
         if: matrix.cross
@@ -107,6 +117,14 @@ jobs:
       - name: Build (native)
         if: '!matrix.cross'
         run: cargo build --release --target ${{ matrix.target }} --no-default-features --features ${{ steps.features.outputs.features }} --bin sipnab
+
+      - name: Build audio plugin (cross)
+        if: matrix.cross && steps.features.outputs.audio_plugin == 'yes'
+        run: cross build --release --target ${{ matrix.target }} -p sipnab-audio
+
+      - name: Build audio plugin (native)
+        if: '!matrix.cross && steps.features.outputs.audio_plugin == ''yes'''
+        run: cargo build --release --target ${{ matrix.target }} -p sipnab-audio
 
       - name: Strip binary
         run: strip "target/${{ matrix.target }}/release/sipnab" || true
@@ -121,6 +139,18 @@ jobs:
           cp "target/${{ matrix.target }}/release/sipnab" "dist/${stage}/"
           cp README.md LICENSE-MIT LICENSE-APACHE "dist/${stage}/"
           [ -f man/sipnab.1 ] && cp man/sipnab.1 "dist/${stage}/"
+          # Stage the audio plugin alongside the binary when it was built.
+          if [ "${{ steps.features.outputs.audio_plugin }}" = "yes" ]; then
+            case "${{ matrix.target }}" in
+              *-apple-darwin) plugin="target/${{ matrix.target }}/release/libsipnab_audio.dylib" ;;
+              *)              plugin="target/${{ matrix.target }}/release/libsipnab_audio.so" ;;
+            esac
+            if [ -f "$plugin" ]; then
+              cp "$plugin" "dist/${stage}/"
+            else
+              echo "WARNING: audio plugin expected but not found at $plugin" >&2
+            fi
+          fi
           ( cd dist && tar -czf "${stage}.tar.gz" "${stage}" && rm -rf "${stage}" )
           if command -v sha256sum >/dev/null; then
             ( cd dist && sha256sum "${stage}.tar.gz" > "${stage}.tar.gz.sha256" )
@@ -145,7 +175,15 @@ jobs:
             aarch64-unknown-linux-gnu) deb_arch=arm64 ;;
             *) echo "unexpected target ${{ matrix.target }}" >&2; exit 1 ;;
           esac
+          # Pass the prebuilt audio plugin to the deb builder when present so it
+          # ships at /usr/lib/sipnab/ and adds the libasound Recommends.
+          plugin_arg=""
+          if [ "${{ steps.features.outputs.audio_plugin }}" = "yes" ] \
+             && [ -f "target/${{ matrix.target }}/release/libsipnab_audio.so" ]; then
+            plugin_arg="target/${{ matrix.target }}/release/libsipnab_audio.so"
+          fi
           SIPNAB_BIN="target/${{ matrix.target }}/release/sipnab" \
+          SIPNAB_AUDIO_PLUGIN="$plugin_arg" \
             bash contrib/deb/build-deb.sh "$deb_version" "$deb_arch"
           mkdir -p dist
           suffix="${{ steps.features.outputs.suffix }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,6 +3585,7 @@ dependencies = [
  "js-sys",
  "jsonschema",
  "libc",
+ "libloading",
  "log",
  "nom 8.0.0",
  "opus-decoder",
@@ -3595,7 +3596,6 @@ dependencies = [
  "regex",
  "ring",
  "rmcp",
- "rodio",
  "rustls",
  "serde",
  "serde_json",
@@ -3612,6 +3612,14 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "zeroize",
+]
+
+[[package]]
+name = "sipnab-audio"
+version = "0.4.2"
+dependencies = [
+ "libc",
+ "rodio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 members = [".", "crates/sipnab-audio"]
+# `fuzz/` is a standalone cargo-fuzz package (its own build via `cargo fuzz`);
+# it depends on this crate by path and must NOT be pulled into the workspace.
+exclude = ["fuzz"]
 resolver = "2"
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = [".", "crates/sipnab-audio"]
+resolver = "2"
+
 [package]
 name = "sipnab"
 version = "0.4.2"
@@ -59,8 +63,10 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "logg
 aes = { version = "0.9", optional = true }
 cbc = { version = "0.2", features = ["alloc"], optional = true }
 
-# Audio playback (feature-gated)
-rodio = { version = "0.22", default-features = false, features = ["playback"], optional = true }
+# Audio playback (feature-gated). The rodio/ALSA dependency lives in the
+# `sipnab-audio` cdylib plugin (crates/sipnab-audio); the main binary only
+# dlopen's it lazily via libloading so there is no load-time libasound NEEDED.
+libloading = { version = "0.8", optional = true }
 
 # Opus codec (pure Rust, no FFI — always available for WAV export)
 opus-decoder = "0.1"
@@ -110,7 +116,7 @@ native = ["dep:pcap", "dep:clap", "dep:env_logger", "dep:crossbeam-channel", "de
 tui = ["native", "dep:ratatui", "dep:crossterm", "dep:unicode-width"]
 tls = ["dep:zeroize", "dep:ring", "dep:rustls", "dep:aes", "dep:cbc", "dep:base64"]
 hep = ["native"]
-audio = ["dep:rodio", "dep:libc"]
+audio = ["dep:libloading", "dep:libc"]
 api = ["native", "dep:axum", "dep:tokio", "dep:base64"]
 mcp = ["native", "dep:tokio", "dep:rmcp"]
 mcp-http = ["mcp", "api", "rmcp/transport-streamable-http-server"]

--- a/README.md
+++ b/README.md
@@ -46,14 +46,20 @@ target system:
 
 | Library            | Package (Debian/Ubuntu) | Package (Fedora/RHEL)   | When required                                  |
 |--------------------|-------------------------|-------------------------|------------------------------------------------|
-| `libpcap.so.1`     | `libpcap0.8`            | `libpcap`               | Any build that includes the `native` feature   |
-| `libasound.so.2`   | `libasound2`            | `alsa-lib`              | Any build that includes the `audio` feature (in default) |
+| `libpcap.so.1`     | `libpcap0.8`            | `libpcap`               | Mandatory — any build that includes the `native` feature (the binary always links it) |
+| `libasound.so.2`   | `libasound2`            | `alsa-lib`              | **Optional** — only for live audio playback in the TUI (loaded lazily via the audio plugin) |
 
 `tls`, `hep`, `api`, `mcp`, `mcp-http`, and `wasm` are pure-Rust and need no
-additional system libraries. To drop the libasound runtime dependency on a
-headless capture/MCP host, build without the `audio` feature — see the
-`--no-default-features --features native,hep,api,mcp,mcp-http` recipe in the
-Feature Flags section below.
+additional system libraries.
+
+The `audio` feature **no longer links libasound into the `sipnab` binary**.
+Device output lives in a separate plugin, `libsipnab_audio.so`
+(`/usr/lib/sipnab/` from the `.deb`, or next to the binary in dev builds),
+which sipnab `dlopen`s only the moment you press play. So an audio-enabled
+binary starts fine on a host without libasound; if libasound (or the plugin)
+is missing, playback returns a clear error and WAV export (F2) still works.
+Install `libasound2` for live playback — it is a Debian `Recommends`, not a
+hard dependency.
 
 ## Build
 
@@ -125,7 +131,7 @@ All sngrep keybindings are supported. Press `F1` for the full shortcut reference
 |------------|----------------------------------------------------------------------|---------|
 | `native`   | Live capture, file capture, output writers, signal handling, CLI     | yes     |
 | `tui`      | Interactive terminal UI (ratatui + crossterm)                        | yes     |
-| `audio`    | RTP audio playback in TUI + WAV export (rodio)                       | yes     |
+| `audio`    | RTP audio playback in TUI via the lazily-loaded `sipnab-audio` plugin + WAV export | yes     |
 | `tls`      | TLS/DTLS decryption + SRTP key extraction (ring, zeroize, rustls)    | no      |
 | `hep`      | HEP v2/v3 send + receive (Homer Encapsulation Protocol)              | no      |
 | `api`      | REST API + Prometheus metrics endpoint (axum, tokio)                 | no      |
@@ -144,7 +150,7 @@ cargo build --release --features full
 cargo build --release --no-default-features --features native,hep,api,mcp,mcp-http
 ```
 
-Note: `audio` is in the default feature set, so the `libasound2` runtime dependency applies to plain `cargo build --release` too — not just `--features full`. Drop `audio` (e.g. `--no-default-features --features native,tui` or the headless recipe above) if your deploy host won't have libasound.
+Note: `audio` is in the default feature set, but it does **not** add a load-time `libasound2` dependency to the `sipnab` binary. The rodio/ALSA code lives in the separate `sipnab-audio` cdylib plugin (`libsipnab_audio.so`), which the binary `dlopen`s lazily only when you actually play a stream. So the binary starts fine without libasound; install `libasound2` only if you want live playback (otherwise WAV export still works). For a fully audio-free build, drop `audio` (e.g. `--no-default-features --features native,tui` or the headless recipe above) and the plugin is simply not built.
 
 ## Documentation
 

--- a/build.rs
+++ b/build.rs
@@ -15,23 +15,11 @@ fn main() {
     println!("cargo:rustc-env=SIPNAB_GIT_TAG={tag}");
     println!("cargo:rustc-env=SIPNAB_GIT_DIRTY={dirty}");
 
-    // The `audio` feature is in the default set and dynamically links
-    // libasound on Linux: a binary built on a dev box with ALSA present
-    // fails at startup on a headless server without it. Warn at build
-    // time so the runtime dependency is impossible to miss.
-    if std::env::var_os("CARGO_FEATURE_AUDIO").is_some()
-        && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux")
-    {
-        println!(
-            "cargo:warning=sipnab: built with the `audio` feature (in the default set) — \
-             the binary needs libasound.so.2 at runtime (Debian/Ubuntu: libasound2, \
-             Fedora/RHEL: alsa-lib)"
-        );
-        println!(
-            "cargo:warning=sipnab: for headless hosts, drop it: \
-             cargo build --release --no-default-features --features native,tui,tls,hep,api"
-        );
-    }
+    // The `audio` feature no longer links libasound into the binary: device
+    // output lives in the `sipnab-audio` cdylib plugin, which the binary
+    // dlopen's lazily. The binary thus starts fine without libasound — only
+    // live playback needs it — so no build-time runtime-dependency warning is
+    // required for the `audio` feature anymore.
 }
 
 fn git(args: &[&str]) -> Option<String> {

--- a/contrib/deb/build-deb.sh
+++ b/contrib/deb/build-deb.sh
@@ -13,12 +13,28 @@ echo "Building sipnab ${VERSION} for ${ARCH}..."
 # directly and do NOT rebuild or host-strip it -- it may be a foreign-arch
 # binary the local strip cannot handle (the CI already strips native targets).
 # When SIPNAB_BIN is unset (local mode), build natively as before.
+# Resolve the audio plugin (libsipnab_audio.so), if available:
+#   - CI cross mode: $SIPNAB_AUDIO_PLUGIN points at the prebuilt cdylib.
+#   - Local mode: `cargo build --release --features full` builds the whole
+#     workspace, so target/release/libsipnab_audio.so exists.
+# If neither is present (e.g. a no-audio / musl build), ship no plugin and
+# drop the libasound Recommends.
 if [ -n "${SIPNAB_BIN:-}" ]; then
     echo "Using pre-built binary: ${SIPNAB_BIN}"
     BIN_SRC="${SIPNAB_BIN}"
+    PLUGIN_SRC="${SIPNAB_AUDIO_PLUGIN:-}"
 else
     cargo build --release --features full
     BIN_SRC="target/release/sipnab"
+    PLUGIN_SRC="${SIPNAB_AUDIO_PLUGIN:-target/release/libsipnab_audio.so}"
+fi
+
+# Normalize: only ship the plugin if the file actually exists.
+if [ -n "${PLUGIN_SRC}" ] && [ -f "${PLUGIN_SRC}" ]; then
+    SHIP_PLUGIN=1
+else
+    SHIP_PLUGIN=0
+    PLUGIN_SRC=""
 fi
 
 # Create package structure
@@ -38,6 +54,20 @@ cp man/sipnab.1 "$PKG_DIR/usr/share/man/man1/"
 gzip -9 "$PKG_DIR/usr/share/man/man1/sipnab.1"
 cp contrib/sipnab.service "$PKG_DIR/lib/systemd/system/"
 
+# Audio plugin (optional): install the cdylib and add libasound Recommends.
+RECOMMENDS_LINE=""
+if [ "$SHIP_PLUGIN" = "1" ]; then
+    echo "Shipping audio plugin: ${PLUGIN_SRC}"
+    mkdir -p "$PKG_DIR/usr/lib/sipnab"
+    cp "$PLUGIN_SRC" "$PKG_DIR/usr/lib/sipnab/libsipnab_audio.so"
+    if [ -z "${SIPNAB_BIN:-}" ]; then
+        strip "$PKG_DIR/usr/lib/sipnab/libsipnab_audio.so" || true
+    fi
+    RECOMMENDS_LINE="Recommends: libasound2 | libasound2t64"
+else
+    echo "No audio plugin available; building a no-audio package."
+fi
+
 # Create control file
 cat > "$PKG_DIR/DEBIAN/control" << CTRL
 Package: sipnab
@@ -45,7 +75,8 @@ Version: ${VERSION}
 Section: net
 Priority: optional
 Architecture: ${ARCH}
-Depends: libpcap0.8 | libpcap0.8t64
+Depends: libpcap0.8 | libpcap0.8t64${RECOMMENDS_LINE:+
+$RECOMMENDS_LINE}
 Maintainer: Norm Brandinger <n.brandinger@gmail.com>
 Description: SIP & RTP capture, analysis, and security
  sipnab unifies sngrep and sipgrep into a single Rust binary with

--- a/crates/sipnab-audio/Cargo.toml
+++ b/crates/sipnab-audio/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sipnab-audio"
+version = "0.4.2"
+edition = "2024"
+rust-version = "1.92"
+authors = ["Norm Brandinger"]
+description = "sipnab audio playback plugin (rodio/ALSA) — dlopen'd by the sipnab binary"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/NormB/sipnab"
+publish = false
+
+[lib]
+name = "sipnab_audio"
+crate-type = ["cdylib"]
+
+[dependencies]
+rodio = { version = "0.22", default-features = false, features = ["playback"] }
+libc = "0.2"

--- a/crates/sipnab-audio/src/lib.rs
+++ b/crates/sipnab-audio/src/lib.rs
@@ -1,0 +1,223 @@
+//! sipnab audio playback plugin.
+//!
+//! This crate is built as a `cdylib` (`libsipnab_audio.so` on Linux,
+//! `libsipnab_audio.dylib` on macOS). It is the *only* component that links
+//! `rodio` → `cpal` → `alsa-sys` → `libasound`. The main `sipnab` binary
+//! `dlopen`s it lazily (via `libloading`) the moment the user actually plays
+//! audio, so the binary itself carries no load-time `NEEDED libasound.so.2`
+//! ELF entry and starts fine on hosts without libasound installed.
+//!
+//! The exported C ABI is handle-based: the caller opens a player handle, feeds
+//! it f32 PCM buffers, queries/stops playback, and finally closes the handle.
+//! All entry points are null-safe and never unwind across the FFI boundary.
+
+use std::io::Write;
+use std::num::NonZero;
+use std::os::raw::c_void;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use rodio::DeviceSinkBuilder;
+use rodio::Player;
+use rodio::buffer::SamplesBuffer;
+use rodio::stream::MixerDeviceSink;
+
+/// Opaque playback handle: a rodio output device + connected player.
+struct AudioHandle {
+    player: Player,
+    _device_sink: MixerDeviceSink,
+}
+
+/// Open the default audio output device and create a player.
+///
+/// Returns an opaque boxed handle pointer, or null on failure (no device,
+/// libasound errors, etc.). The device open is wrapped in [`StderrSilencer`]
+/// so libasound's C-level error chatter does not corrupt the caller's TUI.
+///
+/// # Safety
+/// The returned pointer must only be passed back to the other `sipnab_audio_*`
+/// functions, and freed exactly once with [`sipnab_audio_close`].
+#[unsafe(no_mangle)]
+pub extern "C" fn sipnab_audio_open() -> *mut c_void {
+    let result = catch_unwind(|| {
+        let mut device_sink = {
+            // libasound writes config/device errors straight to stderr,
+            // which corrupts an alternate-screen TUI. Redirect stderr to
+            // /dev/null for the duration of the device open.
+            let _silencer = StderrSilencer::new();
+            DeviceSinkBuilder::open_default_sink()
+        }
+        .ok()?;
+        device_sink.log_on_drop(false);
+        let player = Player::connect_new(device_sink.mixer());
+        Some(Box::new(AudioHandle {
+            player,
+            _device_sink: device_sink,
+        }))
+    });
+
+    match result {
+        Ok(Some(handle)) => Box::into_raw(handle) as *mut c_void,
+        Ok(None) | Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Append `len` interleaved f32 PCM samples (copied) to the player.
+///
+/// Returns `0` on success and nonzero on error (null handle/pointer, invalid
+/// sample rate or channel count, or a panic caught at the boundary).
+///
+/// # Safety
+/// `handle` must be a live handle from [`sipnab_audio_open`]; `samples` must
+/// point to at least `len` valid `f32` values (or be null with `len == 0`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sipnab_audio_play(
+    handle: *mut c_void,
+    samples: *const f32,
+    len: usize,
+    sample_rate: u32,
+    channels: u16,
+) -> i32 {
+    if handle.is_null() {
+        return 1;
+    }
+    if samples.is_null() && len != 0 {
+        return 2;
+    }
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: handle is non-null and originates from sipnab_audio_open.
+        let handle = unsafe { &*(handle as *const AudioHandle) };
+
+        // Copy the caller's samples; never hold the caller's pointer.
+        let pcm: Vec<f32> = if len == 0 {
+            Vec::new()
+        } else {
+            // SAFETY: caller guarantees `samples` is valid for `len` f32s.
+            unsafe { std::slice::from_raw_parts(samples, len) }.to_vec()
+        };
+
+        let channels = match NonZero::new(channels) {
+            Some(c) => c,
+            None => return 3,
+        };
+        let sample_rate = match NonZero::new(sample_rate) {
+            Some(r) => r,
+            None => return 4,
+        };
+
+        let source = SamplesBuffer::new(channels, sample_rate, pcm);
+        handle.player.append(source);
+        0
+    }));
+
+    result.unwrap_or(5)
+}
+
+/// Stop playback immediately. No-op if `handle` is null.
+///
+/// # Safety
+/// `handle` must be a live handle from [`sipnab_audio_open`] or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sipnab_audio_stop(handle: *mut c_void) {
+    if handle.is_null() {
+        return;
+    }
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: handle is non-null and originates from sipnab_audio_open.
+        let handle = unsafe { &*(handle as *const AudioHandle) };
+        handle.player.stop();
+    }));
+}
+
+/// Return `1` if audio is currently playing, `0` otherwise (including null
+/// handle / caught panic).
+///
+/// # Safety
+/// `handle` must be a live handle from [`sipnab_audio_open`] or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sipnab_audio_is_playing(handle: *mut c_void) -> i32 {
+    if handle.is_null() {
+        return 0;
+    }
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: handle is non-null and originates from sipnab_audio_open.
+        let handle = unsafe { &*(handle as *const AudioHandle) };
+        i32::from(!handle.player.empty())
+    }));
+    result.unwrap_or(0)
+}
+
+/// Drop the player/device and free the handle. No-op if `handle` is null.
+///
+/// # Safety
+/// `handle` must be a handle from [`sipnab_audio_open`] that has not already
+/// been closed; after this call the pointer is dangling and must not be used.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sipnab_audio_close(handle: *mut c_void) {
+    if handle.is_null() {
+        return;
+    }
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: handle is non-null and originates from sipnab_audio_open and
+        // has not been closed before, so reclaiming the Box is sound.
+        drop(unsafe { Box::from_raw(handle as *mut AudioHandle) });
+    }));
+}
+
+/// RAII guard that redirects stderr to `/dev/null` while alive.
+///
+/// Used during audio device initialization so that libasound's C-level error
+/// output (e.g. ALSA config evaluation failures on Tegra/Jetson) does not
+/// bleed through and corrupt the caller's alternate-screen TUI.
+#[cfg(unix)]
+struct StderrSilencer {
+    saved_fd: libc::c_int,
+}
+
+#[cfg(unix)]
+impl StderrSilencer {
+    fn new() -> Option<Self> {
+        let _ = std::io::stderr().flush();
+        // SAFETY: all file descriptors are owned locally and only closed
+        // on the exact paths that produced them.
+        unsafe {
+            let devnull = libc::open(c"/dev/null".as_ptr(), libc::O_WRONLY);
+            if devnull < 0 {
+                return None;
+            }
+            let saved_fd = libc::dup(libc::STDERR_FILENO);
+            if saved_fd < 0 {
+                libc::close(devnull);
+                return None;
+            }
+            if libc::dup2(devnull, libc::STDERR_FILENO) < 0 {
+                libc::close(saved_fd);
+                libc::close(devnull);
+                return None;
+            }
+            libc::close(devnull);
+            Some(Self { saved_fd })
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for StderrSilencer {
+    fn drop(&mut self) {
+        // SAFETY: saved_fd came from a successful dup() in new().
+        unsafe {
+            libc::dup2(self.saved_fd, libc::STDERR_FILENO);
+            libc::close(self.saved_fd);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+struct StderrSilencer;
+
+#[cfg(not(unix))]
+impl StderrSilencer {
+    fn new() -> Option<Self> {
+        None
+    }
+}

--- a/docs/install.md
+++ b/docs/install.md
@@ -89,7 +89,7 @@ sipnab uses Cargo feature flags to control optional functionality. The default b
 |---------|-------------|--------------|
 | `native` | Live capture, file capture, output writers, signal handling, CLI parser. **Required by every other feature except `wasm`.** Included by default. | `pcap`, `clap`, `crossbeam-channel`, `libc`, `pcap-file`, `tracing-subscriber`, `tracing-log` |
 | `tui` | Interactive terminal UI (ratatui + crossterm). Included by default. | `native`, `ratatui`, `crossterm`, `unicode-width` |
-| `audio` | RTP audio playback in the TUI + WAV export. Included by default. Adds a runtime dependency on `libasound.so.2`. | `rodio`, `libc` |
+| `audio` | RTP audio playback in the TUI + WAV export. Included by default. Builds the separate `sipnab-audio` plugin (`libsipnab_audio.so`) that the binary `dlopen`s lazily; the binary itself does **not** link `libasound.so.2`. | `libloading`, `libc` (plugin: `rodio`) |
 | `tls` | TLS/DTLS decryption and SRTP key extraction (pure Rust) | `ring`, `rustls`, `aes`, `cbc`, `zeroize` |
 | `hep` | HEP v2/v3 send + receive (Homer Encapsulation Protocol) | `native` |
 | `api` | REST API + Prometheus metrics endpoint | `native`, `axum`, `tokio` |
@@ -111,7 +111,16 @@ cargo build --release --no-default-features --features native,hep,api,mcp,mcp-ht
 cargo build --release --features full
 ```
 
-A `--features full` (or any build with `audio`) dynamically links `libasound.so.2` and refuses to start without it — install `libasound2` alongside `libpcap0.8` on Debian/Ubuntu, or drop the `audio` feature for headless servers.
+`libasound.so.2` is now an **optional** runtime dependency. The `audio` feature
+builds a separate plugin, `libsipnab_audio.so`, installed to `/usr/lib/sipnab/`
+by the `.deb` (or placed next to the binary in dev builds). The `sipnab` binary
+`dlopen`s this plugin only when you actually play a stream, so an audio-enabled
+binary starts fine on a host without libasound. If libasound (or the plugin) is
+missing, playback returns a clear error and you can still export the stream to a
+WAV file (F2). On Debian/Ubuntu `libasound2` is shipped as a `Recommends` of the
+package; install it for live playback. Only `libpcap0.8` is a hard dependency.
+For a fully audio-free build, drop the `audio` feature and the plugin is not
+built.
 
 See the website install guide ([www.sipnab.com/docs/install](https://www.sipnab.com/docs/install/)) for the full MCP enablement walkthrough including token-file generation and the systemd unit pattern.
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.0.0"
 publish = false
 edition = "2024"
 
+# Detach from the parent workspace: `fuzz/` is built standalone by cargo-fuzz
+# and depends on the parent crate by path. Without this, the parent's
+# `[workspace]` would claim it ("believes it's in a workspace when it's not").
+[workspace]
+
 [package.metadata]
 cargo-fuzz = true
 

--- a/src/rtp/playback.rs
+++ b/src/rtp/playback.rs
@@ -1,49 +1,96 @@
 //! Real-time audio playback from RTP stream payload buffers.
 //!
-//! Decodes G.711 and Opus audio, resamples to the system output rate, and
-//! plays through the default audio device via rodio. G.711 is resampled
-//! from 8 kHz; Opus decodes natively at 48 kHz (no resampling needed).
+//! Decodes G.711 and Opus audio (pure Rust, no ALSA dependency) and resamples
+//! to 48 kHz mono. The actual device output is delegated to the
+//! `sipnab-audio` plugin (`libsipnab_audio.so` / `.dylib`), which is the only
+//! component linking rodio/ALSA. The plugin is `dlopen`'d lazily on first
+//! [`AudioPlayer::new`], so the main binary carries no load-time
+//! `NEEDED libasound.so.2` ELF entry and starts fine without libasound.
 
-use std::io::Write;
-use std::num::NonZero;
+use std::ffi::OsString;
+use std::os::raw::c_void;
+use std::path::PathBuf;
 
 use anyhow::{Result, bail};
-use rodio::DeviceSinkBuilder;
-use rodio::Player;
-use rodio::buffer::SamplesBuffer;
-use rodio::stream::MixerDeviceSink;
+use libloading::{Library, Symbol};
 
 use super::g711::{G711Codec, decode_frame};
 use super::opus_decode::OpusStreamDecoder;
 use super::stream::RtpStream;
 
-/// Audio player wrapping a rodio output device and player.
+// C ABI of the sipnab-audio plugin (see crates/sipnab-audio/src/lib.rs).
+type OpenFn = unsafe extern "C" fn() -> *mut c_void;
+type PlayFn = unsafe extern "C" fn(*mut c_void, *const f32, usize, u32, u16) -> i32;
+type StopFn = unsafe extern "C" fn(*mut c_void);
+type IsPlayingFn = unsafe extern "C" fn(*mut c_void) -> i32;
+type CloseFn = unsafe extern "C" fn(*mut c_void);
+
+/// Audio player backed by the lazily-loaded `sipnab-audio` plugin.
+///
+/// The public API is unchanged from the previous rodio-linked implementation
+/// so TUI callers need no modification.
 pub struct AudioPlayer {
-    player: Player,
-    _device_sink: MixerDeviceSink,
+    // Raw function pointers resolved from `_lib`. They are only valid while
+    // `_lib` is alive, so `_lib` is kept (and dropped last via field order).
+    play: PlayFn,
+    stop: StopFn,
+    is_playing: IsPlayingFn,
+    close: CloseFn,
+    handle: *mut c_void,
+    // The loaded plugin library. MUST outlive the function pointers above and
+    // the handle; it is dropped last (struct fields drop in declaration order,
+    // so `_lib` is listed last here).
+    _lib: Library,
 }
 
 impl AudioPlayer {
-    /// Create a new audio player using the default output device.
+    /// Create a new audio player by `dlopen`-ing the `sipnab-audio` plugin and
+    /// opening the default output device through it.
+    ///
+    /// Returns a clear `Err` (never panics) when the plugin or its libasound
+    /// dependency is unavailable, so callers can fall back to WAV export.
     pub fn new() -> Result<Self> {
-        let mut device_sink = {
-            // libasound writes config/device errors straight to stderr,
-            // which corrupts the alternate-screen TUI. Redirect stderr
-            // to /dev/null for the duration of the device open.
-            let _silencer = StderrSilencer::new();
-            DeviceSinkBuilder::open_default_sink()
-        }
-        .map_err(|e| {
-            anyhow::anyhow!(
-                "No audio output device available ({e}). \
+        let lib = load_plugin()?;
+
+        // SAFETY: the plugin exports exactly these C-ABI symbols. We resolve
+        // them up front and copy the raw fn pointers out so we don't hold
+        // borrows of `lib`.
+        let (open, play, stop, is_playing, close) = unsafe {
+            let open: Symbol<OpenFn> = lib
+                .get(b"sipnab_audio_open\0")
+                .map_err(|e| anyhow::anyhow!("audio plugin missing sipnab_audio_open: {e}"))?;
+            let play: Symbol<PlayFn> = lib
+                .get(b"sipnab_audio_play\0")
+                .map_err(|e| anyhow::anyhow!("audio plugin missing sipnab_audio_play: {e}"))?;
+            let stop: Symbol<StopFn> = lib
+                .get(b"sipnab_audio_stop\0")
+                .map_err(|e| anyhow::anyhow!("audio plugin missing sipnab_audio_stop: {e}"))?;
+            let is_playing: Symbol<IsPlayingFn> =
+                lib.get(b"sipnab_audio_is_playing\0").map_err(|e| {
+                    anyhow::anyhow!("audio plugin missing sipnab_audio_is_playing: {e}")
+                })?;
+            let close: Symbol<CloseFn> = lib
+                .get(b"sipnab_audio_close\0")
+                .map_err(|e| anyhow::anyhow!("audio plugin missing sipnab_audio_close: {e}"))?;
+            (*open, *play, *stop, *is_playing, *close)
+        };
+
+        // SAFETY: `open` is a valid plugin symbol; it returns null on failure.
+        let handle = unsafe { open() };
+        if handle.is_null() {
+            bail!(
+                "No audio output device available. \
                  Use F2 to save the stream as a WAV file instead."
-            )
-        })?;
-        device_sink.log_on_drop(false);
-        let player = Player::connect_new(device_sink.mixer());
+            );
+        }
+
         Ok(Self {
-            player,
-            _device_sink: device_sink,
+            play,
+            stop,
+            is_playing,
+            close,
+            handle,
+            _lib: lib,
         })
     }
 
@@ -78,16 +125,14 @@ impl AudioPlayer {
         };
 
         let duration_secs = pcm_48k.len() as f64 / output_rate as f64;
-        let channels = match NonZero::new(1u16) {
-            Some(c) => c,
-            None => bail!("invalid channel count"),
-        };
-        let sample_rate = match NonZero::new(output_rate) {
-            Some(r) => r,
-            None => bail!("invalid sample rate"),
-        };
-        let source = SamplesBuffer::new(channels, sample_rate, pcm_48k);
-        self.player.append(source);
+
+        // SAFETY: `self.play` is a valid plugin symbol resolved in `new`;
+        // `self.handle` is a live handle; the slice is valid for its length.
+        let rc =
+            unsafe { (self.play)(self.handle, pcm_48k.as_ptr(), pcm_48k.len(), output_rate, 1) };
+        if rc != 0 {
+            bail!("audio plugin playback failed (code {rc})");
+        }
 
         Ok(format!(
             "Playing {:.1}s of {} audio ({} frames)",
@@ -99,13 +144,86 @@ impl AudioPlayer {
 
     /// Stop playback immediately.
     pub fn stop(&self) {
-        self.player.stop();
+        // SAFETY: valid plugin symbol + live handle.
+        unsafe { (self.stop)(self.handle) };
     }
 
     /// Check if audio is currently playing.
     pub fn is_playing(&self) -> bool {
-        !self.player.empty()
+        // SAFETY: valid plugin symbol + live handle.
+        unsafe { (self.is_playing)(self.handle) != 0 }
     }
+}
+
+impl Drop for AudioPlayer {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            // SAFETY: valid plugin symbol; `handle` was opened in `new` and is
+            // closed exactly once here before `_lib` is dropped.
+            unsafe { (self.close)(self.handle) };
+            self.handle = std::ptr::null_mut();
+        }
+        // `_lib` drops after this (last field), unloading the plugin.
+    }
+}
+
+/// Candidate filename for the plugin on this platform
+/// (`libsipnab_audio.so` / `libsipnab_audio.dylib`).
+fn plugin_filename() -> String {
+    format!(
+        "{}sipnab_audio{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    )
+}
+
+/// Build the ordered list of candidate plugin paths to try:
+/// 1. `$SIPNAB_AUDIO_PLUGIN` (explicit path),
+/// 2. next to the current executable (dev builds),
+/// 3. `/usr/lib/sipnab/<soname>` (Debian install),
+/// 4. the bare soname via the loader search path.
+fn plugin_candidates() -> Vec<OsString> {
+    let filename = plugin_filename();
+    let mut candidates: Vec<OsString> = Vec::new();
+
+    if let Some(explicit) = std::env::var_os("SIPNAB_AUDIO_PLUGIN") {
+        candidates.push(explicit);
+    }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        candidates.push(dir.join(&filename).into_os_string());
+    }
+    candidates.push(
+        PathBuf::from("/usr/lib/sipnab")
+            .join(&filename)
+            .into_os_string(),
+    );
+    candidates.push(OsString::from(&filename));
+    candidates
+}
+
+/// Resolve and `dlopen` the audio plugin, trying [`plugin_candidates`] in
+/// order and returning the first that loads.
+fn load_plugin() -> Result<Library> {
+    let candidates = plugin_candidates();
+
+    let mut last_err = String::from("no candidate paths");
+    for cand in &candidates {
+        // SAFETY: loading a trusted plugin library; any initializers it runs
+        // are our own code. Errors are non-fatal (we try the next candidate).
+        match unsafe { Library::new(cand) } {
+            Ok(lib) => return Ok(lib),
+            Err(e) => last_err = format!("{}: {e}", cand.to_string_lossy()),
+        }
+    }
+
+    bail!(
+        "Audio playback unavailable — the sipnab audio plugin or libasound2 is \
+         not installed (last error: {last_err}). Install libasound2 (Debian: \
+         `apt install libasound2t64`) or use F2 to save the stream as a WAV \
+         file instead."
+    )
 }
 
 /// Decode G.711 frames to f32 PCM in [-1.0, 1.0] range.
@@ -139,64 +257,6 @@ fn decode_opus_to_f32(stream: &RtpStream) -> Result<Vec<f32>> {
     Ok(pcm)
 }
 
-/// RAII guard that redirects stderr to /dev/null while alive.
-///
-/// Used during audio device initialization so that libasound's C-level
-/// error output (e.g. ALSA config evaluation failures on Tegra/Jetson)
-/// does not bleed through and corrupt the TUI's alternate screen.
-#[cfg(unix)]
-struct StderrSilencer {
-    saved_fd: libc::c_int,
-}
-
-#[cfg(unix)]
-impl StderrSilencer {
-    fn new() -> Option<Self> {
-        let _ = std::io::stderr().flush();
-        // SAFETY: all file descriptors are owned locally and only closed
-        // on the exact paths that produced them.
-        unsafe {
-            let devnull = libc::open(c"/dev/null".as_ptr(), libc::O_WRONLY);
-            if devnull < 0 {
-                return None;
-            }
-            let saved_fd = libc::dup(libc::STDERR_FILENO);
-            if saved_fd < 0 {
-                libc::close(devnull);
-                return None;
-            }
-            if libc::dup2(devnull, libc::STDERR_FILENO) < 0 {
-                libc::close(saved_fd);
-                libc::close(devnull);
-                return None;
-            }
-            libc::close(devnull);
-            Some(Self { saved_fd })
-        }
-    }
-}
-
-#[cfg(unix)]
-impl Drop for StderrSilencer {
-    fn drop(&mut self) {
-        // SAFETY: saved_fd came from a successful dup() in new().
-        unsafe {
-            libc::dup2(self.saved_fd, libc::STDERR_FILENO);
-            libc::close(self.saved_fd);
-        }
-    }
-}
-
-#[cfg(not(unix))]
-struct StderrSilencer;
-
-#[cfg(not(unix))]
-impl StderrSilencer {
-    fn new() -> Option<Self> {
-        None
-    }
-}
-
 /// Resample f32 PCM using linear interpolation.
 fn resample_f32(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
     if from_rate == to_rate || samples.is_empty() {
@@ -216,9 +276,9 @@ fn resample_f32(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
     out
 }
 
-// Tests cover the device-free DSP helpers (decode + resample). The rodio
-// `AudioPlayer` / `MixerDeviceSink` device path is hardware-bound and stays
-// uncovered by design.
+// Tests cover the device-free DSP helpers (decode + resample) and the plugin
+// load/error paths. The rodio device path lives in the `sipnab-audio` plugin
+// and is hardware-bound, so it stays uncovered by design.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,5 +377,63 @@ mod tests {
         let pcm = decode_opus_to_f32(&s).expect("opus decode ok despite bad frames");
         // Undecodable frames produce no samples.
         assert!(pcm.is_empty());
+    }
+
+    #[test]
+    fn plugin_filename_is_platform_appropriate() {
+        let name = plugin_filename();
+        assert!(name.contains("sipnab_audio"));
+        // On Linux this is `libsipnab_audio.so`; on macOS `.dylib`.
+        assert!(name.ends_with(std::env::consts::DLL_SUFFIX));
+    }
+
+    #[test]
+    fn explicit_nonexistent_plugin_path_does_not_load() {
+        // A non-existent explicit path must not dlopen successfully. We test
+        // the candidate directly to stay independent of fallback paths.
+        let bad = OsString::from("/nonexistent/path/to/libsipnab_audio.so");
+        // SAFETY: loading a (missing) library; the call simply fails.
+        let loaded = unsafe { Library::new(&bad) }.is_ok();
+        assert!(!loaded, "a non-existent plugin path must not load");
+    }
+
+    #[test]
+    fn new_with_missing_plugin_returns_err_not_panic() {
+        // Pointing SIPNAB_AUDIO_PLUGIN at a non-existent path forces the
+        // explicit-path candidate to fail. The remaining fallbacks are highly
+        // unlikely to find a real plugin in the test environment, so this
+        // exercises the graceful-fallback error path (no panic/abort).
+        //
+        // SAFETY: set_var/remove_var are unsafe in edition 2024; tests are
+        // single-threaded here and we restore the previous value.
+        let prev = std::env::var_os("SIPNAB_AUDIO_PLUGIN");
+        unsafe {
+            std::env::set_var(
+                "SIPNAB_AUDIO_PLUGIN",
+                "/nonexistent/path/to/libsipnab_audio.so",
+            );
+        }
+
+        let result = AudioPlayer::new();
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("SIPNAB_AUDIO_PLUGIN", v),
+                None => std::env::remove_var("SIPNAB_AUDIO_PLUGIN"),
+            }
+        }
+
+        // The contract is: never panic/abort. The explicit bad path must fail
+        // to load; if no other candidate finds a real plugin (the common test
+        // case) we get the "Audio playback unavailable" load error. If a real
+        // plugin *does* load via a fallback path but no audio device exists
+        // (CI), `open()` returns null and we get "No audio output device
+        // available". Both are clean `Err`s — what matters is that we did not
+        // unwind. Any `Ok` would mean a real device opened, which is also a
+        // non-panicking outcome.
+        if let Err(e) = &result {
+            let msg = e.to_string();
+            assert!(!msg.is_empty(), "error message should be non-empty");
+        }
     }
 }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,793 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,796 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1793" data-suffix="">1793</span>
+        <span class="arch-stat" data-count="1796" data-suffix="">1796</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Fixes the Debian install failure (`error while loading shared libraries: libasound.so.2`) by making libasound a **lazily dlopen'd** dependency.

## What
Moves all rodio/ALSA code into a new `crates/sipnab-audio` **cdylib** plugin. The main binary `dlopen`s it (via `libloading`) only when the user actually plays audio.

**Core proof:** the default (audio-enabled) binary has **no load-time `NEEDED libasound.so.2`** — `readelf -d target/debug/sipnab` shows only libpcap/libgcc/libm/libc — while `libsipnab_audio.so` links libasound. One universal build runs everywhere; libasound becomes a `Recommends`, pulled only for live playback.

## Changes
- **Workspace + plugin:** `crates/sipnab-audio` (cdylib) with a null-safe, panic-catching handle-based C ABI (open/play/stop/is_playing/close). Holds the rodio device/Player + StderrSilencer.
- **Main binary:** drop `rodio`; add optional `libloading`; `audio = ["dep:libloading", "dep:libc"]`. `AudioPlayer` keeps its **identical public API** (TUI callers unchanged); all pure-Rust DSP (G.711/Opus decode + resample) retained. Plugin path: `$SIPNAB_AUDIO_PLUGIN` → next-to-exe → `/usr/lib/sipnab/` → soname. Graceful `Err` + WAV fallback if absent (no panic).
- **Packaging:** `build-deb.sh` ships the plugin to `/usr/lib/sipnab/`, adds `Recommends: libasound2 | libasound2t64` when shipped (`Depends`/libpcap unchanged). `release.yml` builds + stages the plugin for gnu/macOS (full); musl/static stay no-audio.
- **Docs:** README + `docs/install.md` document libasound2 as optional + the WAV fallback.

## Validation
Full suite **1796 passed, 0 failed**; graceful-fallback tests (missing/bad plugin → Err, not panic) added; `fmt` + `clippy --workspace --all-targets` clean; readelf proof verified independently.