### PR TITLE
docs(website): note checkbox-driven selective save on homepage

### DIFF
--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -89,7 +89,7 @@
           <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         </div>
         <h3>Export Everything</h3>
-        <p>PCAP, PCAP-NG, TXT, Mermaid sequence diagrams, JSON, NDJSON, Markdown call reports, fail2ban format, Wireshark filters, tshark display filters. Pipe NDJSON to jq for custom pipelines.</p>
+        <p>PCAP, PCAP-NG, TXT, Mermaid sequence diagrams, JSON, NDJSON, Markdown call reports, fail2ban format, Wireshark filters, tshark display filters. Pipe NDJSON to jq for custom pipelines. Tick sngrep-style checkboxes to save just the dialogs you select, or export everything at once.</p>
       </div>
     </div>
   </div>
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,854 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,857 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary

Surfaces the just-merged call-list selection feature (#67) on the marketing homepage and fixes a stale count.

- **Export Everything** feature card now notes you can tick sngrep-style checkboxes to save just the selected dialogs, or export everything at once.
- Synced the "What sipnab Does" reference table prose from "1,854 automated tests" to **1,857**, matching the animated `data-count` stat that #67 already bumped (the pre-commit homepage-count check confirms 1857).

Docs-only; no code or test changes.