### PR TITLE
test: M6 burn-down batch 5 — match modifiers --ignore-case/--invert/--word (23→20)

### DIFF
--- a/tasks/verification-plan.md
+++ b/tasks/verification-plan.md
@@ -341,14 +341,14 @@ the decryption CLI flags are tracked as debt by the T6.2 gate until real fixture
 | ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
 |---|---|---|---|---|---|
 | [ ] **T6.1** | Living traceability matrix | `tasks/verification-matrix.md` | M2–M4 | M | deferred — large enumeration; the per-class gates (T6.2) provide the enforced subset. The `[x]`/`◐`/`⚠` annotations across M1–M5 in THIS plan are the de-facto matrix |
-| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **23** currently-untested flags (was 36; 13 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
+| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **20** currently-untested flags (was 36; 16 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
 | [◐] **T6.3** | CI job wiring | `.github/workflows/ci.yml` | M1–M5 | M | the gates + golden/schema/service/token/HEP suites already run via `cargo test --all-features` / `--features full` in CI + hooks. Dedicated `e2e-docker`/`perf` jobs deferred (env-bound: no docker/NICs — see T4.7/M5) |
 | [ ] **T6.4** | Docs: test architecture | `CONTRIBUTING.md` / `docs/` | M1–M4 | S | deferred (S) — the determinism contract + layer model are documented inline in each test module's header |
 | [◐] **T6.5** | Surface registry (all 4 classes) | `tests/registry/surface.toml` | M2–M4, M3b | L | the **CLI-flag class** is enforced now (T6.2). The full multi-class TOML registry (UI controls, API fields, token states, doc examples) is the remaining large enumeration — deferred |
 | [◐] **T6.6** | 100% completeness CI gate | `tests/flag_coverage_test.rs` (+ future registry) | T6.5 | M | enforced for the **CLI-flag class** now (fails red on a new untested flag; negative meta-test proves it). Extends to the other classes when T6.5's registry lands |
 
 **M6 exit gate:** a new CLI flag cannot merge untested — **enforced now** (T6.2 ratchet, green with a
-23-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
+20-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
 enumeration follow-ups; the other classes (API/MCP/HEP/views) are already test-covered by M3/M3b/M4.
 - **Validate with:** run the extended `docs_drift_test`; as a **negative/meta-test**, add a throwaway
   flag with no referencing test and confirm the gate goes **red** (proving it actually guards), then

--- a/tests/cli_flag_behavior_test.rs
+++ b/tests/cli_flag_behavior_test.rs
@@ -255,3 +255,54 @@ fn on_dialog_exec_runs_per_dialog() {
         "--on-dialog-exec command must run for the fixture's dialog"
     );
 }
+
+#[test]
+fn ignore_case_matches_case_insensitively() {
+    // The fixture's User-Agent is "sipnab-test/1.0". A wrong-case --ua pattern
+    // matches nothing by default but matches with --ignore-case.
+    let sensitive = ndjson_lines(&run(&["-N", "-I", FIXTURE, "--ua", "SIPNAB", "--json"]));
+    assert!(
+        sensitive.is_empty(),
+        "case-sensitive --ua SIPNAB must not match"
+    );
+    let insensitive = ndjson_lines(&run(&[
+        "-N",
+        "-I",
+        FIXTURE,
+        "--ua",
+        "SIPNAB",
+        "--ignore-case",
+        "--json",
+    ]));
+    assert!(
+        !insensitive.is_empty(),
+        "--ignore-case must match the differently-cased User-Agent"
+    );
+}
+
+#[test]
+fn invert_shows_non_matching() {
+    // Every message's From is 1001, so --from 1001 matches all; --invert flips
+    // it to none.
+    let matched = ndjson_lines(&run(&["-N", "-I", FIXTURE, "--from", "1001", "--json"]));
+    assert_eq!(matched.len(), 7, "--from 1001 should match all 7 messages");
+    let inverted = ndjson_lines(&run(&[
+        "-N", "-I", FIXTURE, "--from", "1001", "--invert", "--json",
+    ]));
+    assert!(
+        inverted.is_empty(),
+        "--invert must drop the matching messages"
+    );
+}
+
+#[test]
+fn word_matches_whole_words_only() {
+    // "nab" is a substring of the UA "sipnab-test" but not a whole word, so
+    // --word excludes it while a plain substring match includes it.
+    let substring = ndjson_lines(&run(&["-N", "-I", FIXTURE, "--ua", "nab", "--json"]));
+    assert!(!substring.is_empty(), "substring --ua nab should match");
+    let whole = ndjson_lines(&run(&[
+        "-N", "-I", FIXTURE, "--ua", "nab", "--word", "--json",
+    ]));
+    assert!(whole.is_empty(), "--word must require a whole-word match");
+}

--- a/tests/flag_coverage_test.rs
+++ b/tests/flag_coverage_test.rs
@@ -32,8 +32,6 @@ const KNOWN_UNTESTED: &[&str] = &[
     "chroot",
     "dtls-keylog",
     "hep-parse",
-    "ignore-case",
-    "invert",
     "keylog",
     "keylog-watch",
     "metrics",
@@ -48,7 +46,6 @@ const KNOWN_UNTESTED: &[&str] = &[
     "tag",
     "telephone-event",
     "tls-key",
-    "word",
 ];
 
 /// All long flags (and long aliases) the CLI accepts, via clap.

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,848 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,851 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1848" data-suffix="">1848</span>
+        <span class="arch-stat" data-count="1851" data-suffix="">1851</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Behavior tests via the `--ua`/`--from` regex filters:
- **`--ignore-case`**: `--ua SIPNAB` matches nothing; with `--ignore-case` it matches.
- **`--invert`**: `--from 1001` matches all 7; `--invert` drops to none.
- **`--word`**: `--ua nab` matches as a substring; `--word` requires a whole word (none).

Removed from `KNOWN_UNTESTED`; **16 flags burned down total (36→20)**. Combo-safe (unconditional flags, file api-gated). Full suite **1851/0**.