### PR TITLE
test: M6 burn-down batch 2 — config/bpf-file/on-dialog-exec (29→26)

### DIFF
--- a/tasks/verification-plan.md
+++ b/tasks/verification-plan.md
@@ -341,14 +341,14 @@ the decryption CLI flags are tracked as debt by the T6.2 gate until real fixture
 | ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
 |---|---|---|---|---|---|
 | [ ] **T6.1** | Living traceability matrix | `tasks/verification-matrix.md` | M2–M4 | M | deferred — large enumeration; the per-class gates (T6.2) provide the enforced subset. The `[x]`/`◐`/`⚠` annotations across M1–M5 in THIS plan are the de-facto matrix |
-| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **29** currently-untested flags (was 36; 7 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
+| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **26** currently-untested flags (was 36; 10 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
 | [◐] **T6.3** | CI job wiring | `.github/workflows/ci.yml` | M1–M5 | M | the gates + golden/schema/service/token/HEP suites already run via `cargo test --all-features` / `--features full` in CI + hooks. Dedicated `e2e-docker`/`perf` jobs deferred (env-bound: no docker/NICs — see T4.7/M5) |
 | [ ] **T6.4** | Docs: test architecture | `CONTRIBUTING.md` / `docs/` | M1–M4 | S | deferred (S) — the determinism contract + layer model are documented inline in each test module's header |
 | [◐] **T6.5** | Surface registry (all 4 classes) | `tests/registry/surface.toml` | M2–M4, M3b | L | the **CLI-flag class** is enforced now (T6.2). The full multi-class TOML registry (UI controls, API fields, token states, doc examples) is the remaining large enumeration — deferred |
 | [◐] **T6.6** | 100% completeness CI gate | `tests/flag_coverage_test.rs` (+ future registry) | T6.5 | M | enforced for the **CLI-flag class** now (fails red on a new untested flag; negative meta-test proves it). Extends to the other classes when T6.5's registry lands |
 
 **M6 exit gate:** a new CLI flag cannot merge untested — **enforced now** (T6.2 ratchet, green with a
-29-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
+26-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
 enumeration follow-ups; the other classes (API/MCP/HEP/views) are already test-covered by M3/M3b/M4.
 - **Validate with:** run the extended `docs_drift_test`; as a **negative/meta-test**, add a throwaway
   flag with no referencing test and confirm the gate goes **red** (proving it actually guards), then

--- a/tests/cli_flag_behavior_test.rs
+++ b/tests/cli_flag_behavior_test.rs
@@ -146,3 +146,84 @@ fn mint_with_mcp_signing_key_file_produces_token() {
         "minted MCP token shape: {token}"
     );
 }
+
+#[test]
+fn config_file_is_loaded() {
+    // --config: the loader reads the file and --dump-config reflects it.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cfg = dir.path().join("c.toml");
+    std::fs::File::create(&cfg)
+        .unwrap()
+        .write_all(b"[display]\npayload_limit = 99\n")
+        .unwrap();
+
+    let out = run(&["-D", "--config", cfg.to_str().unwrap()]);
+    assert!(
+        out.contains("Loaded from:"),
+        "must report the loaded source"
+    );
+    assert!(
+        out.contains("payload_limit = 99"),
+        "--config values must appear in the dumped config:\n{out}"
+    );
+}
+
+#[test]
+fn bpf_file_filters_from_a_file() {
+    // --bpf-file: a matching filter passes all packets; a non-matching one
+    // passes none — proving the BPF is read from the file and applied.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let matching = dir.path().join("match.bpf");
+    std::fs::File::create(&matching)
+        .unwrap()
+        .write_all(b"udp port 5060\n")
+        .unwrap();
+    let none = dir.path().join("none.bpf");
+    std::fs::File::create(&none)
+        .unwrap()
+        .write_all(b"tcp port 80\n")
+        .unwrap();
+
+    let pass = ndjson_lines(&run(&[
+        "-N",
+        "-I",
+        FIXTURE,
+        "--bpf-file",
+        matching.to_str().unwrap(),
+        "--json",
+    ]));
+    assert_eq!(
+        pass.len(),
+        7,
+        "matching --bpf-file must pass all 7 messages"
+    );
+
+    let drop = ndjson_lines(&run(&[
+        "-N",
+        "-I",
+        FIXTURE,
+        "--bpf-file",
+        none.to_str().unwrap(),
+        "--json",
+    ]));
+    assert!(drop.is_empty(), "non-matching --bpf-file must pass none");
+}
+
+#[test]
+fn on_dialog_exec_runs_per_dialog() {
+    // --on-dialog-exec: the command runs as dialogs complete. Use a command
+    // that creates a marker file and assert it exists afterward.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let marker = dir.path().join("fired");
+    run(&[
+        "-N",
+        "-I",
+        FIXTURE,
+        "--on-dialog-exec",
+        &format!("touch {}", marker.to_str().unwrap()),
+    ]);
+    assert!(
+        marker.exists(),
+        "--on-dialog-exec command must run for the fixture's dialog"
+    );
+}

--- a/tests/flag_coverage_test.rs
+++ b/tests/flag_coverage_test.rs
@@ -28,10 +28,8 @@ const KNOWN_UNTESTED: &[&str] = &[
     // mcp-signing-key-file — removed from this baseline as the ratchet requires.
     "after",
     "alert-exec",
-    "bpf-file",
     "buffer",
     "chroot",
-    "config",
     "dtls-keylog",
     "hep-parse",
     "ignore-case",
@@ -43,7 +41,6 @@ const KNOWN_UNTESTED: &[&str] = &[
     "mcp-token-file",
     "metrics",
     "metrics-auth",
-    "on-dialog-exec",
     "on-quality-exec",
     "pcap-export-mode",
     "replay",

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,842 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,845 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1842" data-suffix="">1842</span>
+        <span class="arch-stat" data-count="1845" data-suffix="">1845</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Three more `KNOWN_UNTESTED` flags get real behavior tests:
- **`--config`**: `-D --config <f>` reports `Loaded from:` and reflects the file's `payload_limit = 99`.
- **`--bpf-file`**: matching (`udp port 5060`) passes all 7; non-matching (`tcp port 80`) passes none.
- **`--on-dialog-exec`**: runs per completed dialog (creates a marker file).

Removed from `KNOWN_UNTESTED` (ratchet); baseline **29→26** (10 burned down total). Gate green. Full suite **1845/0**.