### PR TITLE
fix(metrics): --metrics-auth doc (Basic not Bearer) + log bound port

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -410,8 +410,9 @@ pub struct Cli {
     #[arg(long, value_name = "ADDR")]
     pub metrics: Option<String>,
 
-    /// Bearer token for metrics endpoint authentication.
-    #[arg(long, value_name = "TOKEN")]
+    /// HTTP Basic auth credentials (`user:pass`) required by the metrics
+    /// endpoint. When set, requests must send `Authorization: Basic <base64>`.
+    #[arg(long, value_name = "USER:PASS")]
     pub metrics_auth: Option<String>,
 
     /// Enable REST API endpoint (e.g., "0.0.0.0:8080").

--- a/src/output/prometheus_server.rs
+++ b/src/output/prometheus_server.rs
@@ -34,7 +34,10 @@ pub fn start_metrics_server(
     let listener = TcpListener::bind(bind_addr)
         .map_err(|e| anyhow::anyhow!("Failed to bind metrics server on {bind_addr}: {e}"))?;
 
-    tracing::info!("Prometheus metrics server listening on {bind_addr}");
+    // Log the actual bound address: with port 0 the OS assigns an ephemeral
+    // port, so logging `bind_addr` would print ":0" (mirrors the REST API/HEP).
+    let actual_addr = listener.local_addr().unwrap_or(bind_addr);
+    tracing::info!("Prometheus metrics server listening on {actual_addr}");
 
     let handle = std::thread::Builder::new()
         .name("metrics-server".to_string())

--- a/tests/cli_flag_behavior_test.rs
+++ b/tests/cli_flag_behavior_test.rs
@@ -122,6 +122,9 @@ fn mint_with_api_signing_key_file_and_ttl_roundtrips_with_expiry() {
     );
 }
 
+// Minting from an MCP signing key needs the `mcp` feature (the MCP verifier
+// config is mcp-gated); only run this where mcp is compiled in.
+#[cfg(feature = "mcp")]
 #[test]
 fn mint_with_mcp_signing_key_file_produces_token() {
     // --mcp-signing-key-file: mint using an MCP signing key loaded from a file.


### PR DESCRIPTION
Two correctness fixes found during the M6 flag-coverage burn-down:
- **`--metrics-auth` doc bug**: help said 'Bearer token', but the metrics server does **HTTP Basic auth** (`Authorization: Basic base64(user:pass)`). Corrected help + `value_name` → `USER:PASS` to match `check_basic_auth()`.
- **bound-port logging**: `start_metrics_server` now logs `local_addr()` not the requested `bind_addr`, so `:0` reports its ephemeral port (mirrors the earlier REST API + HEP fixes).

Auth logic already unit-tested (`basic_auth_valid/invalid`); the standalone metrics server only stays alive with a live source, so its offline e2e stays env-bound. No behavior change beyond the log line + help text.