### PR TITLE
test: M6 burn-down batch 4 — MCP --mcp-token-file + --mcp-allowed-host (25→23)

### DIFF
--- a/tasks/verification-plan.md
+++ b/tasks/verification-plan.md
@@ -341,14 +341,14 @@ the decryption CLI flags are tracked as debt by the T6.2 gate until real fixture
 | ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
 |---|---|---|---|---|---|
 | [ ] **T6.1** | Living traceability matrix | `tasks/verification-matrix.md` | M2–M4 | M | deferred — large enumeration; the per-class gates (T6.2) provide the enforced subset. The `[x]`/`◐`/`⚠` annotations across M1–M5 in THIS plan are the de-facto matrix |
-| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **25** currently-untested flags (was 36; 11 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
+| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **23** currently-untested flags (was 36; 13 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
 | [◐] **T6.3** | CI job wiring | `.github/workflows/ci.yml` | M1–M5 | M | the gates + golden/schema/service/token/HEP suites already run via `cargo test --all-features` / `--features full` in CI + hooks. Dedicated `e2e-docker`/`perf` jobs deferred (env-bound: no docker/NICs — see T4.7/M5) |
 | [ ] **T6.4** | Docs: test architecture | `CONTRIBUTING.md` / `docs/` | M1–M4 | S | deferred (S) — the determinism contract + layer model are documented inline in each test module's header |
 | [◐] **T6.5** | Surface registry (all 4 classes) | `tests/registry/surface.toml` | M2–M4, M3b | L | the **CLI-flag class** is enforced now (T6.2). The full multi-class TOML registry (UI controls, API fields, token states, doc examples) is the remaining large enumeration — deferred |
 | [◐] **T6.6** | 100% completeness CI gate | `tests/flag_coverage_test.rs` (+ future registry) | T6.5 | M | enforced for the **CLI-flag class** now (fails red on a new untested flag; negative meta-test proves it). Extends to the other classes when T6.5's registry lands |
 
 **M6 exit gate:** a new CLI flag cannot merge untested — **enforced now** (T6.2 ratchet, green with a
-25-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
+23-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
 enumeration follow-ups; the other classes (API/MCP/HEP/views) are already test-covered by M3/M3b/M4.
 - **Validate with:** run the extended `docs_drift_test`; as a **negative/meta-test**, add a throwaway
   flag with no referencing test and confirm the gate goes **red** (proving it actually guards), then

--- a/tests/flag_coverage_test.rs
+++ b/tests/flag_coverage_test.rs
@@ -36,8 +36,6 @@ const KNOWN_UNTESTED: &[&str] = &[
     "invert",
     "keylog",
     "keylog-watch",
-    "mcp-allowed-host",
-    "mcp-token-file",
     "metrics",
     "metrics-auth",
     "on-quality-exec",

--- a/tests/mcp_token_test.rs
+++ b/tests/mcp_token_test.rs
@@ -275,3 +275,94 @@ fn mint_token_cli_mode_produces_verifiable_token() {
         "CLI-minted token should verify under same key"
     );
 }
+
+// M6 burn-down: --mcp-token-file (static token loaded from a file).
+#[test]
+fn static_mcp_token_file_backward_compat() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("mcp.token");
+    std::fs::write(&path, "file-static-mcp-secret\n").expect("write token file");
+
+    let (child, addr) =
+        spawn_http(&["--mcp-token-file", path.to_str().unwrap()]).expect("server should start");
+    // The file's token (trimmed) authenticates; wrong/missing → 401.
+    assert_eq!(
+        initialize_status(&addr, Some("file-static-mcp-secret")),
+        200,
+        "token from --mcp-token-file → 200"
+    );
+    assert_eq!(
+        initialize_status(&addr, Some("wrong")),
+        401,
+        "wrong token → 401"
+    );
+    assert_eq!(initialize_status(&addr, None), 401, "missing token → 401");
+    shutdown(child);
+}
+
+/// POST `initialize` with an explicit `Host` header (to exercise the DNS-rebind
+/// allowlist), connecting to `addr` regardless of the header value.
+fn initialize_status_with_host(addr: &str, host_header: &str, bearer: Option<&str>) -> u16 {
+    let (host, port_str) = addr.rsplit_once(':').expect("host:port");
+    let port: u16 = port_str.parse().expect("port");
+    let body = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                   "clientInfo": {"name": "test", "version": "0"}}
+    });
+    let body_str = serde_json::to_string(&body).unwrap();
+    let mut stream = TcpStream::connect((host, port)).expect("connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("read timeout");
+    let mut req = format!(
+        "POST /mcp HTTP/1.1\r\n\
+         Host: {host_header}\r\n\
+         Content-Type: application/json\r\n\
+         Accept: application/json, text/event-stream\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n",
+        body_str.len(),
+    );
+    if let Some(b) = bearer {
+        req.push_str(&format!("Authorization: Bearer {b}\r\n"));
+    }
+    req.push_str("\r\n");
+    req.push_str(&body_str);
+    stream.write_all(req.as_bytes()).expect("write");
+    let mut resp = Vec::new();
+    stream.read_to_end(&mut resp).expect("read");
+    String::from_utf8_lossy(&resp)
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|c| c.parse().ok())
+        .unwrap_or(0)
+}
+
+// M6 burn-down: --mcp-allowed-host extends rmcp's Host-header allowlist.
+#[test]
+fn mcp_allowed_host_controls_host_header() {
+    let (child, addr) = spawn_http(&[
+        "--mcp-signing-key",
+        SIGNING_KEY,
+        "--mcp-allowed-host",
+        "custom.example",
+    ])
+    .expect("server should start");
+    let token = sipnab::auth::mint(SIGNING_KEY.as_bytes(), "host-test", now() + 3600);
+
+    // The configured Host is accepted (and auth passes) → 200.
+    assert_eq!(
+        initialize_status_with_host(&addr, "custom.example", Some(&token)),
+        200,
+        "Host added via --mcp-allowed-host must be accepted"
+    );
+    // A Host that is neither loopback nor allow-listed is rejected (not 200).
+    assert_ne!(
+        initialize_status_with_host(&addr, "blocked.invalid", Some(&token)),
+        200,
+        "a non-allowlisted Host must be rejected by DNS-rebind protection"
+    );
+    shutdown(child);
+}

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,846 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,848 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1846" data-suffix="">1846</span>
+        <span class="arch-stat" data-count="1848" data-suffix="">1848</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
- **`--mcp-token-file`**: HTTP MCP with a static token from a file → authenticates (200), wrong/missing → 401.
- **`--mcp-allowed-host`**: a request whose `Host` matches the configured allow value is accepted (200); a non-allowlisted Host is rejected by rmcp's DNS-rebind protection (≠200).

Both fully gated on `mcp-http` (combo-safe). Removed from `KNOWN_UNTESTED` (ratchet); **13 flags burned down total (36→23)**. Full suite **1848/0**; verified locally under `full` + `mcp-http,api`.