### PR TITLE
test: M6 burn-down batch 3 — --limit dialog cap (26→25)

### DIFF
--- a/tasks/verification-plan.md
+++ b/tasks/verification-plan.md
@@ -341,14 +341,14 @@ the decryption CLI flags are tracked as debt by the T6.2 gate until real fixture
 | ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
 |---|---|---|---|---|---|
 | [ ] **T6.1** | Living traceability matrix | `tasks/verification-matrix.md` | M2–M4 | M | deferred — large enumeration; the per-class gates (T6.2) provide the enforced subset. The `[x]`/`◐`/`⚠` annotations across M1–M5 in THIS plan are the de-facto matrix |
-| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **26** currently-untested flags (was 36; 10 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
+| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **25** currently-untested flags (was 36; 11 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
 | [◐] **T6.3** | CI job wiring | `.github/workflows/ci.yml` | M1–M5 | M | the gates + golden/schema/service/token/HEP suites already run via `cargo test --all-features` / `--features full` in CI + hooks. Dedicated `e2e-docker`/`perf` jobs deferred (env-bound: no docker/NICs — see T4.7/M5) |
 | [ ] **T6.4** | Docs: test architecture | `CONTRIBUTING.md` / `docs/` | M1–M4 | S | deferred (S) — the determinism contract + layer model are documented inline in each test module's header |
 | [◐] **T6.5** | Surface registry (all 4 classes) | `tests/registry/surface.toml` | M2–M4, M3b | L | the **CLI-flag class** is enforced now (T6.2). The full multi-class TOML registry (UI controls, API fields, token states, doc examples) is the remaining large enumeration — deferred |
 | [◐] **T6.6** | 100% completeness CI gate | `tests/flag_coverage_test.rs` (+ future registry) | T6.5 | M | enforced for the **CLI-flag class** now (fails red on a new untested flag; negative meta-test proves it). Extends to the other classes when T6.5's registry lands |
 
 **M6 exit gate:** a new CLI flag cannot merge untested — **enforced now** (T6.2 ratchet, green with a
-26-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
+25-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
 enumeration follow-ups; the other classes (API/MCP/HEP/views) are already test-covered by M3/M3b/M4.
 - **Validate with:** run the extended `docs_drift_test`; as a **negative/meta-test**, add a throwaway
   flag with no referencing test and confirm the gate goes **red** (proving it actually guards), then

--- a/tests/cli_flag_behavior_test.rs
+++ b/tests/cli_flag_behavior_test.rs
@@ -148,6 +148,31 @@ fn mint_with_mcp_signing_key_file_produces_token() {
 }
 
 #[test]
+fn limit_caps_tracked_dialogs() {
+    // --limit N caps the number of dialogs tracked. The RTP fixture has 2
+    // dialogs; --limit 1 must keep only 1 in the report.
+    let rtp = "tests/pcap-samples/sip-rtp-g711.pcap";
+    let full = run(&["-N", "-I", rtp, "--report", "--no-cli-print"]);
+    let full_rows = full.lines().filter(|l| l.contains('@')).count();
+    assert!(
+        full_rows >= 2,
+        "RTP fixture should have ≥2 dialogs, got {full_rows}"
+    );
+
+    let capped = run(&[
+        "-N",
+        "-I",
+        rtp,
+        "--limit",
+        "1",
+        "--report",
+        "--no-cli-print",
+    ]);
+    let capped_rows = capped.lines().filter(|l| l.contains('@')).count();
+    assert_eq!(capped_rows, 1, "--limit 1 must keep exactly one dialog");
+}
+
+#[test]
 fn config_file_is_loaded() {
     // --config: the loader reads the file and --dump-config reflects it.
     let dir = tempfile::tempdir().expect("tempdir");

--- a/tests/flag_coverage_test.rs
+++ b/tests/flag_coverage_test.rs
@@ -36,7 +36,6 @@ const KNOWN_UNTESTED: &[&str] = &[
     "invert",
     "keylog",
     "keylog-watch",
-    "limit",
     "mcp-allowed-host",
     "mcp-token-file",
     "metrics",

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,845 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,846 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1845" data-suffix="">1845</span>
+        <span class="arch-stat" data-count="1846" data-suffix="">1846</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
`--limit N` caps tracked dialogs: the RTP fixture (2 dialogs) with `--limit 1` keeps exactly one. Removed from `KNOWN_UNTESTED` (ratchet); **11 flags burned down total (36→25)**. Gate green. Full suite **1846/0**.