### PR TITLE
test: M6 burn-down — genuinely test 7 KNOWN_UNTESTED flags (36→29)

### DIFF
--- a/tasks/verification-plan.md
+++ b/tasks/verification-plan.md
@@ -341,14 +341,14 @@ the decryption CLI flags are tracked as debt by the T6.2 gate until real fixture
 | ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
 |---|---|---|---|---|---|
 | [ ] **T6.1** | Living traceability matrix | `tasks/verification-matrix.md` | M2–M4 | M | deferred — large enumeration; the per-class gates (T6.2) provide the enforced subset. The `[x]`/`◐`/`⚠` annotations across M1–M5 in THIS plan are the de-facto matrix |
-| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **36** currently-untested flags captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
+| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **29** currently-untested flags (was 36; 7 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
 | [◐] **T6.3** | CI job wiring | `.github/workflows/ci.yml` | M1–M5 | M | the gates + golden/schema/service/token/HEP suites already run via `cargo test --all-features` / `--features full` in CI + hooks. Dedicated `e2e-docker`/`perf` jobs deferred (env-bound: no docker/NICs — see T4.7/M5) |
 | [ ] **T6.4** | Docs: test architecture | `CONTRIBUTING.md` / `docs/` | M1–M4 | S | deferred (S) — the determinism contract + layer model are documented inline in each test module's header |
 | [◐] **T6.5** | Surface registry (all 4 classes) | `tests/registry/surface.toml` | M2–M4, M3b | L | the **CLI-flag class** is enforced now (T6.2). The full multi-class TOML registry (UI controls, API fields, token states, doc examples) is the remaining large enumeration — deferred |
 | [◐] **T6.6** | 100% completeness CI gate | `tests/flag_coverage_test.rs` (+ future registry) | T6.5 | M | enforced for the **CLI-flag class** now (fails red on a new untested flag; negative meta-test proves it). Extends to the other classes when T6.5's registry lands |
 
 **M6 exit gate:** a new CLI flag cannot merge untested — **enforced now** (T6.2 ratchet, green with a
-36-flag debt baseline). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
+29-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
 enumeration follow-ups; the other classes (API/MCP/HEP/views) are already test-covered by M3/M3b/M4.
 - **Validate with:** run the extended `docs_drift_test`; as a **negative/meta-test**, add a throwaway
   flag with no referencing test and confirm the gate goes **red** (proving it actually guards), then

--- a/tests/cli_flag_behavior_test.rs
+++ b/tests/cli_flag_behavior_test.rs
@@ -1,0 +1,148 @@
+//! Behavioral coverage for CLI flags that were in the T6.2 `KNOWN_UNTESTED`
+//! debt baseline (verification plan M6 burn-down). Each test exercises the
+//! flag's real effect, not just its name.
+#![cfg(feature = "api")] // `api` implies `native` (pcap + mint + auth available)
+
+use std::io::Write;
+use std::process::Command;
+
+use sipnab::auth::{TokenVerifier, VerifierConfig};
+
+const FIXTURE: &str = "tests/fixtures/sip_call.pcap";
+
+/// Run the binary from the crate root with a quiet, deterministic env; return stdout.
+fn run(args: &[&str]) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_sipnab"))
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .args(args)
+        .env("SIPNAB_LOG", "off")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("spawn sipnab");
+    assert!(
+        out.status.success(),
+        "sipnab {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).expect("utf8")
+}
+
+fn ndjson_lines(s: &str) -> Vec<serde_json::Value> {
+    s.lines()
+        .filter(|l| l.starts_with('{'))
+        .map(|l| serde_json::from_str(l).expect("ndjson"))
+        .collect()
+}
+
+#[test]
+fn count_limits_message_output() {
+    // --count N stops after N packets → at most N messages.
+    let msgs = ndjson_lines(&run(&["-N", "-I", FIXTURE, "--count", "3", "--json"]));
+    assert_eq!(msgs.len(), 3, "--count 3 must yield exactly 3 messages");
+}
+
+#[test]
+fn calls_only_emits_only_call_associated_messages() {
+    // --calls-only suppresses standalone messages → every emitted message
+    // carries a call_id.
+    let msgs = ndjson_lines(&run(&["-N", "-I", FIXTURE, "--calls-only", "--json"]));
+    assert!(!msgs.is_empty(), "--calls-only should still emit the call");
+    for m in &msgs {
+        assert!(
+            m.get("call_id").and_then(|v| v.as_str()).is_some(),
+            "--calls-only must not emit standalone (call_id-less) messages: {m}"
+        );
+    }
+}
+
+#[test]
+fn text_dump_emits_raw_sip() {
+    // --text-dump prints the raw SIP message text (request line + headers).
+    let out = run(&["-N", "-I", FIXTURE, "--text-dump"]);
+    assert!(
+        out.contains("INVITE sip:1002@10.0.0.2 SIP/2.0"),
+        "--text-dump must contain the raw SIP request line"
+    );
+    assert!(out.contains("Via: SIP/2.0/UDP"), "raw headers expected");
+}
+
+#[test]
+fn pcapng_output_writes_pcapng_magic() {
+    // -O <file> --pcapng writes a PCAP-NG file (Section Header Block magic).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out_path = dir.path().join("out.pcapng");
+    run(&[
+        "-N",
+        "-I",
+        FIXTURE,
+        "-O",
+        out_path.to_str().unwrap(),
+        "--pcapng",
+    ]);
+    let bytes = std::fs::read(&out_path).expect("read written pcapng");
+    assert!(bytes.len() >= 4, "pcapng too short");
+    assert_eq!(&bytes[..4], &[0x0a, 0x0d, 0x0d, 0x0a], "pcapng SHB magic");
+}
+
+#[test]
+fn mint_with_api_signing_key_file_and_ttl_roundtrips_with_expiry() {
+    // --api-signing-key-file (key from a file) + --api-token-ttl (lifetime):
+    // mint a token via the CLI, then verify it round-trips and expires per TTL.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let key_path = dir.path().join("api.key");
+    let key = b"file-loaded-signing-key-0123456789";
+    std::fs::File::create(&key_path)
+        .unwrap()
+        .write_all(key)
+        .unwrap();
+
+    let token = run(&[
+        "--mint-token",
+        "--api-signing-key-file",
+        key_path.to_str().unwrap(),
+        "--api-token-ttl",
+        "60",
+        "--token-id",
+        "burn-down-1",
+    ])
+    .trim()
+    .to_string();
+    assert!(token.starts_with("s1."), "minted token shape: {token}");
+
+    let verifier = TokenVerifier::new(VerifierConfig {
+        signing_keys: vec![key.to_vec()],
+        static_keys: vec![],
+        revoked_file: None,
+    });
+    let now = chrono::Utc::now().timestamp();
+    assert!(verifier.verify(&token, now), "token must verify now");
+    assert!(
+        !verifier.verify(&token, now + 61),
+        "token minted with --api-token-ttl 60 must be expired at now+61"
+    );
+}
+
+#[test]
+fn mint_with_mcp_signing_key_file_produces_token() {
+    // --mcp-signing-key-file: mint using an MCP signing key loaded from a file.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let key_path = dir.path().join("mcp.key");
+    std::fs::File::create(&key_path)
+        .unwrap()
+        .write_all(b"mcp-file-signing-key-987654321")
+        .unwrap();
+
+    let token = run(&[
+        "--mint-token",
+        "--mcp-signing-key-file",
+        key_path.to_str().unwrap(),
+        "--token-id",
+        "burn-down-mcp",
+    ])
+    .trim()
+    .to_string();
+    assert!(
+        token.starts_with("s1.") && token.matches('.').count() == 2,
+        "minted MCP token shape: {token}"
+    );
+}

--- a/tests/flag_coverage_test.rs
+++ b/tests/flag_coverage_test.rs
@@ -23,16 +23,15 @@ use clap::CommandFactory;
 /// adding a test for a listed flag also fails the gate until you remove it
 /// from this list. Burn this down toward zero (spec §15 = 100%).
 const KNOWN_UNTESTED: &[&str] = &[
+    // Burned down in M6 (see tests/cli_flag_behavior_test.rs): count,
+    // calls-only, text-dump, pcapng, api-signing-key-file, api-token-ttl,
+    // mcp-signing-key-file — removed from this baseline as the ratchet requires.
     "after",
     "alert-exec",
-    "api-signing-key-file",
-    "api-token-ttl",
     "bpf-file",
     "buffer",
-    "calls-only",
     "chroot",
     "config",
-    "count",
     "dtls-keylog",
     "hep-parse",
     "ignore-case",
@@ -41,14 +40,12 @@ const KNOWN_UNTESTED: &[&str] = &[
     "keylog-watch",
     "limit",
     "mcp-allowed-host",
-    "mcp-signing-key-file",
     "mcp-token-file",
     "metrics",
     "metrics-auth",
     "on-dialog-exec",
     "on-quality-exec",
     "pcap-export-mode",
-    "pcapng",
     "replay",
     "rotate",
     "split",
@@ -56,7 +53,6 @@ const KNOWN_UNTESTED: &[&str] = &[
     "syslog",
     "tag",
     "telephone-event",
-    "text-dump",
     "tls-key",
     "word",
 ];
@@ -105,11 +101,10 @@ fn read_tree(dir: &Path, exts: &[&str], out: &mut String) {
             .and_then(|e| e.to_str())
             .map(|e| exts.contains(&e))
             .unwrap_or(false)
+            && let Ok(s) = std::fs::read_to_string(&path)
         {
-            if let Ok(s) = std::fs::read_to_string(&path) {
-                out.push_str(&s);
-                out.push('\n');
-            }
+            out.push_str(&s);
+            out.push('\n');
         }
     }
 }
@@ -123,10 +118,10 @@ fn test_corpus(manifest: &Path) -> String {
 
     // Append only the test module of cli.rs (after the first `#[cfg(test)]`),
     // so flag *definitions* (`long = "..."`) don't trivially satisfy the gate.
-    if let Ok(cli) = std::fs::read_to_string(manifest.join("src/cli.rs")) {
-        if let Some(idx) = cli.find("#[cfg(test)]") {
-            corpus.push_str(&cli[idx..]);
-        }
+    if let Ok(cli) = std::fs::read_to_string(manifest.join("src/cli.rs"))
+        && let Some(idx) = cli.find("#[cfg(test)]")
+    {
+        corpus.push_str(&cli[idx..]);
     }
     corpus
 }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,836 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,842 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1836" data-suffix="">1836</span>
+        <span class="arch-stat" data-count="1842" data-suffix="">1842</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Burns down the T6.2 flag-debt baseline with **real behavior tests** (`tests/cli_flag_behavior_test.rs`):
- `--count` → exactly N messages; `--calls-only` → every message has a call_id; `--text-dump` → raw SIP; `--pcapng` → SHB magic `0a0d0d0a`.
- `--api-signing-key-file` + `--api-token-ttl` → mint from a key file with TTL 60, verify it round-trips and **expires at now+61** (via `TokenVerifier`).
- `--mcp-signing-key-file` → mint from an MCP key file.

Removed the 7 from `KNOWN_UNTESTED` (ratchet requires it; **36→29**). Gate still green, negative meta-test intact, clippy/fmt clean. Full suite **1842/0**.