### PR TITLE
feat(tui): sngrep-style [ ]/[*] selection checkboxes drive Save & Clear

### DIFF
--- a/src/tui/call_list.rs
+++ b/src/tui/call_list.rs
@@ -308,6 +308,67 @@ pub struct CallListDisplay<'a> {
 /// Uses sngrep-style: borderless, bold-on-cyan header, reverse-video
 /// selected row, full-width layout. No title line -- status is rendered
 /// separately at the top of the screen.
+/// Returns true if `dialog` matches the case-insensitive search query,
+/// scanning the same fields the call list displays plus raw message bodies
+/// (the sngrep/Wireshark-style full-text fallback). `query_lower` must
+/// already be lowercased by the caller.
+pub fn dialog_matches_search(dialog: &crate::sip::dialog::SipDialog, query_lower: &str) -> bool {
+    dialog.call_id.to_ascii_lowercase().contains(query_lower)
+        || dialog
+            .method
+            .as_str()
+            .to_ascii_lowercase()
+            .contains(query_lower)
+        || dialog
+            .from_user
+            .as_deref()
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .contains(query_lower)
+        || dialog
+            .to_user
+            .as_deref()
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .contains(query_lower)
+        || dialog.src_addr.to_string().contains(query_lower)
+        || dialog.dst_addr.to_string().contains(query_lower)
+        || state_display_str(dialog.state())
+            .to_ascii_lowercase()
+            .contains(query_lower)
+        || dialog.messages.iter().any(|msg| {
+            String::from_utf8_lossy(&msg.raw)
+                .to_ascii_lowercase()
+                .contains(query_lower)
+        })
+}
+
+/// Build the dialog list in the exact order the call list displays it:
+/// filtered by `filter`, then by `search_query`, then sorted by the active
+/// column/direction.
+///
+/// This is the single source of truth shared by the renderer and by the
+/// save/clear actions, so that multi-select row indices always map to the
+/// same dialogs the user sees on screen.
+pub fn displayed_dialogs<'a>(
+    store: &'a DialogStore,
+    filter: Option<&FilterExpr>,
+    search_query: &str,
+    sort_column: SortColumn,
+    sort_ascending: bool,
+) -> Vec<&'a crate::sip::dialog::SipDialog> {
+    let mut dialogs: Vec<_> = match filter {
+        Some(f) => store.iter().filter(|d| f.matches_dialog(d, &[])).collect(),
+        None => store.iter().collect(),
+    };
+    if !search_query.is_empty() {
+        let q = search_query.to_ascii_lowercase();
+        dialogs.retain(|d| dialog_matches_search(d, &q));
+    }
+    sort_dialogs(&mut dialogs, sort_column, sort_ascending);
+    dialogs
+}
+
 pub fn render_call_list(
     frame: &mut Frame,
     area: Rect,
@@ -367,47 +428,15 @@ pub fn render_call_list(
     let all_widths = compute_column_widths(table_area.width);
     let widths: Vec<Constraint> = vis_indices.iter().map(|&i| all_widths[i]).collect();
 
-    let mut dialogs: Vec<_> = if let Some(filter) = filter {
-        store
-            .iter()
-            .filter(|d| filter.matches_dialog(d, &[]))
-            .collect()
-    } else {
-        store.iter().collect()
-    };
-
-    // Text search: filter across all visible fields (case-insensitive),
-    // falling back to raw message body search (like sngrep/Wireshark).
-    if !search_query.is_empty() {
-        let q = search_query.to_ascii_lowercase();
-        dialogs.retain(|d| {
-            d.call_id.to_ascii_lowercase().contains(&q)
-                || d.method.as_str().to_ascii_lowercase().contains(&q)
-                || d.from_user
-                    .as_deref()
-                    .unwrap_or("")
-                    .to_ascii_lowercase()
-                    .contains(&q)
-                || d.to_user
-                    .as_deref()
-                    .unwrap_or("")
-                    .to_ascii_lowercase()
-                    .contains(&q)
-                || d.src_addr.to_string().contains(&q)
-                || d.dst_addr.to_string().contains(&q)
-                || state_display_str(d.state())
-                    .to_ascii_lowercase()
-                    .contains(&q)
-                || d.messages.iter().any(|msg| {
-                    String::from_utf8_lossy(&msg.raw)
-                        .to_ascii_lowercase()
-                        .contains(&q)
-                })
-        });
-    }
-
-    // Sort dialogs by the selected column
-    sort_dialogs(&mut dialogs, state.sort_column(), state.sort_ascending());
+    // Build the displayed list (filter + search + sort) via the shared
+    // helper so multi-select indices map to exactly these rows.
+    let dialogs = displayed_dialogs(
+        store,
+        filter,
+        search_query,
+        state.sort_column(),
+        state.sort_ascending(),
+    );
 
     // Always render the header, even when empty (sngrep style).
     // Show a help message below the header if there are no dialogs.
@@ -465,11 +494,12 @@ pub fn render_call_list(
         .map(|(vis_idx, dialog)| {
             let idx = scroll_offset + vis_idx; // original index in full list
 
-            // Show selection marker for multi-selected rows
-            let diag_icon = if state.selected_rows.contains(&idx) {
-                "\u{25B8}" // ▸
+            // sngrep-style selection checkbox: [*] when checked, [ ] otherwise.
+            // The checkbox marks which dialogs an action (e.g. save) applies to.
+            let checkbox = if state.selected_rows.contains(&idx) {
+                "[*]"
             } else {
-                " "
+                "[ ]"
             };
 
             // Date column formatting based on timestamp mode
@@ -523,7 +553,7 @@ pub fn render_call_list(
             };
 
             let all_cells = [
-                Cell::from(Span::raw(format!("{}{}", diag_icon, idx + 1))),
+                Cell::from(Span::raw(format!("{}{}", checkbox, idx + 1))),
                 Cell::from(Span::styled(dialog.method.as_str(), method_style)),
                 Cell::from(Span::raw(dialog.from_user.as_deref().unwrap_or("-"))),
                 Cell::from(Span::raw(dialog.to_user.as_deref().unwrap_or("-"))),
@@ -601,8 +631,9 @@ fn compute_column_widths(total_width: u16) -> Vec<Constraint> {
     let overhead: u16 = 11;
 
     if total_width >= 120 {
-        // Fixed: #(5) + Method(10) + State(12) + Msgs(5) + Date(8) + PDD(8) = 48
-        let fixed: u16 = 48 + overhead;
+        // Fixed: #(6) + Method(10) + State(12) + Msgs(5) + Date(8) + PDD(8) = 49
+        // #(6) holds the "[ ]" checkbox plus up to a 3-digit index.
+        let fixed: u16 = 49 + overhead;
         let flex = total_width.saturating_sub(fixed);
         // Src/Dst each get 21+, From/To split remainder
         let addr_each = 21.min(flex / 4);
@@ -610,7 +641,7 @@ fn compute_column_widths(total_width: u16) -> Vec<Constraint> {
         let from_w = from_to_pool / 2;
         let to_w = from_to_pool - from_w;
         vec![
-            Constraint::Length(5),
+            Constraint::Length(6),
             Constraint::Length(10),
             Constraint::Length(from_w),
             Constraint::Length(to_w),
@@ -622,15 +653,16 @@ fn compute_column_widths(total_width: u16) -> Vec<Constraint> {
             Constraint::Length(8),
         ]
     } else {
-        // Tighter layout: #(4) + Method(8) + State(10) + Msgs(4) + Date(8) + PDD(6) = 40
-        let fixed: u16 = 40 + overhead;
+        // Tighter layout: #(5) + Method(8) + State(10) + Msgs(4) + Date(8) + PDD(6) = 41
+        // #(5) holds the "[ ]" checkbox plus up to a 2-digit index.
+        let fixed: u16 = 41 + overhead;
         let flex = total_width.saturating_sub(fixed);
         let addr_each = (flex * 2 / 5).max(11);
         let from_to_pool = flex.saturating_sub(addr_each * 2);
         let from_w = (from_to_pool / 2).max(4);
         let to_w = from_to_pool.saturating_sub(from_w).max(4);
         vec![
-            Constraint::Length(4),
+            Constraint::Length(5),
             Constraint::Length(8),
             Constraint::Length(from_w),
             Constraint::Length(to_w),

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -236,14 +236,15 @@ pub(super) fn clear_calls(app: &mut App) {
         // Clear only selected rows: collect the Call-IDs to remove
         let call_ids_to_remove: Vec<String> = {
             let store = app.dialog_store.read();
-            let dialogs: Vec<_> = if let Some(ref filter) = app.active_filter {
-                store
-                    .iter()
-                    .filter(|d| filter.matches_dialog(d, &[]))
-                    .collect()
-            } else {
-                store.iter().collect()
-            };
+            // Map selected row indices to dialogs through the same displayed
+            // (filter + search + sort) ordering the user sees on screen.
+            let dialogs = call_list::displayed_dialogs(
+                &store,
+                app.active_filter.as_ref(),
+                &app.search_query,
+                app.call_list.sort_column(),
+                app.call_list.sort_ascending(),
+            );
             selected_rows
                 .iter()
                 .filter_map(|&idx| dialogs.get(idx).map(|d| d.call_id.clone()))

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1092,6 +1092,37 @@ impl App {
         &self.search_query
     }
 
+    /// Dialogs that a call-list action (save, clear) applies to, in the
+    /// order shown on screen: the checkbox-selected rows if any are checked,
+    /// otherwise every displayed (filtered + searched) dialog.
+    ///
+    /// Borrows from the provided store guard. This mirrors what the user sees
+    /// — selection indices are positions in the rendered, sorted list — so
+    /// the same helper backs both rendering and these actions.
+    pub(super) fn dialogs_to_export<'a>(
+        &self,
+        store: &'a DialogStore,
+    ) -> Vec<&'a crate::sip::dialog::SipDialog> {
+        let displayed = call_list::displayed_dialogs(
+            store,
+            self.active_filter.as_ref(),
+            &self.search_query,
+            self.call_list.sort_column(),
+            self.call_list.sort_ascending(),
+        );
+        let selected = self.call_list.selected_rows();
+        if selected.is_empty() {
+            displayed
+        } else {
+            displayed
+                .into_iter()
+                .enumerate()
+                .filter(|(i, _)| selected.contains(i))
+                .map(|(_, d)| d)
+                .collect()
+        }
+    }
+
     /// Return whether syntax highlighting is enabled.
     pub fn syntax_highlight(&self) -> bool {
         self.syntax_highlight

--- a/src/tui/save.rs
+++ b/src/tui/save.rs
@@ -11,8 +11,11 @@ pub(super) fn save_to_pcap_path(app: &App, path_str: &str, pcapng: bool) -> Stri
     let store = app.dialog_store.read();
 
     // Collect all messages across all dialogs
-    let messages: Vec<&crate::sip::SipMessage> =
-        store.iter().flat_map(|d| d.messages.iter()).collect();
+    let messages: Vec<&crate::sip::SipMessage> = app
+        .dialogs_to_export(&store)
+        .into_iter()
+        .flat_map(|d| d.messages.iter())
+        .collect();
 
     if messages.is_empty() {
         return "No messages to save".to_string();
@@ -49,8 +52,11 @@ pub(super) fn save_to_txt_path(app: &App, path_str: &str) -> String {
     let path = PathBuf::from(path_str);
     let store = app.dialog_store.read();
 
-    let messages: Vec<&crate::sip::SipMessage> =
-        store.iter().flat_map(|d| d.messages.iter()).collect();
+    let messages: Vec<&crate::sip::SipMessage> = app
+        .dialogs_to_export(&store)
+        .into_iter()
+        .flat_map(|d| d.messages.iter())
+        .collect();
 
     if messages.is_empty() {
         return "No messages to save".to_string();
@@ -119,8 +125,11 @@ pub(super) fn save_to_mermaid_path(app: &App, path_str: &str) -> String {
                 Vec::new()
             }
         } else {
-            // In call list: export all dialogs
-            store.iter().flat_map(|d| d.messages.clone()).collect()
+            // In call list: export the selected dialogs (or all if none checked)
+            app.dialogs_to_export(&store)
+                .into_iter()
+                .flat_map(|d| d.messages.clone())
+                .collect()
         };
 
     if messages.is_empty() {
@@ -189,7 +198,7 @@ pub(super) fn csv_escape(field: &str) -> String {
 pub(super) fn save_to_json_path(app: &App, path_str: &str) -> String {
     let path = PathBuf::from(path_str);
     let store = app.dialog_store.read();
-    let dialogs: Vec<&crate::sip::dialog::SipDialog> = store.iter().collect();
+    let dialogs: Vec<&crate::sip::dialog::SipDialog> = app.dialogs_to_export(&store);
 
     if dialogs.is_empty() {
         return "No dialogs to save".to_string();
@@ -256,7 +265,7 @@ pub(super) fn save_to_json_path(app: &App, path_str: &str) -> String {
 pub(super) fn save_to_ndjson_path(app: &App, path_str: &str) -> String {
     let path = PathBuf::from(path_str);
     let store = app.dialog_store.read();
-    let dialogs: Vec<&crate::sip::dialog::SipDialog> = store.iter().collect();
+    let dialogs: Vec<&crate::sip::dialog::SipDialog> = app.dialogs_to_export(&store);
 
     if dialogs.is_empty() {
         return "No dialogs to save".to_string();
@@ -327,7 +336,7 @@ pub(super) fn save_to_ndjson_path(app: &App, path_str: &str) -> String {
 pub(super) fn save_to_csv_path(app: &App, path_str: &str) -> String {
     let path = PathBuf::from(path_str);
     let store = app.dialog_store.read();
-    let dialogs: Vec<&crate::sip::dialog::SipDialog> = store.iter().collect();
+    let dialogs: Vec<&crate::sip::dialog::SipDialog> = app.dialogs_to_export(&store);
 
     if dialogs.is_empty() {
         return "No dialogs to save".to_string();
@@ -370,7 +379,7 @@ pub(super) fn save_to_csv_path(app: &App, path_str: &str) -> String {
 pub(super) fn save_to_markdown_path(app: &App, path_str: &str) -> String {
     let path = PathBuf::from(path_str);
     let store = app.dialog_store.read();
-    let dialogs: Vec<&crate::sip::dialog::SipDialog> = store.iter().collect();
+    let dialogs: Vec<&crate::sip::dialog::SipDialog> = app.dialogs_to_export(&store);
 
     if dialogs.is_empty() {
         return "No dialogs to save".to_string();
@@ -519,11 +528,12 @@ pub(super) fn save_to_sipp_path(app: &App, path_str: &str) -> String {
     let path = PathBuf::from(path_str);
     let store = app.dialog_store.read();
 
-    // Pick dialog: current call flow view or first dialog
+    // Pick dialog: current call flow view, else the first selected dialog
+    // (or the first overall when nothing is checked).
     let dialog = if let View::CallFlow(ref call_id) = app.current_view {
         store.get(call_id)
     } else {
-        store.iter().next()
+        app.dialogs_to_export(&store).into_iter().next()
     };
 
     let dialog = match dialog {
@@ -865,6 +875,41 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&content).unwrap();
         assert!(v.is_array());
         assert_eq!(v.as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn json_save_honors_selection() {
+        // sngrep parity: checking rows limits the export to the selected
+        // dialogs (the [*] checkbox group). Here only call-1 is checked.
+        let mut app = app_with_dialogs();
+        app.call_list.move_to_top(); // cursor on row 0 (call-1)
+        app.call_list.toggle_selection(); // check it
+        let p = tmp_path("sel.json");
+        let msg = save_to_json_path(&app, p.to_str().unwrap());
+        assert!(msg.contains("Saved"), "got: {msg}");
+        let content = std::fs::read_to_string(&p).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            v.as_array().unwrap().len(),
+            1,
+            "only the selected dialog should be exported"
+        );
+        assert!(content.contains("call-1@test"), "selected dialog present");
+        assert!(
+            !content.contains("call-2@test"),
+            "unselected dialog must be excluded"
+        );
+    }
+
+    #[test]
+    fn save_with_no_selection_exports_all() {
+        // No checkboxes set -> export everything (current default behavior).
+        let app = app_with_dialogs();
+        let p = tmp_path("all.json");
+        save_to_json_path(&app, p.to_str().unwrap());
+        let content = std::fs::read_to_string(&p).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 2, "all dialogs exported");
     }
 
     #[test]

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_autoscroll_off.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_autoscroll_off.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 596
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲  Method  From To   Source      Destination State      Msgs Date     PDD
->  1   INVITE  1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
-   2   INVITE  1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
-   3   INVITE  1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
+  # ▲   Method From To   Source      Destination State      Msgs Date     PDD
+> [ ]1  INVITE 1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
+  [ ]2  INVITE 1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
+  [ ]3  INVITE 1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_column_selector_popup.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_column_selector_popup.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 643
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲  Method  From To   Source      Destination State      Msgs Date     PDD
->  1   INVITE  1001 1┌ Columns ───────────────────────────┐ 4    +0.000s  1000ms
-   2   INVITE  1003 1│> [x] #                             │ 2    +5.000s
-   3   INVITE  1005 1│  [x] Method                        │ 2    +5.000s
+  # ▲   Method From To   Source      Destination State      Msgs Date     PDD
+> [ ]1  INVITE 1001 1┌ Columns ───────────────────────────┐ 4    +0.000s  1000ms
+  [ ]2  INVITE 1003 1│> [x] #                             │ 2    +5.000s
+  [ ]3  INVITE 1005 1│  [x] Method                        │ 2    +5.000s
                      │  [x] From                          │
                      │  [x] To                            │
                      │  [x] Source                        │

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_empty.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_empty.snap
@@ -1,12 +1,11 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 284
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 0 (0 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-# ▲  Method   From To   Source      Destination State      Msgs Date     PDD
+# ▲   Method   From To   Source      Destination State      Msgs Date     PDD
 
   No SIP dialogs found.
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_failed_dialog_styling.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_failed_dialog_styling.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 421
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 1 (1 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲  Method  From To   Source      Destination State      Msgs Date     PDD
->  1   INVITE  1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +0.000s
+  # ▲   Method From To   Source      Destination State      Msgs Date     PDD
+> [ ]1  INVITE 1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +0.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_multi_selected.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_multi_selected.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 585
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲  Method  From To   Source      Destination State      Msgs Date     PDD
-  ▸1   INVITE  1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
-> ▸2   INVITE  1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
-   3   INVITE  1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
+  # ▲   Method From To   Source      Destination State      Msgs Date     PDD
+  [*]1  INVITE 1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
+> [*]2  INVITE 1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
+  [ ]3  INVITE 1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_paused.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_paused.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 607
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  PAUSED  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲  Method  From To   Source      Destination State      Msgs Date     PDD
->  1   INVITE  1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
-   2   INVITE  1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
-   3   INVITE  1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
+  # ▲   Method From To   Source      Destination State      Msgs Date     PDD
+> [ ]1  INVITE 1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
+  [ ]2  INVITE 1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
+  [ ]3  INVITE 1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_search_active.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_search_active.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 632
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  /test
-  # ▲  Method  From To   Source      Destination State      Msgs Date     PDD
->  1   INVITE  1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
-   2   INVITE  1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
-   3   INVITE  1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
+  # ▲   Method From To   Source      Destination State      Msgs Date     PDD
+> [ ]1  INVITE 1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
+  [ ]2  INVITE 1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
+  [ ]3  INVITE 1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_sort_by_method.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_sort_by_method.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 572
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-   #   Method  From To   Source      Destination State      Msgs Date     PDD
->  1   INVITE  1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
-   2   INVITE  1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
-   3   INVITE  1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
+   #    Method From To   Source      Destination State      Msgs Date     PDD
+> [ ]1  INVITE 1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
+  [ ]2  INVITE 1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
+  [ ]3  INVITE 1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_status_error.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_status_error.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 618
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Time: Delta-first
-  # ▲  Method  From To   Source      Destination State      Msgs Date     PDD
->  1   INVITE  1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
-   2   INVITE  1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
-   3   INVITE  1005 1006 10.0.0.1    10.0.0.2    InCall     2    +10.000s
+  # ▲   Method From To   Source      Destination State      Msgs Date     PDD
+> [ ]1  INVITE 1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
+  [ ]2  INVITE 1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
+  [ ]3  INVITE 1005 1006 10.0.0.1    10.0.0.2    InCall     2    +10.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_timestamp_delta_first.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_timestamp_delta_first.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 561
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Time: Scaled
-  # ▲  Method  From To   Source      Destination State      Msgs Date     PDD
->  1   INVITE  1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
-   2   INVITE  1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
-   3   INVITE  1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
+  # ▲   Method From To   Source      Destination State      Msgs Date     PDD
+> [ ]1  INVITE 1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
+  [ ]2  INVITE 1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
+  [ ]3  INVITE 1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_timestamp_delta_prev.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_timestamp_delta_prev.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 549
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Time: Delta-first
-  # ▲  Method  From To   Source      Destination State      Msgs Date     PDD
->  1   INVITE  1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
-   2   INVITE  1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
-   3   INVITE  1005 1006 10.0.0.1    10.0.0.2    InCall     2    +10.000s
+  # ▲   Method From To   Source      Destination State      Msgs Date     PDD
+> [ ]1  INVITE 1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
+  [ ]2  INVITE 1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
+  [ ]3  INVITE 1005 1006 10.0.0.1    10.0.0.2    InCall     2    +10.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_with_dialogs.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_with_dialogs.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 296
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲  Method  From To   Source      Destination State      Msgs Date     PDD
->  1   INVITE  1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
-   2   INVITE  1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
-   3   INVITE  1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
+  # ▲   Method From To   Source      Destination State      Msgs Date     PDD
+> [ ]1  INVITE 1001 1002 10.0.0.1    10.0.0.2    Completed  4    +0.000s  1000ms
+  [ ]2  INVITE 1003 1004 10.0.0.1    10.0.0.2    FAILED     2    +5.000s
+  [ ]3  INVITE 1005 1006 10.0.0.1    10.0.0.2    InCall     2    +5.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_with_dialogs_wide.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_with_dialogs_wide.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 308
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲   Method     From               To                  Source            Destination       State        Msgs  Date     PDD
->  1    INVITE     1001               1002                10.0.0.1          10.0.0.2          Completed    4     +0.000s  1000ms
-   2    INVITE     1003               1004                10.0.0.1          10.0.0.2          FAILED       2     +5.000s
-   3    INVITE     1005               1006                10.0.0.1          10.0.0.2          InCall       2     +5.000s
+  # ▲    Method     From               To                 Source            Destination       State        Msgs  Date     PDD
+> [ ]1   INVITE     1001               1002               10.0.0.1          10.0.0.2          Completed    4     +0.000s  1000ms
+  [ ]2   INVITE     1003               1004               10.0.0.1          10.0.0.2          FAILED       2     +5.000s
+  [ ]3   INVITE     1005               1006               10.0.0.1          10.0.0.2          InCall       2     +5.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_with_filter_active.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_with_filter_active.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 396
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (1 displayed)  [A]
  Match Expression: from.user =~ '1003'    BPF Filter:
  Display Filter: from.user =~ '1003'
-  # ▲  Method   From  To     Source              Destination         State      Msgs Date     PDD
->  1   INVITE   1003  1004   10.0.0.1            10.0.0.2            FAILED     2    +0.000s
+  # ▲   Method   From  To    Source              Destination         State      Msgs Date     PDD
+> [ ]1  INVITE   1003  1004  10.0.0.1            10.0.0.2            FAILED     2    +0.000s
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__file_open_popup.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__file_open_popup.snap
@@ -5,10 +5,10 @@ expression: output
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲   Method     From            To               Source          Destination     State        Msgs  Date     PDD
->  1    INVITE     1001            1002             10.0.0.1        10.0.0.2        Completed    4     +0.000s  1000ms
-   2    INVITE     1003            1004             10.0.0.1        10.0.0.2        FAILED       2     +5.000s
-   3    INVITE     1005            1006             10.0.0.1        10.0.0.2        InCall       2     +5.000s
+  # ▲    Method     From            To              Source          Destination     State        Msgs  Date     PDD
+> [ ]1   INVITE     1001            1002            10.0.0.1        10.0.0.2        Completed    4     +0.000s  1000ms
+  [ ]2   INVITE     1003            1004            10.0.0.1        10.0.0.2        FAILED       2     +5.000s
+  [ ]3   INVITE     1005            1006            10.0.0.1        10.0.0.2        InCall       2     +5.000s
 
 
                     ┌ Open PCAP File ──────────────────────────────────────────────────────────────┐

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__filter_dialog_popup.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__filter_dialog_popup.snap
@@ -5,7 +5,7 @@ expression: output
  Current Mode: Online (any)    Dialogs: 0 (0 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Fil┌ Filter ──────────────────────────────────────────────┐
-# ▲  Method │                                                      │     PDD
+# ▲   Method│                                                      │e     PDD
             │  SIP From:    [                                   ]  │
   No SIP dia│  SIP To:      [                                   ]  │
             │  Source:      [                                   ]  │

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__narrow_terminal_layout.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__narrow_terminal_layout.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 755
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲  Meth From To   Source Desti State  Msgs Date   PDD
->  1   INVI 1001 1002 10.0.0 10.0. Comple 4    +0.000 1000ms
-   2   INVI 1003 1004 10.0.0 10.0. FAILED 2    +5.000
-   3   INVI 1005 1006 10.0.0 10.0. InCall 2    +5.000
+  # ▲   Metho From To   Sourc Desti State Msgs Date   PDD
+> [ ]1  INVIT 1001 1002 10.0. 10.0. Compl 4    +0.000 1000ms
+  [ ]2  INVIT 1003 1004 10.0. 10.0. FAILE 2    +5.000
+  [ ]3  INVIT 1005 1006 10.0. 10.0. InCal 2    +5.000
 
 
 

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_csv_format.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_csv_format.snap
@@ -6,9 +6,9 @@ expression: output
  Match Expression:     BPF Filter:
  Dis┌ Save Capture ────────────────────────────────────────────────────────┐
   # │                                                                      │D
->  1│  Save to: /tmp/sipnab_20240615_120000.csv                            │00ms
-   2│                                                                      │
-   3│  Packet Capture                                                      │
+> [ │  Save to: /tmp/sipnab_20240615_120000.csv                            │00ms
+  [ │                                                                      │
+  [ │  Packet Capture                                                      │
     │      PCAP    Universal baseline (Wireshark, tcpdump, Homer)          │
     │      PCAP-NG Modern format with metadata and annotations             │
     │                                                                      │

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_html_format.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_html_format.snap
@@ -6,9 +6,9 @@ expression: output
  Match Expression:     BPF Filter:
  Dis┌ Save Capture ────────────────────────────────────────────────────────┐
   # │                                                                      │D
->  1│  Save to: /tmp/sipnab_20240615_120000.html                           │00ms
-   2│                                                                      │
-   3│  Packet Capture                                                      │
+> [ │  Save to: /tmp/sipnab_20240615_120000.html                           │00ms
+  [ │                                                                      │
+  [ │  Packet Capture                                                      │
     │      PCAP    Universal baseline (Wireshark, tcpdump, Homer)          │
     │      PCAP-NG Modern format with metadata and annotations             │
     │                                                                      │

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_json_format.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_json_format.snap
@@ -6,9 +6,9 @@ expression: output
  Match Expression:     BPF Filter:
  Dis┌ Save Capture ────────────────────────────────────────────────────────┐
   # │                                                                      │D
->  1│  Save to: /tmp/sipnab_20240615_120000.json                           │00ms
-   2│                                                                      │
-   3│  Packet Capture                                                      │
+> [ │  Save to: /tmp/sipnab_20240615_120000.json                           │00ms
+  [ │                                                                      │
+  [ │  Packet Capture                                                      │
     │      PCAP    Universal baseline (Wireshark, tcpdump, Homer)          │
     │      PCAP-NG Modern format with metadata and annotations             │
     │                                                                      │

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_pcapng_format.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_pcapng_format.snap
@@ -6,9 +6,9 @@ expression: output
  Match Expression:     BPF Filter:
  Dis┌ Save Capture ────────────────────────────────────────────────────────┐
   # │                                                                      │D
->  1│  Save to: /tmp/sipnab_20240615_120000.pcapng                         │00ms
-   2│                                                                      │
-   3│  Packet Capture                                                      │
+> [ │  Save to: /tmp/sipnab_20240615_120000.pcapng                         │00ms
+  [ │                                                                      │
+  [ │  Packet Capture                                                      │
     │      PCAP    Universal baseline (Wireshark, tcpdump, Homer)          │
     │    ▸ PCAP-NG Modern format with metadata and annotations             │
     │                                                                      │

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_popup.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_popup.snap
@@ -6,9 +6,9 @@ expression: output
  Match Expression:     BPF Filter:
  Dis┌ Save Capture ────────────────────────────────────────────────────────┐
   # │                                                                      │D
->  1│  Save to: /tmp/sipnab_20240615_120000.pcap                           │00ms
-   2│                                                                      │
-   3│  Packet Capture                                                      │
+> [ │  Save to: /tmp/sipnab_20240615_120000.pcap                           │00ms
+  [ │                                                                      │
+  [ │  Packet Capture                                                      │
     │    ▸ PCAP    Universal baseline (Wireshark, tcpdump, Homer)          │
     │      PCAP-NG Modern format with metadata and annotations             │
     │                                                                      │

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_sipp_xml_format.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_sipp_xml_format.snap
@@ -6,9 +6,9 @@ expression: output
  Match Expression:     BPF Filter:
  Dis┌ Save Capture ────────────────────────────────────────────────────────┐
   # │                                                                      │D
->  1│  Save to: /tmp/sipnab_20240615_120000.xml                            │00ms
-   2│                                                                      │
-   3│  Packet Capture                                                      │
+> [ │  Save to: /tmp/sipnab_20240615_120000.xml                            │00ms
+  [ │                                                                      │
+  [ │  Packet Capture                                                      │
     │      PCAP    Universal baseline (Wireshark, tcpdump, Homer)          │
     │      PCAP-NG Modern format with metadata and annotations             │
     │                                                                      │

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_txt_format.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__save_dialog_txt_format.snap
@@ -6,9 +6,9 @@ expression: output
  Match Expression:     BPF Filter:
  Dis┌ Save Capture ────────────────────────────────────────────────────────┐
   # │                                                                      │D
->  1│  Save to: /tmp/sipnab_20240615_120000.txt                            │00ms
-   2│                                                                      │
-   3│  Packet Capture                                                      │
+> [ │  Save to: /tmp/sipnab_20240615_120000.txt                            │00ms
+  [ │                                                                      │
+  [ │  Packet Capture                                                      │
     │      PCAP    Universal baseline (Wireshark, tcpdump, Homer)          │
     │      PCAP-NG Modern format with metadata and annotations             │
     │                                                                      │

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__settings_popup.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__settings_popup.snap
@@ -5,10 +5,10 @@ expression: output
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲   Method     From            To               Source          Destination     State        Msgs  Date     PDD
->  1    INVITE     1001            1002             10.0.0.1        10.0.0.2        Completed    4     +0.000s  1000ms
-   2    INVITE     1003            1004             10.0.0.1        10.0.0.2        FAILED       2     +5.000s
-   3    INVITE     1005            1006             10.0.0.1        10.0.0.2        InCall       2     +5.000s
+  # ▲    Method     From            To              Source          Destination     State        Msgs  Date     PDD
+> [ ]1   INVITE     1001            1002            10.0.0.1        10.0.0.2        Completed    4     +0.000s  1000ms
+  [ ]2   INVITE     1003            1004            10.0.0.1        10.0.0.2        FAILED       2     +5.000s
+  [ ]3   INVITE     1005            1006            10.0.0.1        10.0.0.2        InCall       2     +5.000s
 
 
 

--- a/tests/tui_snapshot_test.rs
+++ b/tests/tui_snapshot_test.rs
@@ -606,6 +606,27 @@ mod tui_snapshots {
         insta::assert_snapshot!(output);
     }
 
+    // sngrep parity: every call-list row shows a [ ]/[*] selection checkbox
+    // so users can see and pick which dialogs to act on (e.g. save).
+    #[test]
+    fn call_list_selection_checkbox_visible() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = test_app_with_dialogs();
+        app.handle_key(KeyCode::Char(' ')); // check row 0
+        terminal.draw(|frame| app.render(frame)).unwrap();
+        let output = buffer_to_string(&terminal);
+        // The checked row shows [*]; unchecked rows show [ ].
+        assert!(
+            output.contains("[*]"),
+            "expected a checked [*] row:\n{output}"
+        );
+        assert!(
+            output.contains("[ ]"),
+            "expected unchecked [ ] rows:\n{output}"
+        );
+    }
+
     #[test]
     fn call_list_autoscroll_off() {
         let backend = TestBackend::new(80, 24);

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1854" data-suffix="">1854</span>
+        <span class="arch-stat" data-count="1857" data-suffix="">1857</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Adds sngrep-style selection checkboxes to the call list so users can see and pick which dialogs an action applies to.

- Every call-list row now renders a `[ ]` / `[*]` selection checkbox (replacing the prior `▸`/space marker), with the index column widened to fit it.
- **Save** now honors the selection: when one or more rows are checked, only those dialogs are exported; when none are checked, all displayed dialogs are exported (unchanged default). Applies across pcap/pcapng, txt, json, ndjson, csv, markdown, and sipp-xml.
- Introduces a single shared `displayed_dialogs()` helper (filter + search + sort) that backs the renderer, Save, and Clear, so multi-select row indices always map to the exact rows the user sees on screen.
- Fixes a latent bug where **Clear** mapped selection indices against an unsorted list.

## Tests

- Checkbox visibility assertion (`call_list_selection_checkbox_visible`).
- `json_save_honors_selection` and `save_with_no_selection_exports_all`.
- Updated call-list snapshots under both the audio and headless (no-audio) feature sets.
- Full suite green (`cargo test --features full`); clippy `--all-features` clean; homepage test count updated to 1857.