### PR TITLE
test: M6 burn-down batch 6 — --after/--rotate/--tag (20→17)

### DIFF
--- a/tasks/verification-plan.md
+++ b/tasks/verification-plan.md
@@ -341,14 +341,14 @@ the decryption CLI flags are tracked as debt by the T6.2 gate until real fixture
 | ID | Task | Deliverable files | Deps | Size | Success (pass) criteria |
 |---|---|---|---|---|---|
 | [ ] **T6.1** | Living traceability matrix | `tasks/verification-matrix.md` | M2–M4 | M | deferred — large enumeration; the per-class gates (T6.2) provide the enforced subset. The `[x]`/`◐`/`⚠` annotations across M1–M5 in THIS plan are the de-facto matrix |
-| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **20** currently-untested flags (was 36; 16 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
+| [x] **T6.2** | "No untested flag" CI gate | `tests/flag_coverage_test.rs` | T1.4 | M | ✅ clap-enumerated flags must each be referenced in the test corpus (tests/ + cli.rs `#[cfg(test)]`, definitions excluded). **Ratchet**: fails on a new untested flag, on a waived flag that became tested (list may only shrink), and on a stale waiver. Baseline of **17** currently-untested flags (was 36; 19 burned down in M6 — see `cli_flag_behavior_test.rs`) captured as `KNOWN_UNTESTED` debt. **Negative meta-test** proves it guards. Runs in CI via `cargo test --features full` |
 | [◐] **T6.3** | CI job wiring | `.github/workflows/ci.yml` | M1–M5 | M | the gates + golden/schema/service/token/HEP suites already run via `cargo test --all-features` / `--features full` in CI + hooks. Dedicated `e2e-docker`/`perf` jobs deferred (env-bound: no docker/NICs — see T4.7/M5) |
 | [ ] **T6.4** | Docs: test architecture | `CONTRIBUTING.md` / `docs/` | M1–M4 | S | deferred (S) — the determinism contract + layer model are documented inline in each test module's header |
 | [◐] **T6.5** | Surface registry (all 4 classes) | `tests/registry/surface.toml` | M2–M4, M3b | L | the **CLI-flag class** is enforced now (T6.2). The full multi-class TOML registry (UI controls, API fields, token states, doc examples) is the remaining large enumeration — deferred |
 | [◐] **T6.6** | 100% completeness CI gate | `tests/flag_coverage_test.rs` (+ future registry) | T6.5 | M | enforced for the **CLI-flag class** now (fails red on a new untested flag; negative meta-test proves it). Extends to the other classes when T6.5's registry lands |
 
 **M6 exit gate:** a new CLI flag cannot merge untested — **enforced now** (T6.2 ratchet, green with a
-20-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
+17-flag debt baseline (down from 36)). The full 4-class surface registry (T6.5) + matrix (T6.1) remain as large
 enumeration follow-ups; the other classes (API/MCP/HEP/views) are already test-covered by M3/M3b/M4.
 - **Validate with:** run the extended `docs_drift_test`; as a **negative/meta-test**, add a throwaway
   flag with no referencing test and confirm the gate goes **red** (proving it actually guards), then

--- a/tests/cli_flag_behavior_test.rs
+++ b/tests/cli_flag_behavior_test.rs
@@ -306,3 +306,67 @@ fn word_matches_whole_words_only() {
     ]));
     assert!(whole.is_empty(), "--word must require a whole-word match");
 }
+
+#[test]
+fn after_shows_trailing_context() {
+    // --after N is grep -A: N messages after each match. The UA appears on one
+    // request; --after 2 adds the two following messages.
+    let match_only = ndjson_lines(&run(&["-N", "-I", FIXTURE, "--ua", "sipnab", "--json"]));
+    assert_eq!(match_only.len(), 1, "exactly one message carries the UA");
+    let with_after = ndjson_lines(&run(&[
+        "-N", "-I", FIXTURE, "--ua", "sipnab", "--after", "2", "--json",
+    ]));
+    assert_eq!(with_after.len(), 3, "--after 2 adds two trailing messages");
+}
+
+#[test]
+fn rotate_discards_oldest_dialog() {
+    // The RTP fixture has two dialogs (1-1966 then 1-1968). --limit 1 keeps the
+    // FIRST; --limit 1 --rotate discards the oldest and keeps the NEWEST.
+    let rtp = "tests/pcap-samples/sip-rtp-g711.pcap";
+    let no_rotate = run(&[
+        "-N",
+        "-I",
+        rtp,
+        "--limit",
+        "1",
+        "--report",
+        "--no-cli-print",
+    ]);
+    assert!(
+        no_rotate.contains("1-1966@") && !no_rotate.contains("1-1968@"),
+        "--limit 1 (no rotate) keeps the first dialog"
+    );
+    let rotated = run(&[
+        "-N",
+        "-I",
+        rtp,
+        "--limit",
+        "1",
+        "--rotate",
+        "--report",
+        "--no-cli-print",
+    ]);
+    assert!(
+        rotated.contains("1-1968@") && !rotated.contains("1-1966@"),
+        "--rotate keeps the newest dialog and discards the oldest"
+    );
+}
+
+#[test]
+fn tag_labels_dialogs() {
+    // --tag applies the given tag to dialogs; it shows in the report Tags column.
+    let out = run(&[
+        "-N",
+        "-I",
+        FIXTURE,
+        "--tag",
+        "burndown-tag",
+        "--report",
+        "--no-cli-print",
+    ]);
+    assert!(
+        out.contains("burndown-tag"),
+        "--tag value must appear in the report:\n{out}"
+    );
+}

--- a/tests/flag_coverage_test.rs
+++ b/tests/flag_coverage_test.rs
@@ -26,7 +26,6 @@ const KNOWN_UNTESTED: &[&str] = &[
     // Burned down in M6 (see tests/cli_flag_behavior_test.rs): count,
     // calls-only, text-dump, pcapng, api-signing-key-file, api-token-ttl,
     // mcp-signing-key-file — removed from this baseline as the ratchet requires.
-    "after",
     "alert-exec",
     "buffer",
     "chroot",
@@ -39,11 +38,9 @@ const KNOWN_UNTESTED: &[&str] = &[
     "on-quality-exec",
     "pcap-export-mode",
     "replay",
-    "rotate",
     "split",
     "srtp-keys",
     "syslog",
-    "tag",
     "telephone-event",
     "tls-key",
 ];

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,851 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,854 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1851" data-suffix="">1851</span>
+        <span class="arch-stat" data-count="1854" data-suffix="">1854</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
- **`--after`** (grep -A): one UA match + `--after 2` → 3 messages.
- **`--rotate`**: with `--limit 1` on the 2-dialog RTP fixture, `--rotate` discards the oldest (keeps 1-1968) vs `--limit` alone keeping 1-1966.
- **`--tag`**: the tag value appears in the report Tags column.

**19 flags burned down total (36→17).** Combo-safe, locally verified. Full suite **1854/0**.