### PR TITLE
fix(capture): transparently read gzip-compressed capture files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aes"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +744,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1218,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fluent-uri"
@@ -2176,6 +2201,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -3534,6 +3569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,6 +3630,7 @@ dependencies = [
  "env_logger",
  "etherparse",
  "expectrl",
+ "flate2",
  "hmac",
  "http-body-util",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ exclude = ["website/", "demos/", "tasks/", "fuzz/", ".githooks/", "tests/pcap-sa
 [dependencies]
 # Phase 1: Capture & core
 pcap = { version = "2", optional = true }
+# Transparent decompression of gzip-compressed capture files (libpcap, unlike
+# Wireshark, cannot read them directly). Native-only; see the `native` feature.
+flate2 = { version = "1", optional = true }
+tempfile = { version = "3", optional = true }
 etherparse = "0.20"
 clap = { version = "4", features = ["derive", "env", "string"], optional = true }
 regex = "1"
@@ -121,7 +125,7 @@ harness = false
 [features]
 default = ["native", "tui", "audio"]
 # Native platform deps (not available in WASM)
-native = ["dep:pcap", "dep:clap", "dep:env_logger", "dep:crossbeam-channel", "dep:libc", "dep:pcap-file", "dep:tracing-subscriber", "dep:tracing-log"]
+native = ["dep:pcap", "dep:clap", "dep:env_logger", "dep:crossbeam-channel", "dep:libc", "dep:pcap-file", "dep:tracing-subscriber", "dep:tracing-log", "dep:flate2", "dep:tempfile"]
 tui = ["native", "dep:ratatui", "dep:crossterm", "dep:unicode-width"]
 tls = ["dep:zeroize", "dep:ring", "dep:rustls", "dep:aes", "dep:cbc", "dep:base64"]
 hep = ["native"]

--- a/src/capture/file.rs
+++ b/src/capture/file.rs
@@ -14,10 +14,67 @@ use super::CaptureConfig;
 use super::packet::Packet;
 use crate::signals;
 
+/// Open an offline capture, transparently decompressing gzip-compressed files.
+///
+/// libpcap's `pcap_open_offline` cannot read gzip-compressed captures (it
+/// reports "unknown file format"), but Wireshark decompresses them on the fly —
+/// and tools routinely hand out `.pcap` files that are actually gzip. We match
+/// Wireshark: if the file starts with the gzip magic (`1f 8b`), decompress it
+/// to a temporary file and open that instead.
+///
+/// Returns the open capture together with an optional temp-file guard. The
+/// guard owns the decompressed file and deletes it on drop, so the caller MUST
+/// keep it alive for as long as it reads from the capture.
+pub fn open_offline(
+    path: &Path,
+) -> Result<(pcap::Capture<pcap::Offline>, Option<tempfile::TempPath>)> {
+    use std::io::Read;
+
+    // Peek the first two bytes for the gzip magic. A file too short to hold a
+    // magic number isn't gzip; let libpcap report on it as before.
+    let is_gzip = {
+        let mut magic = [0u8; 2];
+        let read_two = std::fs::File::open(path)
+            .and_then(|mut f| f.read(&mut magic))
+            .map(|n| n == 2)
+            .unwrap_or(false);
+        read_two && magic == [0x1f, 0x8b]
+    };
+
+    if !is_gzip {
+        let cap = pcap::Capture::from_file(path)
+            .with_context(|| format!("Failed to open pcap file '{}'", path.display()))?;
+        return Ok((cap, None));
+    }
+
+    // Decompress to a temp file libpcap can open. MultiGzDecoder handles
+    // concatenated gzip members, which some capture tools emit.
+    let input = std::fs::File::open(path)
+        .with_context(|| format!("Failed to open '{}'", path.display()))?;
+    let mut decoder = flate2::read::MultiGzDecoder::new(std::io::BufReader::new(input));
+    let mut temp = tempfile::Builder::new()
+        .prefix("sipnab-gz-")
+        .suffix(".pcap")
+        .tempfile()
+        .context("Failed to create temp file for gzip decompression")?;
+    std::io::copy(&mut decoder, temp.as_file_mut())
+        .with_context(|| format!("Failed to decompress gzip capture '{}'", path.display()))?;
+    let temp_path = temp.into_temp_path();
+
+    let cap = pcap::Capture::from_file(&temp_path).with_context(|| {
+        format!(
+            "Failed to open decompressed capture from '{}'",
+            path.display()
+        )
+    })?;
+    Ok((cap, Some(temp_path)))
+}
+
 /// Read packets from a pcap file and send them through the channel.
 ///
-/// Opens the file with `pcap::Capture::from_file`, applies any BPF filter,
-/// and reads packets until EOF, shutdown, count limit, or duration limit.
+/// Opens the file with [`open_offline`] (transparently handling gzip), applies
+/// any BPF filter, and reads packets until EOF, shutdown, count limit, or
+/// duration limit.
 ///
 /// This function blocks and is intended to be called from a dedicated thread.
 pub fn capture_file(
@@ -26,10 +83,10 @@ pub fn capture_file(
     tx: Sender<Packet>,
     ready_tx: Option<crossbeam_channel::Sender<Result<(), String>>>,
 ) -> Result<()> {
-    let mut cap = match pcap::Capture::from_file(path)
-        .with_context(|| format!("Failed to open pcap file '{}'", path.display()))
-    {
-        Ok(cap) => cap,
+    // `_gz_guard` owns any decompressed temp file; it must outlive all reads
+    // below, so keep it bound for the whole function.
+    let (mut cap, _gz_guard) = match open_offline(path) {
+        Ok(opened) => opened,
         Err(e) => {
             if let Some(ready) = ready_tx {
                 let _ = ready.send(Err(format!("{e:#}")));
@@ -155,6 +212,56 @@ mod tests {
             .join("tests")
             .join("fixtures")
             .join("udp_5060.pcap")
+    }
+
+    /// Helper: a real multi-packet SIP/RTP sample (classic pcap).
+    fn sample_pcap() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("pcap-samples")
+            .join("sip-rtp-g711.pcap")
+    }
+
+    /// Read a capture file via `capture_file` and return the packet count.
+    fn count_packets(path: &Path) -> usize {
+        let (tx, rx) = unbounded();
+        capture_file(path, &CaptureConfig::default(), tx, None).unwrap();
+        rx.try_iter().count()
+    }
+
+    /// gzip-compressed captures must read transparently: libpcap cannot open
+    /// them (it reports "unknown file format"), but Wireshark decompresses on
+    /// the fly, so sipnab matches that behavior. Regression for the
+    /// `.pcap.gz`-mislabeled-as-`.pcap` case.
+    #[test]
+    fn reads_gzip_compressed_pcap() {
+        use std::io::Write;
+
+        let sample = sample_pcap();
+        if !sample.exists() {
+            eprintln!("Skipping: sample not found at {}", sample.display());
+            return;
+        }
+        let baseline = count_packets(&sample);
+        assert!(baseline > 0, "sample should contain packets");
+
+        // Produce a gzip-compressed copy with a deliberately plain `.pcap` name.
+        let raw = std::fs::read(&sample).unwrap();
+        let gz_file = tempfile::Builder::new()
+            .prefix("sipnab-test-")
+            .suffix(".pcap")
+            .tempfile()
+            .unwrap();
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(&raw).unwrap();
+        let compressed = encoder.finish().unwrap();
+        std::fs::write(gz_file.path(), &compressed).unwrap();
+
+        let via_gz = count_packets(gz_file.path());
+        assert_eq!(
+            via_gz, baseline,
+            "gzip-compressed capture should yield the same packets as the original"
+        );
     }
 
     #[test]

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1213,9 +1213,12 @@ pub(super) fn load_pcap_file(app: &mut App, path_str: &str) -> String {
         return format!("File not found: {path_str}");
     }
 
-    let mut cap = match pcap::Capture::from_file(path) {
-        Ok(c) => c,
-        Err(e) => return format!("Failed to open: {e}"),
+    // Transparently handles gzip-compressed captures (libpcap cannot). The
+    // guard owns any decompressed temp file and must outlive the read loop
+    // below, so keep it bound for the rest of the function.
+    let (mut cap, _gz_guard) = match crate::capture::file::open_offline(path) {
+        Ok(opened) => opened,
+        Err(e) => return format!("Failed to open: {e:#}"),
     };
 
     // Clear existing data

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -163,7 +163,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,857 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,858 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -230,7 +230,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1857" data-suffix="">1857</span>
+        <span class="arch-stat" data-count="1858" data-suffix="">1858</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

sipnab failed to open gzip-compressed captures with `libpcap error: unknown file format`, even though Wireshark opens them fine. Root cause: libpcap's `pcap_open_offline` has no gzip support, while Wireshark (libwiretap) transparently decompresses. Tools routinely hand out `.pcap` files that are actually gzip (the reporter's `9bbc7162-….pcap` was gzip-compressed pcapng).

sipnab now matches Wireshark: if a file begins with the gzip magic (`1f 8b`), it's decompressed to a temp file before being handed to libpcap.

## Changes

- New shared `open_offline()` helper in `src/capture/file.rs` does gzip detection + decompression and returns the capture plus a temp-file guard (deletes on drop; kept alive across reads).
- Both entry points route through it: the CLI `-I` path (`capture_file`) and the in-app **File Open** dialog (`load_pcap_file`). So `sipnab -I foo.pcap.gz` and opening a gzip file in the TUI both work.
- `MultiGzDecoder` handles concatenated gzip members.
- `flate2` + `tempfile` added as **optional** deps under the existing `native` feature — WASM build is unaffected (verified).

## Tests

- `reads_gzip_compressed_pcap`: gzip-compresses a real sample pcap and asserts `capture_file` yields the same packet count as the uncompressed original. Red before the fix (`unknown file format`), green after.
- Full suite: 1858 passed, 0 failed. Clippy `--all-features` clean. WASM `cargo check` clean.
- Verified end-to-end on the original reporter file: `sipnab -I 9bbc7162-….pcap` now parses the SIP traffic directly, no manual `gunzip`.

Homepage test count bumped 1857 → 1858 for the new test.