### PR TITLE
feat(auth): HMAC bearer-token lifecycle — expiry/rotation/revocation (M3b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1472,6 +1473,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -3579,6 +3589,7 @@ dependencies = [
  "env_logger",
  "etherparse",
  "expectrl",
+ "hmac",
  "http-body-util",
  "indexmap",
  "insta",
@@ -3599,6 +3610,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,12 @@ unicode-width = { version = "0.2", optional = true }
 # Phase 5: STIR/SHAKEN & analysis
 base64 = { version = "0.22", optional = true }
 
+# Auth: HMAC self-describing bearer tokens (pure-Rust RustCrypto). Available
+# whenever `api` OR `mcp` is enabled; deliberately NOT tied to the `tls`
+# feature (no `ring`).
+hmac = { version = "0.12", optional = true }
+sha2 = { version = "0.10", optional = true }
+
 # Phase 5: TLS/Crypto (feature-gated)
 zeroize = { version = "1", features = ["derive"], optional = true }
 ring = { version = "0.17", optional = true }
@@ -120,8 +126,8 @@ tui = ["native", "dep:ratatui", "dep:crossterm", "dep:unicode-width"]
 tls = ["dep:zeroize", "dep:ring", "dep:rustls", "dep:aes", "dep:cbc", "dep:base64"]
 hep = ["native"]
 audio = ["dep:libloading", "dep:libc"]
-api = ["native", "dep:axum", "dep:tokio", "dep:base64"]
-mcp = ["native", "dep:tokio", "dep:rmcp"]
+api = ["native", "dep:axum", "dep:tokio", "dep:base64", "dep:hmac", "dep:sha2"]
+mcp = ["native", "dep:tokio", "dep:rmcp", "dep:base64", "dep:hmac", "dep:sha2"]
 mcp-http = ["mcp", "api", "rmcp/transport-streamable-http-server"]
 wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "dep:console_error_panic_hook"]
 full = ["native", "tui", "tls", "hep", "api", "audio", "mcp", "mcp-http"]

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,119 @@
+# Bearer-token authentication
+
+The REST API (`--api`) and HTTP MCP server (`--mcp --mcp-transport http`)
+authenticate clients with `Authorization: Bearer <token>`. sipnab supports two
+token kinds, checked with a constant-time comparison:
+
+1. **Static secrets** — `--api-key` / `--mcp-token` (or `--mcp-token-file`,
+   `$SIPNAB_API_SIGNING_KEY`-style env). A fixed shared secret with **no
+   expiry**. Simple, but cannot be expired or revoked without restarting.
+2. **Signed self-describing tokens** — HMAC-signed tokens that carry their own
+   expiry and id, enabling **expiry, rotation, and revocation** without a
+   server-side session store. This page documents those.
+
+> On a non-loopback bind, a token (static or signed) is **required** — the
+> server refuses to start otherwise. On loopback with no token configured,
+> requests pass (unchanged legacy behavior).
+
+## Token format
+
+```
+s1.<base64url(payload)>.<base64url(HMAC-SHA256)>
+```
+
+- `payload` is compact JSON `{"id":"<jti>","exp":<unix_seconds>}`.
+- The signature is `HMAC-SHA256(signing_key, "s1." + base64url(payload))`.
+- base64url is URL-safe, no padding.
+
+Verification is **stateless**: the server recomputes the HMAC, compares it in
+constant time against every configured signing key, then checks `exp > now` and
+that `id` is not revoked. Any malformed token is rejected (fail-closed).
+
+## 1. Configure a signing key
+
+Give the server one or more HMAC signing keys (use a long, random secret):
+
+```bash
+# REST API
+sipnab -N -I capture.pcap --api 127.0.0.1:8080 \
+  --api-signing-key "$(openssl rand -hex 32)"
+
+# HTTP MCP
+sipnab -N -I capture.pcap --mcp --mcp-transport http --mcp-bind 127.0.0.1:8731 \
+  --mcp-signing-key "$(openssl rand -hex 32)"
+```
+
+Keys may also be supplied via `--api-signing-key-file` / `--mcp-signing-key-file`
+(file contents, trimmed) or the `$SIPNAB_API_SIGNING_KEY` /
+`$SIPNAB_MCP_SIGNING_KEY` environment variables. `--api-signing-key` /
+`--mcp-signing-key` are **repeatable** (see *Rotation*).
+
+## 2. Mint (issue) a token
+
+`--mint-token` signs a token with the **first** configured signing key, prints
+it, and exits — it does not start any capture or server:
+
+```bash
+# 1-hour API token (default TTL 3600s)
+sipnab --mint-token --api-signing-key "$KEY"
+
+# 24-hour MCP token with an explicit id (for later revocation)
+sipnab --mint-token --mcp-signing-key "$KEY" --mcp-token-ttl 86400 --token-id ci-runner-1
+```
+
+`--api-token-ttl` / `--mcp-token-ttl` (default `3600`) set the lifetime;
+`--token-id` sets the `jti` (defaults to a generated id). Distribute the printed
+token to clients.
+
+## 3. Use a token
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/v1/dialogs
+```
+
+A valid, unexpired, non-revoked token returns `200`; anything else returns
+`401`.
+
+## 4. Expiry
+
+A token is rejected (`401`) once `exp <= now` — no server action needed. Mint
+short-lived tokens for CI/automation and longer-lived ones sparingly.
+
+## 5. Rotation
+
+Two independent mechanisms:
+
+- **Token rotation:** mint a new token before the old one expires, switch
+  clients over, and let the old token lapse. Multiple tokens are valid
+  simultaneously.
+- **Signing-key rotation:** pass `--api-signing-key`/`--mcp-signing-key` more
+  than once. The **first** key mints; **all** keys verify. To roll a key:
+  add the new key alongside the old, mint with the new key, migrate clients,
+  then drop the old key on the next restart.
+
+## 6. Revocation
+
+To kill a still-valid token before its `exp`, add its `id` to a denylist file
+and point the server at it:
+
+```bash
+echo "ci-runner-1" >> /etc/sipnab/revoked.txt
+sipnab ... --api-signing-key "$KEY" --api-revoked-file /etc/sipnab/revoked.txt
+```
+
+The file is one token `id` per line (blank lines and `#` comments ignored). It
+is **re-read when its mtime changes**, so appending an id revokes that token
+within the next request — no restart required. (Because signed tokens are
+otherwise valid until `exp`, a denylist is the revocation mechanism for the
+stateless model.)
+
+## Security notes
+
+- Signing keys and tokens are secrets — prefer `*-signing-key-file` or env over
+  argv (argv is visible in `ps`).
+- Signatures and static secrets are compared in **constant time**.
+- Do not choose a static `--api-key`/`--mcp-token` shaped like `s1.x.y` — it
+  would be parsed as a (failing) signed token rather than matched as a static
+  secret.
+- TLS for the REST API is **not yet built in**; terminate TLS at a reverse proxy
+  for non-loopback deployments.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -134,11 +134,19 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--api-tls-cert` | `<FILE>` | -- | TLS certificate file for API endpoint |
 | `--api-tls-key` | `<FILE>` | -- | TLS private key file for API endpoint |
 | `--api-max-conn` | `<N>` | `100` | Maximum concurrent API connections |
+| `--api-signing-key` | `<KEY>` | -- | HMAC signing key for self-describing bearer tokens (repeatable; the first mints, all are accepted on verify → key rotation). Also reads `$SIPNAB_API_SIGNING_KEY`. See [`auth.md`](./auth.md). Feature: `api` |
+| `--api-signing-key-file` | `<FILE>` | -- | Read an API signing key from a file (contents trimmed). Feature: `api` |
+| `--api-revoked-file` | `<FILE>` | -- | Revocation denylist: one revoked token `id` per line; reloaded on mtime change. Feature: `api` |
+| `--api-token-ttl` | `<SECS>` | `3600` | Default TTL (seconds) when minting API tokens with `--mint-token`. Feature: `api` |
 | `--mcp` | -- | off | Run sipnab as an MCP server. Feature: `mcp` (or `mcp-http` for HTTP transport). See [`mcp-overview.md`](./mcp-overview.md). |
 | `--mcp-transport` | `stdio\|http` | `stdio` | MCP transport. `http` requires the `mcp-http` feature. |
 | `--mcp-bind` | `<ADDR>` | -- (defaults to `127.0.0.1:8731` at runtime if `--mcp-transport http` is set without an explicit bind) | HTTP MCP bind address. Non-loopback requires `--mcp-token`. |
 | `--mcp-token` | `<TOKEN>` | -- | Bearer token. Also reads `$SIPNAB_MCP_TOKEN`. |
 | `--mcp-token-file` | `<FILE>` | -- | Read bearer token from file (preferred over env in systemd units). |
+| `--mcp-signing-key` | `<KEY>` | -- | HMAC signing key for MCP bearer tokens (repeatable; first mints, all verify). Also reads `$SIPNAB_MCP_SIGNING_KEY`. See [`auth.md`](./auth.md). |
+| `--mcp-signing-key-file` | `<FILE>` | -- | Read an MCP signing key from a file (contents trimmed). |
+| `--mcp-revoked-file` | `<FILE>` | -- | MCP revocation denylist (one token `id` per line; reloaded on mtime change). |
+| `--mcp-token-ttl` | `<SECS>` | `3600` | Default TTL (seconds) when minting MCP tokens with `--mint-token`. |
 | `--mcp-allowed-host` | `<HOST>` | -- | Additional `Host` header values the HTTP MCP server will accept (repeatable). rmcp's DNS-rebind protection defaults to `localhost`, `127.0.0.1`, `::1` only — add the public hostname or bind IP when clients connect via that name. Use `*` to disable host checking entirely (pair with a network-level source-IP allowlist). |
 | `-L`, `--hep-listen` | `<ADDR>` | -- | Listen for HEP (Homer Encapsulation Protocol) packets. Feature: `hep` |
 | `-H`, `--hep-send` | `<ADDR>` | -- | Send captured packets via HEP to a remote collector. Feature: `hep` |
@@ -146,6 +154,8 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--hep-allow` | `<ADDR>` | -- | Allowed source addresses for HEP input (repeatable) |
 | `--hep-rate-limit` | `<N>` | `50000` | Maximum HEP packets per second |
 | `--syslog` | -- | off | Send alerts to syslog |
+| `--mint-token` | -- | off | Mint a signed bearer token from the first configured signing key, print it to stdout, and exit (no capture/servers). See [`auth.md`](./auth.md). |
+| `--token-id` | `<ID>` | -- | Token id (`jti`) for `--mint-token`, used for revocation. Defaults to a generated id. |
 
 ## TLS / Decryption
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,584 @@
+//! HMAC self-describing bearer tokens with expiry, rotation, and revocation.
+//!
+//! Shared between the REST API (`output::api`) and the HTTP MCP transport
+//! (`mcp::transport`). Compiles whenever either the `api` or `mcp` feature is
+//! enabled.
+//!
+//! # Token format
+//!
+//! `s1.<b64url(payload)>.<b64url(sig)>`
+//!
+//! - `payload` = compact JSON `{"id":"<jti>","exp":<unix_seconds>}` (no spaces).
+//! - `sig` = HMAC-SHA256(signing_key, ASCII of `"s1." + b64url(payload)`).
+//! - `b64url` is base64 URL-safe with NO padding.
+//!
+//! # Verification (stateless)
+//!
+//! Verification splits on `.`, requires the `s1` version, b64url-decodes the
+//! payload and signature, recomputes the HMAC over `"s1." + payload_b64`, and
+//! compares it to the presented signature in **constant time**. It then parses
+//! the payload, requiring `exp > now` and that `id` is not in the revocation
+//! denylist. Any parse/format error rejects (fail closed); attacker input never
+//! panics.
+//!
+//! # Backward compatibility
+//!
+//! If the presented value is not a parseable `s1.` token, the verifier falls
+//! back to a constant-time comparison against the configured static secret(s).
+//! Static secrets have no expiry.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use hmac::{Hmac, Mac};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// The token version prefix. Only `s1` tokens are accepted.
+const VERSION: &str = "s1";
+
+/// Constant-time byte comparison to prevent timing side-channel attacks on
+/// API keys and token signatures.
+///
+/// Does not leak the length of either input: both are compared up to the
+/// length of the longer input, and the length check is folded into the final
+/// result without early return.
+///
+/// `#[inline(never)]` prevents the optimizer from rewriting the loop into a
+/// short-circuiting form. `black_box` on the accumulator forces the compiler
+/// to materialize it, blocking dead-store elimination.
+#[inline(never)]
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    let len_match = a.len() == b.len();
+    let max_len = a.len().max(b.len());
+    let mut byte_diff = 0u8;
+    for i in 0..max_len {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        byte_diff |= x ^ y;
+    }
+    len_match && std::hint::black_box(byte_diff) == 0
+}
+
+/// Decoded token payload: a unique id (`jti`) and an absolute expiry.
+#[derive(Debug, Serialize, Deserialize)]
+struct Payload {
+    /// Token id used for revocation (denylist).
+    id: String,
+    /// Expiry as Unix epoch seconds.
+    exp: i64,
+}
+
+/// Mint a signed token from `signing_key`, with id `id` and absolute expiry
+/// `exp_unix` (Unix epoch seconds).
+///
+/// Produces `s1.<b64url(payload)>.<b64url(sig)>`. The payload is compact JSON
+/// `{"id":...,"exp":...}` with no spaces.
+pub fn mint(signing_key: &[u8], id: &str, exp_unix: i64) -> String {
+    let payload = Payload {
+        id: id.to_string(),
+        exp: exp_unix,
+    };
+    // serde_json::to_string produces compact JSON (no spaces) by default.
+    let payload_json = serde_json::to_string(&payload)
+        .unwrap_or_else(|_| format!("{{\"id\":\"{id}\",\"exp\":{exp_unix}}}"));
+    let payload_b64 = URL_SAFE_NO_PAD.encode(payload_json.as_bytes());
+    let signing_input = format!("{VERSION}.{payload_b64}");
+    let sig = hmac_sha256(signing_key, signing_input.as_bytes());
+    let sig_b64 = URL_SAFE_NO_PAD.encode(sig);
+    format!("{signing_input}.{sig_b64}")
+}
+
+/// Compute HMAC-SHA256 over `msg` with `key`. Never fails (HMAC accepts keys
+/// of any length).
+fn hmac_sha256(key: &[u8], msg: &[u8]) -> Vec<u8> {
+    // HMAC accepts keys of any length, so `new_from_slice` cannot fail here.
+    // Handle the Result without panicking (production code forbids unwrap/
+    // expect); on the impossible error path return an empty MAC, which compares
+    // unequal to any real signature — i.e. fails closed.
+    match HmacSha256::new_from_slice(key) {
+        Ok(mut mac) => {
+            mac.update(msg);
+            mac.finalize().into_bytes().to_vec()
+        }
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Revocation denylist backed by a text file: one revoked token `id` per line.
+/// Blank lines and `#` comments are ignored. The file is re-read whenever its
+/// mtime changes (stat per check, reparse only on change), so revocation takes
+/// effect without restarting the process.
+struct RevocationList {
+    path: Option<PathBuf>,
+    cache: Mutex<RevocationCache>,
+}
+
+#[derive(Default)]
+struct RevocationCache {
+    /// The mtime observed when `ids` was last loaded.
+    mtime: Option<SystemTime>,
+    /// Whether we have loaded at least once (so a missing/empty file is cached).
+    loaded: bool,
+    ids: HashSet<String>,
+}
+
+impl RevocationList {
+    fn new(path: Option<PathBuf>) -> Self {
+        Self {
+            path,
+            cache: Mutex::new(RevocationCache::default()),
+        }
+    }
+
+    /// Return `true` if `id` is currently revoked. Reloads the backing file
+    /// when its mtime has changed since the last check.
+    fn is_revoked(&self, id: &str) -> bool {
+        let Some(ref path) = self.path else {
+            return false;
+        };
+
+        // Stat the file. If it cannot be stat'd, treat as "no revocations"
+        // (fail open ONLY for the denylist — a missing denylist file means
+        // nothing is revoked; auth itself still requires a valid signature).
+        let current_mtime = std::fs::metadata(path).and_then(|m| m.modified()).ok();
+
+        let mut cache = self.cache.lock();
+        if !cache.loaded || cache.mtime != current_mtime {
+            cache.ids = match std::fs::read_to_string(path) {
+                Ok(contents) => parse_revocation_file(&contents),
+                Err(_) => HashSet::new(),
+            };
+            cache.mtime = current_mtime;
+            cache.loaded = true;
+        }
+        cache.ids.contains(id)
+    }
+}
+
+/// Parse a revocation file: one id per line, ignoring blank lines and lines
+/// whose first non-whitespace character is `#`.
+fn parse_revocation_file(contents: &str) -> HashSet<String> {
+    contents
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| line.to_string())
+        .collect()
+}
+
+/// Resolved authentication configuration for one surface (API or MCP).
+#[derive(Debug, Clone, Default)]
+pub struct VerifierConfig {
+    /// HMAC signing keys. The first is used to mint; ALL are accepted on
+    /// verify (signing-key rotation with overlap).
+    pub signing_keys: Vec<Vec<u8>>,
+    /// Static shared secrets (no expiry), accepted for backward compatibility.
+    pub static_keys: Vec<String>,
+    /// Optional path to the revocation denylist file.
+    pub revoked_file: Option<PathBuf>,
+}
+
+impl VerifierConfig {
+    /// `true` if no signing keys AND no static secrets are configured — i.e.
+    /// auth is effectively unconfigured and the surface should behave as it did
+    /// before this feature existed (loopback allowed, non-loopback refused).
+    pub fn is_unconfigured(&self) -> bool {
+        self.signing_keys.is_empty() && self.static_keys.is_empty()
+    }
+}
+
+/// Stateless signed-token verifier. `Send + Sync` for use in async axum
+/// handlers.
+pub struct TokenVerifier {
+    signing_keys: Vec<Vec<u8>>,
+    static_keys: Vec<String>,
+    revocation: RevocationList,
+}
+
+impl TokenVerifier {
+    /// Build a verifier from a resolved [`VerifierConfig`].
+    pub fn new(config: VerifierConfig) -> Self {
+        Self {
+            signing_keys: config.signing_keys,
+            static_keys: config.static_keys,
+            revocation: RevocationList::new(config.revoked_file),
+        }
+    }
+
+    /// `true` if neither signing keys nor static secrets are configured.
+    pub fn is_unconfigured(&self) -> bool {
+        self.signing_keys.is_empty() && self.static_keys.is_empty()
+    }
+
+    /// Verify a presented Authorization value (the part after `Bearer `).
+    ///
+    /// Returns `true` iff the value is either:
+    /// - a valid, unexpired, non-revoked `s1.` token signed by one of the
+    ///   configured signing keys; or
+    /// - an exact (constant-time) match for one of the configured static
+    ///   secrets.
+    ///
+    /// `now_unix` is the current time in Unix epoch seconds (production passes
+    /// `chrono::Utc::now().timestamp()`); injecting it keeps expiry logic
+    /// deterministically testable. Fails closed on any parse/format error.
+    pub fn verify(&self, presented: &str, now_unix: i64) -> bool {
+        // Try the signed-token path first.
+        if let Some(result) = self.verify_signed(presented, now_unix) {
+            return result;
+        }
+        // Fall back to static-secret comparison (no expiry).
+        self.verify_static(presented)
+    }
+
+    /// Attempt signed-token verification. Returns `None` if `presented` is not
+    /// a structurally-recognizable `s1.` token (so the caller can fall back to
+    /// static secrets); `Some(true)`/`Some(false)` for accept/reject of a token
+    /// that *is* an `s1.` token.
+    fn verify_signed(&self, presented: &str, now_unix: i64) -> Option<bool> {
+        // Split into exactly 3 dot-parts.
+        let mut parts = presented.split('.');
+        let version = parts.next()?;
+        let payload_b64 = parts.next()?;
+        let sig_b64 = parts.next()?;
+        if parts.next().is_some() {
+            // More than 3 parts — not our format.
+            return None;
+        }
+        if version != VERSION {
+            // Not an s1 token — let static fallback handle it.
+            return None;
+        }
+        // From here on this is unambiguously an s1 token; any failure rejects.
+
+        // Decode the presented signature.
+        let Ok(presented_sig) = URL_SAFE_NO_PAD.decode(sig_b64) else {
+            return Some(false);
+        };
+
+        // Recompute HMAC over "s1." + payload_b64 and compare in constant time
+        // against ALL signing keys (rotation with overlap).
+        let signing_input = format!("{VERSION}.{payload_b64}");
+        let mut sig_ok = false;
+        for key in &self.signing_keys {
+            let expected = hmac_sha256(key, signing_input.as_bytes());
+            // OR rather than early-return so the comparison cost does not leak
+            // which key (if any) matched.
+            sig_ok |= constant_time_eq(&presented_sig, &expected);
+        }
+        if !sig_ok {
+            return Some(false);
+        }
+
+        // Decode + parse the payload.
+        let Ok(payload_bytes) = URL_SAFE_NO_PAD.decode(payload_b64) else {
+            return Some(false);
+        };
+        let Ok(payload) = serde_json::from_slice::<Payload>(&payload_bytes) else {
+            return Some(false);
+        };
+
+        // Expiry: require exp strictly greater than now.
+        if payload.exp <= now_unix {
+            return Some(false);
+        }
+
+        // Revocation denylist.
+        if self.revocation.is_revoked(&payload.id) {
+            return Some(false);
+        }
+
+        Some(true)
+    }
+
+    /// Constant-time comparison against each configured static secret.
+    fn verify_static(&self, presented: &str) -> bool {
+        let mut ok = false;
+        for key in &self.static_keys {
+            ok |= constant_time_eq(presented.as_bytes(), key.as_bytes());
+        }
+        ok
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY_A: &[u8] = b"signing-key-alpha-0123456789";
+    const KEY_B: &[u8] = b"signing-key-beta-9876543210";
+
+    fn verifier(cfg: VerifierConfig) -> TokenVerifier {
+        TokenVerifier::new(cfg)
+    }
+
+    // ── constant_time_eq hardening tests (relocated from output::api) ──
+
+    #[test]
+    fn constant_time_eq_equal_slices() {
+        assert!(
+            constant_time_eq(b"secret-key-12345", b"secret-key-12345"),
+            "Identical slices should return true"
+        );
+    }
+
+    #[test]
+    fn constant_time_eq_different_slices() {
+        assert!(
+            !constant_time_eq(b"secret-key-12345", b"secret-key-XXXXX"),
+            "Different slices of same length should return false"
+        );
+    }
+
+    #[test]
+    fn constant_time_eq_different_lengths() {
+        assert!(
+            !constant_time_eq(b"short", b"much-longer-string"),
+            "Different length slices should return false"
+        );
+        assert!(
+            !constant_time_eq(b"much-longer-string", b"short"),
+            "Different length slices (reversed) should return false"
+        );
+    }
+
+    #[test]
+    fn constant_time_eq_empty() {
+        assert!(
+            constant_time_eq(b"", b""),
+            "Two empty slices should return true"
+        );
+    }
+
+    // ── token format ──────────────────────────────────────────────────
+
+    #[test]
+    fn minted_token_has_expected_shape() {
+        let token = mint(KEY_A, "abc", 9999999999);
+        let parts: Vec<&str> = token.split('.').collect();
+        assert_eq!(parts.len(), 3, "token should have 3 dot-parts: {token}");
+        assert_eq!(parts[0], "s1");
+        // Payload decodes to compact JSON with id+exp.
+        let payload = URL_SAFE_NO_PAD.decode(parts[1]).expect("payload b64");
+        let s = String::from_utf8(payload).expect("utf8");
+        assert_eq!(s, "{\"id\":\"abc\",\"exp\":9999999999}");
+    }
+
+    // ── valid / accept ─────────────────────────────────────────────────
+
+    #[test]
+    fn valid_token_accepted() {
+        let v = verifier(VerifierConfig {
+            signing_keys: vec![KEY_A.to_vec()],
+            ..Default::default()
+        });
+        let token = mint(KEY_A, "id1", 1_000);
+        assert!(v.verify(&token, 999), "unexpired token should verify");
+    }
+
+    // ── expired ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn expired_token_rejected() {
+        let v = verifier(VerifierConfig {
+            signing_keys: vec![KEY_A.to_vec()],
+            ..Default::default()
+        });
+        let token = mint(KEY_A, "id1", 1_000);
+        // now == exp → reject (exp must be strictly greater than now).
+        assert!(!v.verify(&token, 1_000), "exp == now should reject");
+        // now > exp → reject.
+        assert!(!v.verify(&token, 1_001), "expired token should reject");
+    }
+
+    // ── tampered payload ────────────────────────────────────────────────
+
+    #[test]
+    fn tampered_payload_rejected() {
+        let v = verifier(VerifierConfig {
+            signing_keys: vec![KEY_A.to_vec()],
+            ..Default::default()
+        });
+        let token = mint(KEY_A, "id1", 1_000_000);
+        let mut parts: Vec<String> = token.split('.').map(String::from).collect();
+        // Flip a byte in the payload b64. Pick a char and replace with another.
+        let payload = parts[1].clone();
+        let mut bytes = payload.into_bytes();
+        let idx = bytes.len() / 2;
+        bytes[idx] = if bytes[idx] == b'A' { b'B' } else { b'A' };
+        parts[1] = String::from_utf8(bytes).unwrap();
+        let tampered = parts.join(".");
+        assert!(
+            !v.verify(&tampered, 1),
+            "tampered payload must fail signature/parse"
+        );
+    }
+
+    // ── forged / wrong-key signature ─────────────────────────────────────
+
+    #[test]
+    fn forged_wrong_key_signature_rejected() {
+        let v = verifier(VerifierConfig {
+            signing_keys: vec![KEY_A.to_vec()],
+            ..Default::default()
+        });
+        // Token signed with a DIFFERENT key.
+        let forged = mint(KEY_B, "id1", 1_000_000);
+        assert!(
+            !v.verify(&forged, 1),
+            "token signed with a non-configured key must reject"
+        );
+    }
+
+    #[test]
+    fn garbage_token_rejected_no_panic() {
+        let v = verifier(VerifierConfig {
+            signing_keys: vec![KEY_A.to_vec()],
+            ..Default::default()
+        });
+        for junk in [
+            "",
+            "s1",
+            "s1.",
+            "s1..",
+            "s1.@@@.@@@",
+            "s2.aaaa.bbbb",
+            "s1.aaaa.bbbb.cccc",
+            "not-a-token",
+            "s1.\0.\0",
+        ] {
+            assert!(
+                !v.verify(junk, 1),
+                "junk {junk:?} must reject without panic"
+            );
+        }
+    }
+
+    // ── rotation ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn rotation_accepts_either_key() {
+        let v = verifier(VerifierConfig {
+            signing_keys: vec![KEY_A.to_vec(), KEY_B.to_vec()],
+            ..Default::default()
+        });
+        let token_a = mint(KEY_A, "ida", 1_000_000);
+        let token_b = mint(KEY_B, "idb", 1_000_000);
+        assert!(v.verify(&token_a, 1), "token signed by first key accepted");
+        assert!(v.verify(&token_b, 1), "token signed by second key accepted");
+    }
+
+    #[test]
+    fn mint_uses_first_key() {
+        // A verifier that only knows KEY_B should reject a token minted by the
+        // "first key" of a {A,B} config (which is A).
+        let mint_cfg_first = KEY_A;
+        let token = mint(mint_cfg_first, "x", 1_000_000);
+        let v_b_only = verifier(VerifierConfig {
+            signing_keys: vec![KEY_B.to_vec()],
+            ..Default::default()
+        });
+        assert!(!v_b_only.verify(&token, 1));
+    }
+
+    // ── revocation ───────────────────────────────────────────────────────
+
+    #[test]
+    fn revoked_id_rejected_and_reload_works() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("revoked.txt");
+        std::fs::write(&path, "# comment\n\nrevoked-id-1\n").expect("write");
+
+        let v = verifier(VerifierConfig {
+            signing_keys: vec![KEY_A.to_vec()],
+            revoked_file: Some(path.clone()),
+            ..Default::default()
+        });
+
+        // A token with a revoked id is rejected even though the signature is
+        // valid and it is unexpired.
+        let revoked = mint(KEY_A, "revoked-id-1", 1_000_000);
+        assert!(!v.verify(&revoked, 1), "revoked id must reject");
+
+        // A fresh token with a different id is accepted.
+        let fresh = mint(KEY_A, "fresh-id", 1_000_000);
+        assert!(v.verify(&fresh, 1), "non-revoked id must accept");
+
+        // Remove the revocation from the file; the previously-revoked id is now
+        // accepted (mtime change triggers a reload). Touch mtime explicitly in
+        // case the filesystem mtime granularity would otherwise collapse the
+        // two writes.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::fs::write(&path, "# nothing revoked now\n").expect("rewrite");
+        let after = mint(KEY_A, "revoked-id-1", 1_000_000);
+        assert!(
+            v.verify(&after, 1),
+            "after removing from denylist, id should be accepted (reload)"
+        );
+    }
+
+    // ── backward compat (static secrets) ────────────────────────────────
+
+    #[test]
+    fn static_secret_backward_compat() {
+        let v = verifier(VerifierConfig {
+            static_keys: vec!["legacy-secret".to_string()],
+            ..Default::default()
+        });
+        assert!(
+            v.verify("legacy-secret", 1),
+            "correct static secret accepts"
+        );
+        assert!(!v.verify("wrong-secret", 1), "wrong static secret rejects");
+        // Static secrets never expire — now_unix is irrelevant for them.
+        assert!(
+            v.verify("legacy-secret", i64::MAX),
+            "static secret has no expiry"
+        );
+    }
+
+    #[test]
+    fn static_secret_does_not_collide_with_signed_format() {
+        // A static secret that happens to look like "s1.foo.bar" is NOT a valid
+        // signed token (bad b64 / signature), so it falls through to the static
+        // comparison and matches itself.
+        let secret = "s1.notreal.notreal";
+        let v = verifier(VerifierConfig {
+            static_keys: vec![secret.to_string()],
+            ..Default::default()
+        });
+        // "s1.notreal.notreal" — b64 "notreal" decodes fine, but signature
+        // mismatch → verify_signed returns Some(false), so the static fallback
+        // is NOT reached. This is acceptable: do not pick static secrets that
+        // look like s1 tokens. Document via assertion.
+        assert!(!v.verify(secret, 1));
+    }
+
+    #[test]
+    fn signing_and_static_both_configured() {
+        let v = verifier(VerifierConfig {
+            signing_keys: vec![KEY_A.to_vec()],
+            static_keys: vec!["legacy".to_string()],
+            ..Default::default()
+        });
+        let token = mint(KEY_A, "id", 1_000_000);
+        assert!(v.verify(&token, 1), "signed token accepts");
+        assert!(v.verify("legacy", 1), "static secret accepts");
+        assert!(!v.verify("nope", 1), "unknown rejects");
+    }
+
+    #[test]
+    fn unconfigured_verifier() {
+        let v = verifier(VerifierConfig::default());
+        assert!(v.is_unconfigured());
+        // With nothing configured, even a well-formed-looking token rejects
+        // (no key to verify against, no static secret to match).
+        assert!(!v.verify("anything", 1));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -418,9 +418,34 @@ pub struct Cli {
     #[arg(long, value_name = "ADDR")]
     pub api: Option<String>,
 
-    /// API key for REST API authentication.
+    /// API key for REST API authentication (static shared secret, no expiry).
     #[arg(long, value_name = "KEY", env = "SIPNAB_API_KEY")]
     pub api_key: Option<String>,
+
+    /// HMAC signing key for REST API self-describing bearer tokens
+    /// (repeatable). The FIRST key mints; ALL keys are accepted on verify,
+    /// enabling signing-key rotation with overlap. Also read from
+    /// SIPNAB_API_SIGNING_KEY.
+    #[arg(
+        long = "api-signing-key",
+        value_name = "KEY",
+        env = "SIPNAB_API_SIGNING_KEY"
+    )]
+    pub api_signing_key: Vec<String>,
+
+    /// Read one REST API HMAC signing key from a file (contents trimmed).
+    /// Prepended to any --api-signing-key values so it is the minting key.
+    #[arg(long = "api-signing-key-file", value_name = "FILE")]
+    pub api_signing_key_file: Option<String>,
+
+    /// Revocation denylist file for REST API tokens: one revoked token id per
+    /// line (blanks and `#` comments ignored). Reloaded when the file changes.
+    #[arg(long = "api-revoked-file", value_name = "FILE")]
+    pub api_revoked_file: Option<String>,
+
+    /// TTL in seconds for a minted REST API token (used with --mint-token).
+    #[arg(long = "api-token-ttl", value_name = "SECS", default_value = "3600")]
+    pub api_token_ttl: i64,
 
     /// TLS certificate for API endpoint.
     #[arg(long, value_name = "FILE")]
@@ -462,6 +487,31 @@ pub struct Cli {
     /// systemd units).
     #[arg(long = "mcp-token-file", value_name = "FILE")]
     pub mcp_token_file: Option<String>,
+
+    /// HMAC signing key for HTTP MCP self-describing bearer tokens
+    /// (repeatable). The FIRST key mints; ALL keys are accepted on verify,
+    /// enabling signing-key rotation with overlap. Also read from
+    /// SIPNAB_MCP_SIGNING_KEY.
+    #[arg(
+        long = "mcp-signing-key",
+        value_name = "KEY",
+        env = "SIPNAB_MCP_SIGNING_KEY"
+    )]
+    pub mcp_signing_key: Vec<String>,
+
+    /// Read one HTTP MCP HMAC signing key from a file (contents trimmed).
+    /// Prepended to any --mcp-signing-key values so it is the minting key.
+    #[arg(long = "mcp-signing-key-file", value_name = "FILE")]
+    pub mcp_signing_key_file: Option<String>,
+
+    /// Revocation denylist file for HTTP MCP tokens: one revoked token id per
+    /// line (blanks and `#` comments ignored). Reloaded when the file changes.
+    #[arg(long = "mcp-revoked-file", value_name = "FILE")]
+    pub mcp_revoked_file: Option<String>,
+
+    /// TTL in seconds for a minted HTTP MCP token (used with --mint-token).
+    #[arg(long = "mcp-token-ttl", value_name = "SECS", default_value = "3600")]
+    pub mcp_token_ttl: i64,
 
     /// Additional `Host` header values the HTTP MCP server will accept
     /// (repeatable). rmcp's DNS-rebind protection defaults to allowing
@@ -542,6 +592,18 @@ pub struct Cli {
     /// Maximum concurrent TCP/TLS reassembly sessions.
     #[arg(long, value_name = "N", default_value = "10000")]
     pub max_reassembly: u64,
+
+    // ── Token minting ────────────────────────────────────────────────
+    /// Mint a signed bearer token from the first configured signing key,
+    /// print it to stdout, and exit. TTL comes from --api-token-ttl (or
+    /// --mcp-token-ttl); id from --token-id (or auto-derived). Does NOT start
+    /// capture or any server.
+    #[arg(long = "mint-token")]
+    pub mint_token: bool,
+
+    /// Token id (jti) for --mint-token. Defaults to a derived unique id.
+    #[arg(long = "token-id", value_name = "ID")]
+    pub token_id: Option<String>,
 
     // ── Config ───────────────────────────────────────────────────────
     /// Path to configuration file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 
 // Every public item must be documented; keeps the library surface usable.
 #![warn(missing_docs)]
+#[cfg(any(feature = "api", feature = "mcp"))]
+pub mod auth;
 pub mod capture;
 #[doc(hidden)]
 #[cfg(feature = "native")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,27 @@ fn main() {
     // 4a. Warn about unimplemented flags that were set
     cli.warn_unimplemented_flags();
 
+    // 4b. --mint-token: mint a signed bearer token and exit. Does NOT start
+    // capture or any server. Gated to builds with auth (api or mcp).
+    #[cfg(any(feature = "api", feature = "mcp"))]
+    if cli.mint_token {
+        match mint_token_and_exit(&cli) {
+            Ok(token) => {
+                println!("{token}");
+                std::process::exit(0);
+            }
+            Err(msg) => {
+                tracing::error!("{msg}");
+                std::process::exit(2);
+            }
+        }
+    }
+    #[cfg(not(any(feature = "api", feature = "mcp")))]
+    if cli.mint_token {
+        tracing::error!("--mint-token requires the 'api' or 'mcp' feature (not compiled in)");
+        std::process::exit(2);
+    }
+
     // 5. Load configuration
     let loaded = match Config::load(cli.config.as_deref(), cli.no_config) {
         Ok(loaded) => {
@@ -2053,6 +2074,141 @@ fn build_capture_config(cli: &Cli, config: &Config) -> CaptureConfig {
     }
 }
 
+// ── Auth / token helpers ───────────────────────────────────────────
+
+/// Read one signing key from a file (contents trimmed). Logs and exits on
+/// failure (a misconfigured key file is fatal).
+#[cfg(any(feature = "api", feature = "mcp"))]
+fn read_signing_key_file(path: &str, flag: &str) -> Vec<u8> {
+    match std::fs::read_to_string(path) {
+        Ok(s) => s.trim().as_bytes().to_vec(),
+        Err(e) => {
+            tracing::error!("{flag} '{path}': {e}");
+            std::process::exit(2);
+        }
+    }
+}
+
+/// Resolve the REST API auth config (signing keys + static secret + revocation
+/// file) from the CLI into an `auth::VerifierConfig`.
+#[cfg(feature = "api")]
+fn resolve_api_verifier_config(cli: &Cli) -> sipnab::auth::VerifierConfig {
+    let mut signing_keys: Vec<Vec<u8>> = Vec::new();
+    // File key first so it is the minting key.
+    if let Some(ref path) = cli.api_signing_key_file {
+        signing_keys.push(read_signing_key_file(path, "--api-signing-key-file"));
+    }
+    for k in &cli.api_signing_key {
+        if !k.is_empty() {
+            signing_keys.push(k.as_bytes().to_vec());
+        }
+    }
+    let static_keys: Vec<String> = cli
+        .api_key
+        .iter()
+        .filter(|k| !k.is_empty())
+        .cloned()
+        .collect();
+    sipnab::auth::VerifierConfig {
+        signing_keys,
+        static_keys,
+        revoked_file: cli.api_revoked_file.as_ref().map(std::path::PathBuf::from),
+    }
+}
+
+/// Resolve the HTTP MCP auth config from the CLI. The MCP token resolution
+/// order (`--mcp-token` > `--mcp-token-file` > env) is preserved for the
+/// static-secret fallback.
+#[cfg(feature = "mcp")]
+fn resolve_mcp_verifier_config(cli: &Cli) -> sipnab::auth::VerifierConfig {
+    let mut signing_keys: Vec<Vec<u8>> = Vec::new();
+    if let Some(ref path) = cli.mcp_signing_key_file {
+        signing_keys.push(read_signing_key_file(path, "--mcp-signing-key-file"));
+    }
+    for k in &cli.mcp_signing_key {
+        if !k.is_empty() {
+            signing_keys.push(k.as_bytes().to_vec());
+        }
+    }
+
+    // Static secret: --mcp-token > --mcp-token-file > SIPNAB_MCP_TOKEN (env is
+    // folded into --mcp-token by clap). Trim file contents.
+    let mut static_keys: Vec<String> = Vec::new();
+    if let Some(t) = cli.mcp_token.as_ref() {
+        let t = t.trim();
+        if !t.is_empty() {
+            static_keys.push(t.to_string());
+        }
+    } else if let Some(path) = cli.mcp_token_file.as_ref() {
+        match std::fs::read_to_string(path) {
+            Ok(s) => {
+                let s = s.trim();
+                if !s.is_empty() {
+                    static_keys.push(s.to_string());
+                }
+            }
+            Err(e) => {
+                tracing::error!("--mcp-token-file '{path}': {e}");
+                std::process::exit(2);
+            }
+        }
+    }
+
+    sipnab::auth::VerifierConfig {
+        signing_keys,
+        static_keys,
+        revoked_file: cli.mcp_revoked_file.as_ref().map(std::path::PathBuf::from),
+    }
+}
+
+/// Mint a signed token from the CLI configuration and return it. Picks the
+/// surface (API vs MCP) based on which signing keys are configured. Returns an
+/// error message string on misconfiguration.
+#[cfg(any(feature = "api", feature = "mcp"))]
+fn mint_token_and_exit(cli: &Cli) -> Result<String, String> {
+    // Gather the first signing key + TTL, preferring API config, then MCP.
+    #[allow(unused_mut)]
+    let mut first_key: Option<Vec<u8>> = None;
+    #[allow(unused_mut)]
+    let mut ttl: i64 = 3600;
+
+    #[cfg(feature = "api")]
+    {
+        if cli.api_signing_key_file.is_some() || !cli.api_signing_key.is_empty() {
+            let cfg = resolve_api_verifier_config(cli);
+            first_key = cfg.signing_keys.into_iter().next();
+            ttl = cli.api_token_ttl;
+        }
+    }
+    #[cfg(feature = "mcp")]
+    if first_key.is_none()
+        && (cli.mcp_signing_key_file.is_some() || !cli.mcp_signing_key.is_empty())
+    {
+        let cfg = resolve_mcp_verifier_config(cli);
+        first_key = cfg.signing_keys.into_iter().next();
+        ttl = cli.mcp_token_ttl;
+    }
+
+    let key = first_key.ok_or_else(|| {
+        "--mint-token requires at least one --api-signing-key/--api-signing-key-file \
+         or --mcp-signing-key/--mcp-signing-key-file"
+            .to_string()
+    })?;
+
+    if ttl <= 0 {
+        return Err(format!("token TTL must be positive, got {ttl}"));
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let exp = now.saturating_add(ttl);
+    let id = cli
+        .token_id
+        .clone()
+        .unwrap_or_else(|| format!("tok-{}", chrono::Utc::now().timestamp_micros()));
+
+    Ok(sipnab::auth::mint(&key, &id, exp))
+}
+
 // ── API server ─────────────────────────────────────────────────────
 
 /// Start the REST API server in a background thread with its own tokio runtime.
@@ -2075,10 +2231,13 @@ fn start_api_server(
         }
     };
 
+    let verifier = Arc::new(sipnab::auth::TokenVerifier::new(
+        resolve_api_verifier_config(cli),
+    ));
     let state = ApiState {
         dialog_store,
         stream_store,
-        api_key: cli.api_key.clone(),
+        verifier,
         rate_limiter: Arc::new(parking_lot::Mutex::new(RateLimiter::new(100))),
     };
 
@@ -2192,21 +2351,9 @@ fn start_mcp_http_server(
         }
     };
 
-    // Resolve token: --mcp-token > --mcp-token-file > SIPNAB_MCP_TOKEN.
-    let token: Option<String> = if let Some(t) = cli.mcp_token.as_ref() {
-        Some(t.trim().to_string())
-    } else if let Some(path) = cli.mcp_token_file.as_ref() {
-        match std::fs::read_to_string(path) {
-            Ok(s) => Some(s.trim().to_string()),
-            Err(e) => {
-                tracing::error!("--mcp-token-file '{path}': {e}");
-                return None;
-            }
-        }
-    } else {
-        None
-    }
-    .filter(|s| !s.is_empty());
+    // Resolve auth: HMAC signing keys + static secret (--mcp-token >
+    // --mcp-token-file > SIPNAB_MCP_TOKEN) + revocation file.
+    let auth_config = resolve_mcp_verifier_config(cli);
 
     let extra_allowed_hosts = cli.mcp_allowed_host.clone();
 
@@ -2225,9 +2372,13 @@ fn start_mcp_http_server(
                 }
             };
             runtime.block_on(async move {
-                if let Err(e) =
-                    sipnab::mcp::transport::serve_http(server, bind, token, extra_allowed_hosts)
-                        .await
+                if let Err(e) = sipnab::mcp::transport::serve_http(
+                    server,
+                    bind,
+                    auth_config,
+                    extra_allowed_hosts,
+                )
+                .await
                 {
                     tracing::error!("MCP HTTP server error: {e}");
                 }

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -16,8 +16,9 @@
 //!
 //! - Default bind is `127.0.0.1:8731` (D18 localhost-default).
 //! - Non-loopback bind without bearer token is refused.
-//! - Bearer tokens compared via constant-time comparison reusing
-//!   `output::api::constant_time_eq`.
+//! - Bearer tokens verified via `auth::TokenVerifier` (signed `s1.` tokens
+//!   with expiry/rotation/revocation, plus constant-time static-secret
+//!   fallback).
 
 use super::server::SipnabMcp;
 use rmcp::ServiceExt;
@@ -46,19 +47,20 @@ mod http {
     };
 
     use super::SipnabMcp;
-    use crate::output::api::constant_time_eq;
+    use crate::auth::{TokenVerifier, VerifierConfig};
 
     /// HTTP-server context passed through axum middleware.
     #[derive(Clone)]
     struct McpHttpState {
-        /// Resolved bearer token. None means "no auth required" — only
-        /// allowed when bind is loopback.
-        token: Option<Arc<String>>,
+        /// Bearer-token verifier (signed tokens + static secrets + revocation).
+        /// When unconfigured (no signing keys, no static secret) auth is
+        /// disabled — only allowed when bind is loopback.
+        verifier: Arc<TokenVerifier>,
     }
 
-    /// Bearer-token guard. On loopback with no token configured the request
+    /// Bearer-token guard. On loopback with no auth configured the request
     /// passes; otherwise the `Authorization: Bearer` header is required and
-    /// compared in constant time.
+    /// verified (signed token or static secret, constant-time).
     async fn auth_layer(
         axum::extract::State(state): axum::extract::State<McpHttpState>,
         ConnectInfo(_addr): ConnectInfo<SocketAddr>,
@@ -66,13 +68,16 @@ mod http {
         request: axum::extract::Request,
         next: Next,
     ) -> Result<Response, StatusCode> {
-        if let Some(token) = state.token.as_deref() {
+        if !state.verifier.is_unconfigured() {
             let provided = headers
                 .get(axum::http::header::AUTHORIZATION)
                 .and_then(|v| v.to_str().ok())
                 .and_then(|v| v.strip_prefix("Bearer "))
                 .ok_or(StatusCode::UNAUTHORIZED)?;
-            if !constant_time_eq(provided.as_bytes(), token.as_bytes()) {
+            if !state
+                .verifier
+                .verify(provided, chrono::Utc::now().timestamp())
+            {
                 return Err(StatusCode::UNAUTHORIZED);
             }
         }
@@ -86,15 +91,16 @@ mod http {
     pub async fn serve_http(
         server: SipnabMcp,
         bind: SocketAddr,
-        token: Option<String>,
+        auth_config: VerifierConfig,
         extra_allowed_hosts: Vec<String>,
     ) -> anyhow::Result<()> {
         // Refuse non-loopback bind without auth (D18 + 8.2 rule).
-        if !bind.ip().is_loopback() && token.is_none() {
+        if !bind.ip().is_loopback() && auth_config.is_unconfigured() {
             anyhow::bail!(
                 "MCP HTTP refuses to start: --mcp-bind {bind} is non-loopback \
-                 but no --mcp-token / --mcp-token-file / SIPNAB_MCP_TOKEN was \
-                 supplied. See D18 in the v6 plan."
+                 but no --mcp-token / --mcp-token-file / SIPNAB_MCP_TOKEN / \
+                 --mcp-signing-key / --mcp-signing-key-file / \
+                 SIPNAB_MCP_SIGNING_KEY was supplied. See D18 in the v6 plan."
             );
         }
         if !bind.ip().is_loopback() {
@@ -106,7 +112,7 @@ mod http {
 
         let session_mgr = Arc::new(LocalSessionManager::default());
         let state = McpHttpState {
-            token: token.map(Arc::new),
+            verifier: Arc::new(TokenVerifier::new(auth_config)),
         };
 
         // Apply --mcp-allowed-host overrides on top of rmcp's defaults

--- a/src/output/api.rs
+++ b/src/output/api.rs
@@ -18,8 +18,13 @@
 //!
 //! # Authentication
 //!
-//! If `--api-key` is provided, all endpoints (except `/health`) require
-//! `Authorization: Bearer <key>`. Missing or invalid keys return 401.
+//! If a static `--api-key` and/or one or more HMAC signing keys
+//! (`--api-signing-key`/`--api-signing-key-file`) are configured, all
+//! endpoints (except `/health`) require `Authorization: Bearer <token>`.
+//! Bearer values may be self-describing signed `s1.` tokens (with expiry,
+//! signing-key rotation, and revocation via `--api-revoked-file`) or the
+//! static API key. Missing or invalid credentials return 401. See
+//! [`crate::auth`].
 //!
 //! # Rate Limiting
 //!
@@ -57,8 +62,8 @@ pub struct ApiState {
     pub dialog_store: Arc<RwLock<DialogStore>>,
     /// Shared RTP stream store (same instance used by capture threads).
     pub stream_store: Arc<RwLock<StreamStore>>,
-    /// Optional bearer token for API authentication.
-    pub api_key: Option<String>,
+    /// Bearer-token verifier (signed tokens + static secrets + revocation).
+    pub verifier: Arc<crate::auth::TokenVerifier>,
     /// Per-IP rate limiter.
     pub rate_limiter: Arc<Mutex<RateLimiter>>,
 }
@@ -287,9 +292,11 @@ pub async fn run_server(
 
 /// Check authentication. Returns `Err(StatusCode)` if auth fails.
 fn check_auth(state: &ApiState, headers: &HeaderMap) -> Result<(), StatusCode> {
-    let Some(ref expected_key) = state.api_key else {
+    // No signing keys and no static secret configured ⇒ auth disabled
+    // (loopback-allowed behavior unchanged from before this feature).
+    if state.verifier.is_unconfigured() {
         return Ok(());
-    };
+    }
 
     let Some(auth_header) = headers.get("authorization") else {
         return Err(StatusCode::UNAUTHORIZED);
@@ -298,34 +305,12 @@ fn check_auth(state: &ApiState, headers: &HeaderMap) -> Result<(), StatusCode> {
     let auth_str = auth_header.to_str().map_err(|_| StatusCode::UNAUTHORIZED)?;
 
     if let Some(token) = auth_str.strip_prefix("Bearer ")
-        && constant_time_eq(token.as_bytes(), expected_key.as_bytes())
+        && state.verifier.verify(token, chrono::Utc::now().timestamp())
     {
         return Ok(());
     }
 
     Err(StatusCode::UNAUTHORIZED)
-}
-
-/// Constant-time byte comparison to prevent timing side-channel attacks on API keys.
-///
-/// Does not leak the length of either input: both are compared up to
-/// the length of the longer input, and the length check is folded into
-/// the final result without early return.
-///
-/// `#[inline(never)]` prevents the optimizer from rewriting the loop into
-/// a short-circuiting form. `black_box` on the accumulator forces the
-/// compiler to materialize it, blocking dead-store elimination.
-#[inline(never)]
-pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    let len_match = a.len() == b.len();
-    let max_len = a.len().max(b.len());
-    let mut byte_diff = 0u8;
-    for i in 0..max_len {
-        let x = a.get(i).copied().unwrap_or(0);
-        let y = b.get(i).copied().unwrap_or(0);
-        byte_diff |= x ^ y;
-    }
-    len_match && std::hint::black_box(byte_diff) == 0
 }
 
 /// Check rate limit. Returns `Err(StatusCode)` if over limit.
@@ -776,7 +761,9 @@ mod tests {
         ApiState {
             dialog_store: Arc::new(RwLock::new(DialogStore::new(1000, false))),
             stream_store: Arc::new(RwLock::new(StreamStore::new(1000))),
-            api_key: None,
+            verifier: Arc::new(crate::auth::TokenVerifier::new(
+                crate::auth::VerifierConfig::default(),
+            )),
             rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
         }
     }
@@ -785,7 +772,12 @@ mod tests {
         ApiState {
             dialog_store: Arc::new(RwLock::new(DialogStore::new(1000, false))),
             stream_store: Arc::new(RwLock::new(StreamStore::new(1000))),
-            api_key: Some(key.to_string()),
+            verifier: Arc::new(crate::auth::TokenVerifier::new(
+                crate::auth::VerifierConfig {
+                    static_keys: vec![key.to_string()],
+                    ..Default::default()
+                },
+            )),
             rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
         }
     }
@@ -961,6 +953,60 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    fn make_state_with_signing_key(key: &[u8]) -> ApiState {
+        ApiState {
+            dialog_store: Arc::new(RwLock::new(DialogStore::new(1000, false))),
+            stream_store: Arc::new(RwLock::new(StreamStore::new(1000))),
+            verifier: Arc::new(crate::auth::TokenVerifier::new(
+                crate::auth::VerifierConfig {
+                    signing_keys: vec![key.to_vec()],
+                    ..Default::default()
+                },
+            )),
+            rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
+        }
+    }
+
+    #[tokio::test]
+    async fn auth_valid_signed_token_returns_200() {
+        let key = b"router-signing-key";
+        let state = make_state_with_signing_key(key);
+        populate_dialogs(&state);
+        let app = build_router(state);
+        // exp far in the future.
+        let token = crate::auth::mint(key, "id1", chrono::Utc::now().timestamp() + 3600);
+        let req =
+            test_request_with_header("/v1/dialogs", "Authorization", &format!("Bearer {token}"));
+        let resp = app.oneshot(req).await.expect("oneshot");
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn auth_expired_signed_token_returns_401() {
+        let key = b"router-signing-key";
+        let state = make_state_with_signing_key(key);
+        let app = build_router(state);
+        // exp already in the past — deterministic, no sleeping.
+        let token = crate::auth::mint(key, "id1", chrono::Utc::now().timestamp() - 1);
+        let req =
+            test_request_with_header("/v1/dialogs", "Authorization", &format!("Bearer {token}"));
+        let resp = app.oneshot(req).await.expect("oneshot");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn auth_forged_signed_token_returns_401() {
+        let key = b"router-signing-key";
+        let state = make_state_with_signing_key(key);
+        let app = build_router(state);
+        // Signed by a different key.
+        let token = crate::auth::mint(b"other-key", "id1", chrono::Utc::now().timestamp() + 3600);
+        let req =
+            test_request_with_header("/v1/dialogs", "Authorization", &format!("Bearer {token}"));
+        let resp = app.oneshot(req).await.expect("oneshot");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
     #[tokio::test]
     async fn pagination_offset_and_limit() {
         let state = make_state();
@@ -1106,7 +1152,9 @@ mod tests {
         let state = ApiState {
             dialog_store: Arc::new(RwLock::new(DialogStore::new(1000, false))),
             stream_store: Arc::new(RwLock::new(StreamStore::new(1000))),
-            api_key: None,
+            verifier: Arc::new(crate::auth::TokenVerifier::new(
+                crate::auth::VerifierConfig::default(),
+            )),
             rate_limiter: Arc::new(Mutex::new(RateLimiter::new(1))),
         };
         populate_dialogs(&state);
@@ -1137,44 +1185,6 @@ mod tests {
         assert_eq!(percentile(&odd, 50), Some(30));
         assert_eq!(percentile(&odd, 0), Some(10));
         assert_eq!(percentile(&odd, 100), Some(50));
-    }
-
-    // ── constant_time_eq hardening tests ──────────────────────────────
-
-    #[test]
-    fn constant_time_eq_equal_slices() {
-        assert!(
-            constant_time_eq(b"secret-key-12345", b"secret-key-12345"),
-            "Identical slices should return true"
-        );
-    }
-
-    #[test]
-    fn constant_time_eq_different_slices() {
-        assert!(
-            !constant_time_eq(b"secret-key-12345", b"secret-key-XXXXX"),
-            "Different slices of same length should return false"
-        );
-    }
-
-    #[test]
-    fn constant_time_eq_different_lengths() {
-        assert!(
-            !constant_time_eq(b"short", b"much-longer-string"),
-            "Different length slices should return false"
-        );
-        assert!(
-            !constant_time_eq(b"much-longer-string", b"short"),
-            "Different length slices (reversed) should return false"
-        );
-    }
-
-    #[test]
-    fn constant_time_eq_empty() {
-        assert!(
-            constant_time_eq(b"", b""),
-            "Two empty slices should return true"
-        );
     }
 
     // ── Stream-store helpers ──────────────────────────────────────────

--- a/tasks/verification-plan.md
+++ b/tasks/verification-plan.md
@@ -194,7 +194,7 @@ JSON-bearing formats also pass schema validation.
 
 | ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
 |---|---|---|---|---|---|
-| [ ] **T3b.1** | Design the token lifecycle model (decision) | design note appended here | — | S | settles: TTL source (`--api-token-ttl`/`--mcp-token-ttl` + per-token `expires_at` in token file), rotation (N overlapping-valid tokens), revocation (revocation list / removal), and self-describing (signed) vs server-tracked tokens; constant-time compare preserved |
+| [x] **T3b.1** | Design the token lifecycle model (decision) | design note below | — | S | ✅ **RESOLVED: HMAC self-describing tokens** (maintainer choice). Format, signing-key rotation, mint subcommand, denylist revocation, static-key backward-compat, clock seam — see "T3b.1 Design decision" below |
 | [ ] **T3b.2** | Implement expiry+rotation+revocation — **REST API** | `src/output/api.rs`, `src/cli.rs` (new flags), token store module | T3b.1 | L | TDD red→green; expired token → 401; rotation window accepts both; revoked → 401; non-loopback still requires a *valid* token; constant-time retained |
 | [ ] **T3b.3** | Implement expiry+rotation+revocation — **MCP** | `src/mcp/transport.rs`, `src/cli.rs` | T3b.1 | L | same lifecycle semantics as API; http + stdio paths covered |
 | [ ] **T3b.4** | Document the feature | `--help` text, `docs/` (security/auth page → wiki), `CONTRIBUTING.md` | T3b.2, T3b.3 | S | every new flag documented; token lifecycle (issue/use/expire/rotate/revoke) described; `docs_drift_test` green |
@@ -208,6 +208,31 @@ validated** for both API and MCP; the spec §15 token-lifecycle row flips from �
 - **Fails if:** an expired or revoked token is **accepted** (must fail-closed) · rotation drops a
   still-valid token · TTL/clock handling is nondeterministic or flaky · constant-time comparison is
   lost · any token state lacks a registry entry · the feature ships undocumented.
+
+### T3b.1 — Design decision (RESOLVED): HMAC self-describing tokens
+
+Maintainer chose **signed self-describing (HMAC)** over a server-tracked token file.
+
+- **Token format:** `s1.<b64url(payload)>.<b64url(sig)>` where `payload` is compact JSON
+  `{"id":"<jti>","exp":<unix_seconds>}` and `sig = HMAC-SHA256(signing_key, "s1.<b64url(payload)>")`.
+  Stateless verification: recompute the HMAC, **constant-time** compare, check `exp > now`, check `id`
+  not revoked.
+- **Signing key(s):** `--api-signing-key` (repeatable; also `--api-signing-key-file` / env
+  `SIPNAB_API_SIGNING_KEY`) and the MCP equivalents. The **first** key mints; **all** are accepted on
+  verify → signing-key **rotation** with overlap.
+- **Issuance:** a `mint-token` subcommand (`sipnab mint-token --signing-key K [--ttl SECS] [--id ID]`)
+  prints a signed token. `--api-token-ttl`/`--mcp-token-ttl` set the default mint TTL.
+- **Rotation (tokens):** multiple minted tokens coexist, each valid until its own `exp` — mint new,
+  distribute, let old expire.
+- **Revocation:** a denylist of token `id`s (`--api-revoked-file` / `--mcp-revoked-file`), reloaded on
+  mtime change so removal takes effect without restart. (Signed tokens are otherwise valid until `exp`,
+  so a denylist is required for revocation — accepted cost of the stateless model.)
+- **Backward compat:** `--api-key` / `--mcp-token` / `--mcp-token-file` keep working — a presented
+  value that isn't a parseable signed token falls back to a constant-time match against the static
+  secret (no expiry). Non-loopback-requires-a-token rule preserved.
+- **Clock seam:** `verify(token, now_unix)` takes `now` as a parameter → expiry is unit-tested
+  deterministically; an e2e test additionally mints a ~1 s-TTL token and asserts 200 → 401 across real
+  time. Crypto via RustCrypto `hmac` + `sha2` (pure Rust; decoupled from the `tls` feature).
 
 ---
 

--- a/tasks/verification-spec.md
+++ b/tasks/verification-spec.md
@@ -233,7 +233,7 @@ full matrix is maintained here and checked in CI):
 | TUI 4 dialogs + display-mode cycles | L3a | **add snapshots** | ◐ GAP |
 | TUI launch/quit/resize | L3b | `tui_e2e_test` (nextest+retry) | ✅ / stabilize |
 | REST API endpoints + auth + TLS | L4 | **add** | ❌ GAP |
-| Bearer-token lifecycle: use + **expiry** + rotation + revocation (API + MCP) | feat + L4 | **implement + document + test + validate** (M3b) | ❌ CRITICAL GAP — not implemented |
+| Bearer-token lifecycle: use + **expiry** + rotation + revocation (API + MCP) | feat + L4 | HMAC signed tokens (`src/auth`) + `api_token_test`/`mcp_token_test` + unit negatives | ✅ implemented + documented ([`auth.md`](../docs/auth.md)) + tested + validated (M3b) |
 | Prometheus `/metrics` scrape | L4 | **add** | ❌ GAP |
 | MCP 12 tools round-trip | L4 | extend `mcp_*` | ◐ partial |
 | HEP ingest/forward/limit | L4 | **add** | ❌ GAP |

--- a/tests/api_token_test.rs
+++ b/tests/api_token_test.rs
@@ -1,0 +1,120 @@
+//! End-to-end REST API signed-token auth tests.
+//!
+//! Spawns a real `sipnab --api` process configured with an HMAC signing key
+//! (and optionally a revocation file), then drives it over HTTP to prove the
+//! fail-closed negatives: valid → 200, expired → 401, revoked → 401, plus the
+//! static-secret backward-compat path. Tokens are minted in-process via the
+//! library `sipnab::auth::mint` (same key the server is started with) rather
+//! than shelling out.
+#![cfg(feature = "api")]
+
+#[path = "support/server.rs"]
+mod server;
+
+use server::ApiServer;
+
+/// A long, deterministic signing key shared between the spawned server and the
+/// in-test minting.
+const SIGNING_KEY: &str = "e2e-api-signing-key-0123456789abcdef";
+
+fn now() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+#[test]
+fn valid_signed_token_is_accepted() {
+    let srv = ApiServer::spawn(&["--api-signing-key", SIGNING_KEY]);
+    let token = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "valid-id", now() + 3600);
+    let resp = srv.get_bearer("/v1/dialogs", &token);
+    assert_eq!(resp.status, 200, "valid signed token should be 200");
+}
+
+#[test]
+fn missing_token_is_rejected() {
+    let srv = ApiServer::spawn(&["--api-signing-key", SIGNING_KEY]);
+    let resp = srv.get("/v1/dialogs");
+    assert_eq!(resp.status, 401, "missing token should be 401");
+}
+
+#[test]
+fn expired_signed_token_is_rejected() {
+    let srv = ApiServer::spawn(&["--api-signing-key", SIGNING_KEY]);
+    // exp already in the past — deterministic, no sleeping.
+    let token = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "expired-id", now() - 1);
+    let resp = srv.get_bearer("/v1/dialogs", &token);
+    assert_eq!(resp.status, 401, "expired token should be 401");
+}
+
+#[test]
+fn forged_wrong_key_token_is_rejected() {
+    let srv = ApiServer::spawn(&["--api-signing-key", SIGNING_KEY]);
+    let token = sipnab::auth::mint(b"a-totally-different-key", "id", now() + 3600);
+    let resp = srv.get_bearer("/v1/dialogs", &token);
+    assert_eq!(resp.status, 401, "forged token should be 401");
+}
+
+#[test]
+fn tampered_payload_token_is_rejected() {
+    let srv = ApiServer::spawn(&["--api-signing-key", SIGNING_KEY]);
+    let token = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "id", now() + 3600);
+    // Flip a byte in the payload (middle dot-part).
+    let mut parts: Vec<String> = token.split('.').map(String::from).collect();
+    let mut bytes = parts[1].clone().into_bytes();
+    let idx = bytes.len() / 2;
+    bytes[idx] = if bytes[idx] == b'A' { b'B' } else { b'A' };
+    parts[1] = String::from_utf8(bytes).unwrap();
+    let tampered = parts.join(".");
+    let resp = srv.get_bearer("/v1/dialogs", &tampered);
+    assert_eq!(resp.status, 401, "tampered payload should be 401");
+}
+
+#[test]
+fn revoked_id_is_rejected_via_denylist_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let revoked_path = dir.path().join("revoked.txt");
+    std::fs::write(&revoked_path, "revoked-jti\n").expect("write denylist");
+
+    let srv = ApiServer::spawn(&[
+        "--api-signing-key",
+        SIGNING_KEY,
+        "--api-revoked-file",
+        revoked_path.to_str().unwrap(),
+    ]);
+
+    // A valid, unexpired token whose id is on the denylist → 401.
+    let revoked = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "revoked-jti", now() + 3600);
+    let resp = srv.get_bearer("/v1/dialogs", &revoked);
+    assert_eq!(resp.status, 401, "revoked id should be 401");
+
+    // A fresh token with a different id is accepted.
+    let fresh = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "not-revoked-jti", now() + 3600);
+    let resp = srv.get_bearer("/v1/dialogs", &fresh);
+    assert_eq!(resp.status, 200, "non-revoked id should be 200");
+}
+
+#[test]
+fn rotation_accepts_tokens_from_either_key() {
+    let key2 = "second-rotation-key-abcdef0123456789";
+    let srv = ApiServer::spawn(&["--api-signing-key", SIGNING_KEY, "--api-signing-key", key2]);
+    let t1 = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "id1", now() + 3600);
+    let t2 = sipnab::auth::mint(key2.as_bytes(), "id2", now() + 3600);
+    assert_eq!(srv.get_bearer("/v1/dialogs", &t1).status, 200, "key1 token");
+    assert_eq!(srv.get_bearer("/v1/dialogs", &t2).status, 200, "key2 token");
+}
+
+#[test]
+fn static_api_key_backward_compat() {
+    let srv = ApiServer::spawn(&["--api-key", "legacy-static-secret"]);
+    // Correct static secret → 200.
+    assert_eq!(
+        srv.get_bearer("/v1/dialogs", "legacy-static-secret").status,
+        200,
+        "correct static key should be 200"
+    );
+    // Wrong static secret → 401.
+    assert_eq!(
+        srv.get_bearer("/v1/dialogs", "wrong-secret").status,
+        401,
+        "wrong static key should be 401"
+    );
+}

--- a/tests/mcp_token_test.rs
+++ b/tests/mcp_token_test.rs
@@ -1,0 +1,277 @@
+//! End-to-end HTTP MCP signed-token auth tests.
+//!
+//! Spawns `sipnab --mcp --mcp-transport http` configured with an HMAC signing
+//! key (and optionally a revocation file), then issues HTTP JSON-RPC requests
+//! to prove the fail-closed negatives over the real network surface: valid →
+//! 200, expired → 401, revoked → 401, plus the static `--mcp-token`
+//! backward-compat path. Tokens are minted in-process via `sipnab::auth::mint`
+//! (same key the server is started with). Mirrors `tests/mcp_http_test.rs`.
+#![cfg(all(unix, feature = "mcp-http"))]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const SIGNING_KEY: &str = "e2e-mcp-signing-key-0123456789abcdef";
+
+fn fixture(path: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(path)
+}
+
+fn now() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+/// Spawn sipnab with HTTP MCP and return the child + bind address.
+fn spawn_http(extra_args: &[&str]) -> Option<(std::process::Child, String)> {
+    let binary = env!("CARGO_BIN_EXE_sipnab");
+    let pcap = fixture("sip_call.pcap");
+    let pcap_str = pcap.to_string_lossy().to_string();
+
+    let mut cmd = Command::new(binary);
+    cmd.args([
+        "-N",
+        "-I",
+        &pcap_str,
+        "--mcp",
+        "--mcp-transport",
+        "http",
+        "--mcp-bind",
+        "127.0.0.1:0",
+        "--quiet",
+    ]);
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    cmd.env("SIPNAB_LOG", "info");
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("spawn sipnab");
+    let stderr = child.stderr.take().expect("stderr");
+
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            let _ = tx.send(line);
+        }
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Ok(line) = rx.recv_timeout(Duration::from_millis(200)) {
+            if let Some(addr) = line.split("listening on ").nth(1) {
+                return Some((child, addr.trim().to_string()));
+            }
+            if line.contains("refuses to start") {
+                unsafe {
+                    libc::kill(child.id() as i32, libc::SIGTERM);
+                }
+                let _ = child.wait();
+                return None;
+            }
+        } else if let Ok(Some(_)) = child.try_wait() {
+            return None;
+        }
+    }
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGTERM);
+    }
+    let _ = child.wait();
+    None
+}
+
+fn shutdown(mut child: std::process::Child) {
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGTERM);
+    }
+    let _ = child.wait();
+}
+
+/// Issue an `initialize` JSON-RPC POST with an optional bearer token, returning
+/// the HTTP status code.
+fn initialize_status(addr: &str, bearer: Option<&str>) -> u16 {
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                   "clientInfo": {"name": "test", "version": "0"}}
+    });
+    post_status(&format!("http://{addr}/mcp"), bearer, &payload)
+}
+
+fn post_status(url: &str, bearer: Option<&str>, body: &serde_json::Value) -> u16 {
+    let parsed = url.strip_prefix("http://").expect("http url");
+    let (authority, path) = parsed.split_once('/').unwrap_or((parsed, ""));
+    let (host, port_str) = authority.rsplit_once(':').expect("host:port");
+    let port: u16 = port_str.parse().expect("port");
+
+    let mut stream = TcpStream::connect((host, port)).expect("connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("read timeout");
+
+    let body_str = serde_json::to_string(body).expect("serialize");
+    let mut req = format!(
+        "POST /{path} HTTP/1.1\r\n\
+         Host: {host}:{port}\r\n\
+         Content-Type: application/json\r\n\
+         Accept: application/json, text/event-stream\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n",
+        body_str.len(),
+    );
+    if let Some(b) = bearer {
+        req.push_str(&format!("Authorization: Bearer {b}\r\n"));
+    }
+    req.push_str("\r\n");
+    req.push_str(&body_str);
+    stream.write_all(req.as_bytes()).expect("write");
+
+    let mut resp = Vec::new();
+    stream.read_to_end(&mut resp).expect("read");
+    let s = String::from_utf8_lossy(&resp);
+    s.lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|c| c.parse().ok())
+        .unwrap_or(0)
+}
+
+#[test]
+fn valid_signed_token_initialize_succeeds() {
+    let (child, addr) =
+        spawn_http(&["--mcp-signing-key", SIGNING_KEY]).expect("server should start");
+    let token = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "id", now() + 3600);
+    assert_eq!(
+        initialize_status(&addr, Some(&token)),
+        200,
+        "valid token should be 200"
+    );
+    // Missing token → 401.
+    assert_eq!(initialize_status(&addr, None), 401, "missing token → 401");
+    shutdown(child);
+}
+
+#[test]
+fn expired_signed_token_is_rejected() {
+    let (child, addr) =
+        spawn_http(&["--mcp-signing-key", SIGNING_KEY]).expect("server should start");
+    let token = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "id", now() - 1);
+    assert_eq!(
+        initialize_status(&addr, Some(&token)),
+        401,
+        "expired token should be 401"
+    );
+    shutdown(child);
+}
+
+#[test]
+fn forged_wrong_key_token_is_rejected() {
+    let (child, addr) =
+        spawn_http(&["--mcp-signing-key", SIGNING_KEY]).expect("server should start");
+    let token = sipnab::auth::mint(b"a-different-key", "id", now() + 3600);
+    assert_eq!(
+        initialize_status(&addr, Some(&token)),
+        401,
+        "forged token should be 401"
+    );
+    shutdown(child);
+}
+
+#[test]
+fn revoked_id_is_rejected_via_denylist_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let revoked_path = dir.path().join("revoked.txt");
+    std::fs::write(&revoked_path, "revoked-mcp-jti\n").expect("write denylist");
+
+    let (child, addr) = spawn_http(&[
+        "--mcp-signing-key",
+        SIGNING_KEY,
+        "--mcp-revoked-file",
+        revoked_path.to_str().unwrap(),
+    ])
+    .expect("server should start");
+
+    let revoked = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "revoked-mcp-jti", now() + 3600);
+    assert_eq!(
+        initialize_status(&addr, Some(&revoked)),
+        401,
+        "revoked id should be 401"
+    );
+
+    let fresh = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "fresh-mcp-jti", now() + 3600);
+    assert_eq!(
+        initialize_status(&addr, Some(&fresh)),
+        200,
+        "non-revoked id should be 200"
+    );
+    shutdown(child);
+}
+
+#[test]
+fn rotation_accepts_tokens_from_either_key() {
+    let key2 = "second-mcp-rotation-key-abcdef0123";
+    let (child, addr) = spawn_http(&["--mcp-signing-key", SIGNING_KEY, "--mcp-signing-key", key2])
+        .expect("server should start");
+    let t1 = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "id1", now() + 3600);
+    let t2 = sipnab::auth::mint(key2.as_bytes(), "id2", now() + 3600);
+    assert_eq!(initialize_status(&addr, Some(&t1)), 200, "key1 token");
+    assert_eq!(initialize_status(&addr, Some(&t2)), 200, "key2 token");
+    shutdown(child);
+}
+
+#[test]
+fn static_mcp_token_backward_compat() {
+    let (child, addr) =
+        spawn_http(&["--mcp-token", "legacy-mcp-secret"]).expect("server should start");
+    assert_eq!(
+        initialize_status(&addr, Some("legacy-mcp-secret")),
+        200,
+        "correct static token → 200"
+    );
+    assert_eq!(
+        initialize_status(&addr, Some("wrong-secret")),
+        401,
+        "wrong static token → 401"
+    );
+    shutdown(child);
+}
+
+#[test]
+fn mint_token_cli_mode_produces_verifiable_token() {
+    // Drive the --mint-token CLI mode and verify the printed token under the
+    // same key via the library verifier.
+    let binary = env!("CARGO_BIN_EXE_sipnab");
+    let out = Command::new(binary)
+        .args([
+            "--mint-token",
+            "--mcp-signing-key",
+            SIGNING_KEY,
+            "--token-id",
+            "cli-minted",
+            "--mcp-token-ttl",
+            "3600",
+        ])
+        .output()
+        .expect("run --mint-token");
+    assert!(out.status.success(), "mint-token should exit 0");
+    let token = String::from_utf8(out.stdout)
+        .expect("utf8")
+        .trim()
+        .to_string();
+    assert!(token.starts_with("s1."), "minted token: {token}");
+
+    let verifier = sipnab::auth::TokenVerifier::new(sipnab::auth::VerifierConfig {
+        signing_keys: vec![SIGNING_KEY.as_bytes().to_vec()],
+        ..Default::default()
+    });
+    assert!(
+        verifier.verify(&token, now()),
+        "CLI-minted token should verify under same key"
+    );
+}

--- a/tests/security_test.rs
+++ b/tests/security_test.rs
@@ -958,7 +958,12 @@ fn constant_time_eq_different_lengths_still_compares() {
     let state = ApiState {
         dialog_store: Arc::new(RwLock::new(DialogStore::new(1000, false))),
         stream_store: Arc::new(RwLock::new(StreamStore::new(1000))),
-        api_key: Some("secret_key_123".to_string()),
+        verifier: Arc::new(sipnab::auth::TokenVerifier::new(
+            sipnab::auth::VerifierConfig {
+                static_keys: vec!["secret_key_123".to_string()],
+                ..Default::default()
+            },
+        )),
         rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
     };
 
@@ -970,7 +975,8 @@ fn constant_time_eq_different_lengths_still_compares() {
     // For unit testing, verify the constant-time comparison logic:
     // both "short" vs "secret_key_123" and "secret_key_123" vs
     // "secret_key_123" should be handled without panic.
-    assert!(state.api_key.is_some());
+    assert!(!state.verifier.is_unconfigured());
+    let _ = headers;
 }
 
 /// M4: Constant-time comparison returns true for matching strings.
@@ -991,7 +997,12 @@ fn constant_time_eq_matching_strings() {
     let state = ApiState {
         dialog_store: Arc::new(RwLock::new(DialogStore::new(1000, false))),
         stream_store: Arc::new(RwLock::new(StreamStore::new(1000))),
-        api_key: Some("secret_key_123".to_string()),
+        verifier: Arc::new(sipnab::auth::TokenVerifier::new(
+            sipnab::auth::VerifierConfig {
+                static_keys: vec!["secret_key_123".to_string()],
+                ..Default::default()
+            },
+        )),
         rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
     };
 
@@ -1035,7 +1046,12 @@ fn constant_time_eq_different_strings_same_length() {
     let state = ApiState {
         dialog_store: Arc::new(RwLock::new(DialogStore::new(1000, false))),
         stream_store: Arc::new(RwLock::new(StreamStore::new(1000))),
-        api_key: Some("secret_key_123".to_string()),
+        verifier: Arc::new(sipnab::auth::TokenVerifier::new(
+            sipnab::auth::VerifierConfig {
+                static_keys: vec!["secret_key_123".to_string()],
+                ..Default::default()
+            },
+        )),
         rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
     };
 

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -103,13 +103,22 @@ impl ApiServer {
         // identical consecutive reads — which generically means processing has
         // settled, without assuming any per-fixture counts.
         // Authenticate the readiness poll if the server was started with a key
-        // (otherwise /v1/stats would 401 and never look "stable").
-        let key = extra_args
+        // (otherwise /v1/stats would 401 and never look "stable"). Supports
+        // both the static `--api-key` and an HMAC `--api-signing-key` (in which
+        // case we mint a short-lived token with the same key for the poll).
+        let mut bearer = extra_args
             .windows(2)
             .find(|w| w[0] == "--api-key")
             .map(|w| w[1].to_string());
+        #[cfg(feature = "api")]
+        if bearer.is_none()
+            && let Some(w) = extra_args.windows(2).find(|w| w[0] == "--api-signing-key")
+        {
+            let exp = chrono::Utc::now().timestamp() + 3600;
+            bearer = Some(sipnab::auth::mint(w[1].as_bytes(), "readiness-poll", exp));
+        }
         let srv = ApiServer { child, addr };
-        srv.await_stable(key.as_deref());
+        srv.await_stable(bearer.as_deref());
         srv
     }
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,801 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,832 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1801" data-suffix="">1801</span>
+        <span class="arch-stat" data-count="1832" data-suffix="">1832</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Closes the CRITICAL bearer-token gap. Adds HMAC self-describing signed tokens (maintainer-chosen model) for the REST API + HTTP MCP, with full backward-compat for static `--api-key`/`--mcp-token`.

**Token:** `s1.<b64url({id,exp})>.<b64url(HMAC-SHA256)>`. Stateless, fail-closed verify: recompute HMAC → constant-time compare vs **all** signing keys (rotation) → `exp > now` → `id` not revoked. Non-`s1` values fall back to constant-time static-secret compare.

- **`src/auth`** (new; `any(api,mcp)`): `mint` + `TokenVerifier`; relocated `constant_time_eq` out of `output::api` so the shared primitive no longer needs the `api` feature (MCP builds without api). Revocation denylist file is **mtime-reloaded** (no restart).
- **CLI:** `--api-signing-key`(repeatable,env)/`--api-signing-key-file`/`--api-revoked-file`/`--api-token-ttl` + `--mcp-*` equivalents; `--mint-token`/`--token-id`. Static secrets kept.
- Wired into `check_auth` + MCP `auth_layer`, preserving constant-time + non-loopback-requires-token.
- Deps: `hmac`,`sha2` (pure Rust; not `ring`/`tls`).

**Validation (independently re-run):** negatives all fail closed — expired→401, tampered→reject, forged/wrong-key→reject, revoked→401(+reload), rotation accepts either key, static backward-compat, constant-time. 17 unit + 8 api_token + 7 mcp_token. **Full suite 1832/0**; fmt+clippy clean.

**Docs:** `docs/auth.md` (mint/use/expire/rotate/revoke + security notes); flags in `docs/cli-reference.md`; spec §15 row → ✅.