### PR TITLE
fix(capture): multi-interface validation + idle --duration hang

### DIFF
--- a/src/capture/device.rs
+++ b/src/capture/device.rs
@@ -65,6 +65,49 @@ pub fn list_devices() -> Vec<String> {
         .collect()
 }
 
+/// Parse and validate a user-supplied interface selection for multi-device
+/// capture (the `-d eth0,docker0 --multi-device` form).
+///
+/// Splits on commas, trims surrounding whitespace from each entry, and:
+/// - rejects an empty or whitespace-only spec (no interface selected),
+/// - rejects empty entries from stray/doubled/leading/trailing commas,
+/// - rejects names containing an embedded NUL byte (it would silently
+///   truncate when handed to libpcap's C string API),
+/// - removes duplicates while preserving first-seen order.
+///
+/// Otherwise-unusual names (backslashes, colons, dots — as in Windows NPF
+/// device paths) are passed through unchanged; whether the interface actually
+/// exists is left to the capture layer, which produces a precise OS error.
+pub fn parse_device_list(spec: &str) -> Result<Vec<String>> {
+    if spec.trim().is_empty() {
+        anyhow::bail!("no interface specified: device list is empty");
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    for (idx, raw) in spec.split(',').enumerate() {
+        let name = raw.trim();
+        if name.is_empty() {
+            anyhow::bail!(
+                "empty interface name at position {} in device list '{}' \
+                 (check for a stray, doubled, leading, or trailing comma)",
+                idx + 1,
+                spec
+            );
+        }
+        if name.contains('\0') {
+            anyhow::bail!(
+                "interface name '{}' contains an embedded NUL byte",
+                name.escape_default()
+            );
+        }
+        if !out.iter().any(|d| d == name) {
+            out.push(name.to_string());
+        }
+    }
+
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -96,5 +139,107 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The headline contract: with no interface selected, Linux must capture
+    /// from ALL interfaces via the "any" pseudo-device (not a single NIC).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn default_device_is_all_interfaces_on_linux() {
+        let dev = find_default_device().expect("Linux default is always 'any'");
+        assert_eq!(
+            dev, "any",
+            "Linux default capture must be the 'any' pseudo-device (all interfaces)"
+        );
+    }
+
+    // ── parse_device_list: selected-interface parsing/validation ─────────
+
+    #[test]
+    fn device_list_single() {
+        assert_eq!(parse_device_list("eth0").unwrap(), vec!["eth0"]);
+    }
+
+    #[test]
+    fn device_list_multiple_in_order() {
+        assert_eq!(
+            parse_device_list("eth0,docker0,lo").unwrap(),
+            vec!["eth0", "docker0", "lo"]
+        );
+    }
+
+    #[test]
+    fn device_list_trims_surrounding_whitespace() {
+        assert_eq!(
+            parse_device_list("  eth0 ,\tdocker0  ").unwrap(),
+            vec!["eth0", "docker0"]
+        );
+    }
+
+    #[test]
+    fn device_list_dedups_preserving_first_seen_order() {
+        assert_eq!(
+            parse_device_list("eth0,docker0,eth0,lo,docker0").unwrap(),
+            vec!["eth0", "docker0", "lo"]
+        );
+    }
+
+    // ── Failure / adversarial cases ──────────────────────────────────────
+
+    #[test]
+    fn device_list_rejects_empty_string() {
+        let err = parse_device_list("").unwrap_err().to_string();
+        assert!(err.contains("empty"), "got: {err}");
+    }
+
+    #[test]
+    fn device_list_rejects_whitespace_only() {
+        assert!(parse_device_list("   \t ").is_err());
+    }
+
+    #[test]
+    fn device_list_rejects_doubled_comma() {
+        // The classic typo: "eth0,,docker0" must fail loudly, not silently
+        // try to open an interface named "".
+        let err = parse_device_list("eth0,,docker0").unwrap_err().to_string();
+        assert!(err.contains("empty interface name"), "got: {err}");
+    }
+
+    #[test]
+    fn device_list_rejects_leading_comma() {
+        assert!(parse_device_list(",eth0").is_err());
+    }
+
+    #[test]
+    fn device_list_rejects_trailing_comma() {
+        assert!(parse_device_list("eth0,").is_err());
+    }
+
+    #[test]
+    fn device_list_rejects_bare_comma() {
+        assert!(parse_device_list(",").is_err());
+    }
+
+    #[test]
+    fn device_list_rejects_embedded_nul() {
+        // A NUL would truncate when passed to libpcap's C API — reject it
+        // rather than silently capture on a different (or no) interface.
+        let err = parse_device_list("eth0\0evil").unwrap_err().to_string();
+        assert!(err.contains("NUL"), "got: {err}");
+    }
+
+    #[test]
+    fn device_list_rejects_nul_only_entry() {
+        assert!(parse_device_list("eth0,\0,docker0").is_err());
+    }
+
+    #[test]
+    fn device_list_preserves_unusual_but_valid_names() {
+        // Backslashes/dots/colons appear in real capture device names on some
+        // platforms (e.g. Windows "\\Device\\NPF_{...}"); they must pass through.
+        assert_eq!(
+            parse_device_list(r"\Device\NPF_{abc},en0.1").unwrap(),
+            vec![r"\Device\NPF_{abc}", "en0.1"]
+        );
     }
 }

--- a/src/capture/live.rs
+++ b/src/capture/live.rs
@@ -13,6 +13,82 @@ use super::CaptureConfig;
 use super::packet::Packet;
 use crate::signals;
 
+/// How long [`wait_readable`] blocks before returning control to the capture
+/// loop so it can re-check the shutdown flag and the count/duration limits.
+///
+/// pcap's own read timeout is unreliable on the Linux `any` pseudo-device and
+/// some drivers (it may not fire at all when the interface is idle), so we do
+/// not depend on it for liveness — we poll the capture fd ourselves with this
+/// bounded interval. This is what makes `--duration` / Ctrl-C take effect even
+/// when no packets are arriving.
+#[cfg(unix)]
+const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Result of waiting for a capture fd to become readable.
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WaitResult {
+    /// Data is available; call `next_packet()`.
+    Readable,
+    /// The wait window elapsed with no data — re-check loop conditions.
+    TimedOut,
+}
+
+/// Convert a [`Duration`](std::time::Duration) into a `poll(2)` timeout in
+/// milliseconds, clamped to `[0, c_int::MAX]`.
+///
+/// The clamp is load-bearing: an unchecked cast of a large duration can wrap to
+/// a negative value, and a negative `poll` timeout means "block forever" — the
+/// exact failure mode we are fixing. We never want that, so we saturate.
+#[cfg(unix)]
+fn poll_timeout_millis(timeout: std::time::Duration) -> libc::c_int {
+    timeout.as_millis().min(libc::c_int::MAX as u128) as libc::c_int
+}
+
+/// Wait up to `timeout` for `fd` to become readable.
+///
+/// Returns [`WaitResult::Readable`] as soon as data is available, or
+/// [`WaitResult::TimedOut`] when the window elapses (or a signal interrupts the
+/// call — surfacing promptly lets the loop notice a shutdown request). A closed
+/// or otherwise invalid fd (`POLLNVAL`) is reported as an error rather than a
+/// spurious `Readable`, which — paired with a non-blocking `next_packet()` that
+/// returns nothing — would otherwise hot-spin.
+#[cfg(unix)]
+fn wait_readable(
+    fd: std::os::unix::io::RawFd,
+    timeout: std::time::Duration,
+) -> std::io::Result<WaitResult> {
+    let mut pfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let ret = unsafe {
+        libc::poll(
+            &mut pfd as *mut libc::pollfd,
+            1,
+            poll_timeout_millis(timeout),
+        )
+    };
+    if ret < 0 {
+        let err = std::io::Error::last_os_error();
+        // EINTR: a signal arrived. Treat as a timeout so the loop re-checks the
+        // shutdown flag immediately instead of erroring out.
+        if err.kind() == std::io::ErrorKind::Interrupted {
+            return Ok(WaitResult::TimedOut);
+        }
+        return Err(err);
+    }
+    if ret == 0 {
+        return Ok(WaitResult::TimedOut);
+    }
+    if pfd.revents & libc::POLLNVAL != 0 {
+        return Err(std::io::Error::other("poll: invalid capture fd (POLLNVAL)"));
+    }
+    // POLLIN, or POLLERR/POLLHUP — let next_packet() surface any real error.
+    Ok(WaitResult::Readable)
+}
+
 /// Run a live capture loop on the given network device.
 ///
 /// Opens the device with the parameters from `config`, applies any BPF filter,
@@ -37,6 +113,11 @@ pub fn capture_live(
                 .snaplen(config.snaplen as i32)
                 .buffer_size((config.buffer_mb * 1_000_000) as i32)
                 .timeout(100) // Return from next_packet every 100ms even without traffic
+                // Deliver packets as soon as they arrive instead of waiting for
+                // the kernel buffer to fill. Required for the poll()-driven loop
+                // below: without it, poll() on the capture fd won't report the
+                // socket readable promptly in non-blocking mode.
+                .immediate_mode(true)
                 .open()
                 .with_context(|| format!("Failed to activate capture on '{device}'"))
         }) {
@@ -58,6 +139,31 @@ pub fn capture_live(
         }
         return Err(err);
     }
+
+    // Put the handle into non-blocking mode. The capture loop drives its own
+    // liveness by polling the fd (see `wait_readable`), so individual reads
+    // must never block — otherwise an idle interface would stall the loop and
+    // `--duration` / Ctrl-C would not take effect until the next packet.
+    #[cfg(unix)]
+    let mut cap = match cap.setnonblock() {
+        Ok(c) => c,
+        Err(e) => {
+            let err = anyhow::Error::new(e)
+                .context(format!("Failed to set non-blocking mode on '{device}'"));
+            if let Some(ready) = ready_tx {
+                let _ = ready.send(Err(format!("{err:#}")));
+            }
+            return Err(err);
+        }
+    };
+
+    // Selectable fd for poll(2). On Linux this is the packet-socket fd and is
+    // valid for the lifetime of the capture.
+    #[cfg(unix)]
+    let poll_fd = {
+        use std::os::unix::io::AsRawFd;
+        cap.as_raw_fd()
+    };
 
     // Signal that the capture device is open and ready.
     if let Some(ready) = ready_tx {
@@ -92,6 +198,19 @@ pub fn capture_live(
         {
             tracing::debug!("Reached duration limit ({duration:?})");
             break;
+        }
+
+        // Bounded wait so the loop re-checks shutdown/count/duration roughly
+        // every POLL_INTERVAL even when the interface is completely idle. This
+        // is what stops `--duration` from hanging on a quiet link.
+        #[cfg(unix)]
+        match wait_readable(poll_fd, POLL_INTERVAL) {
+            Ok(WaitResult::Readable) => {}
+            Ok(WaitResult::TimedOut) => continue,
+            Err(e) => {
+                tracing::error!("poll on capture fd for '{device}' failed: {e}");
+                return Err(e).context("Fatal capture error while polling capture fd");
+            }
         }
 
         match cap.next_packet() {
@@ -172,6 +291,127 @@ mod tests {
         libc::timeval {
             tv_sec: sec as _,
             tv_usec: usec as _,
+        }
+    }
+
+    // ── poll_timeout_millis: overflow-safe Duration → c_int conversion ────
+    #[cfg(unix)]
+    mod poll_timeout {
+        use super::*;
+        use std::time::Duration;
+
+        #[test]
+        fn zero_duration_is_zero() {
+            assert_eq!(poll_timeout_millis(Duration::ZERO), 0);
+        }
+
+        #[test]
+        fn normal_duration_converts_exactly() {
+            assert_eq!(poll_timeout_millis(Duration::from_millis(100)), 100);
+        }
+
+        #[test]
+        fn boundary_at_int_max_is_preserved() {
+            let max = libc::c_int::MAX;
+            assert_eq!(poll_timeout_millis(Duration::from_millis(max as u64)), max);
+        }
+
+        #[test]
+        fn overflowing_duration_clamps_not_wraps() {
+            // A huge duration must clamp to c_int::MAX, never wrap to a small or
+            // negative value (negative = "block forever" in poll(2) — the bug).
+            let huge = Duration::from_millis(u64::MAX);
+            assert_eq!(poll_timeout_millis(huge), libc::c_int::MAX);
+            assert!(poll_timeout_millis(huge) > 0);
+        }
+
+        #[test]
+        fn one_past_int_max_clamps() {
+            let over = Duration::from_millis(libc::c_int::MAX as u64 + 1);
+            assert_eq!(poll_timeout_millis(over), libc::c_int::MAX);
+        }
+    }
+
+    // ── wait_readable: a BOUNDED wait that returns even with no data ──────
+    // This is the property the idle capture loop lacked, which let --duration
+    // hang. Tested deterministically with a pipe — no capture privileges.
+    #[cfg(unix)]
+    mod wait_readable_tests {
+        use super::*;
+        use std::os::unix::io::RawFd;
+        use std::time::{Duration, Instant};
+
+        /// (read_fd, write_fd)
+        fn make_pipe() -> (RawFd, RawFd) {
+            let mut fds = [0 as libc::c_int; 2];
+            let r = unsafe { libc::pipe(fds.as_mut_ptr()) };
+            assert_eq!(r, 0, "pipe(2) failed: {}", std::io::Error::last_os_error());
+            (fds[0], fds[1])
+        }
+
+        fn close(fd: RawFd) {
+            unsafe { libc::close(fd) };
+        }
+
+        #[test]
+        fn times_out_on_idle_fd() {
+            // The regression test: nothing is ever written, yet the wait MUST
+            // return (TimedOut) within roughly the timeout — not block forever.
+            let (r, w) = make_pipe();
+            let start = Instant::now();
+            let res = wait_readable(r, Duration::from_millis(80)).expect("poll ok");
+            let elapsed = start.elapsed();
+            assert_eq!(res, WaitResult::TimedOut);
+            assert!(
+                elapsed >= Duration::from_millis(40),
+                "returned too early: {elapsed:?}"
+            );
+            assert!(
+                elapsed < Duration::from_secs(3),
+                "did not return promptly: {elapsed:?}"
+            );
+            close(r);
+            close(w);
+        }
+
+        #[test]
+        fn returns_readable_when_data_present() {
+            let (r, w) = make_pipe();
+            let n = unsafe { libc::write(w, b"x".as_ptr() as *const libc::c_void, 1) };
+            assert_eq!(n, 1, "write failed");
+            let start = Instant::now();
+            // Generous timeout: must come back fast because data is ready.
+            let res = wait_readable(r, Duration::from_secs(5)).expect("poll ok");
+            assert_eq!(res, WaitResult::Readable);
+            assert!(
+                start.elapsed() < Duration::from_secs(1),
+                "should return immediately when readable"
+            );
+            close(r);
+            close(w);
+        }
+
+        #[test]
+        fn zero_timeout_returns_immediately() {
+            let (r, w) = make_pipe();
+            let start = Instant::now();
+            let res = wait_readable(r, Duration::ZERO).expect("poll ok");
+            assert_eq!(res, WaitResult::TimedOut);
+            assert!(start.elapsed() < Duration::from_millis(500));
+            close(r);
+            close(w);
+        }
+
+        #[test]
+        fn invalid_fd_is_an_error_not_a_spin() {
+            // Adversarial: a closed fd yields POLLNVAL. wait_readable must
+            // surface an error (fatal) rather than report Readable, which —
+            // paired with a no-op next_packet — would hot-spin forever.
+            let (r, w) = make_pipe();
+            close(r);
+            let res = wait_readable(r, Duration::from_millis(50));
+            assert!(res.is_err(), "closed fd must error, got {res:?}");
+            close(w);
         }
     }
 

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -209,11 +209,10 @@ pub fn start_multi_capture(
     tx: Sender<Packet>,
     ready_tx: Option<crossbeam_channel::Sender<Result<(), String>>>,
 ) -> Result<CaptureHandle> {
-    let device_list: Vec<String> = devices.split(',').map(|s| s.trim().to_string()).collect();
-
-    if device_list.is_empty() {
-        anyhow::bail!("No devices specified for multi-device capture");
-    }
+    // Parse + validate the selected-interface list up front so a malformed
+    // spec (empty, doubled/stray comma, embedded NUL) fails with a precise
+    // message *before* we spawn any capture threads.
+    let device_list = device::parse_device_list(devices)?;
 
     if device_list.len() == 1 {
         // Single device: fall back to normal capture
@@ -548,6 +547,27 @@ mod tests {
         handle.thread.join().expect("capture thread panicked").ok();
         let packets: Vec<_> = pkt_rx.try_iter().collect();
         assert!(!packets.is_empty(), "Expected packets from fixture file");
+    }
+
+    // ── start_multi_capture input validation ────────────────────────────
+    #[cfg(feature = "native")]
+    #[test]
+    fn multi_capture_rejects_malformed_device_spec_before_spawning() {
+        // A doubled comma is a validation error: start_multi_capture must
+        // return Err immediately, without spawning any capture thread.
+        let (tx, _rx) = crossbeam_channel::unbounded();
+        match start_multi_capture("eth0,,docker0", CaptureConfig::default(), tx, None) {
+            Ok(_) => panic!("malformed device spec must be rejected"),
+            Err(e) => assert!(e.to_string().contains("empty interface name"), "got: {e}"),
+        }
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn multi_capture_rejects_empty_device_spec() {
+        let (tx, _rx) = crossbeam_channel::unbounded();
+        assert!(start_multi_capture("   ", CaptureConfig::default(), tx, None).is_err());
+        // (Ok(_) is not Debug; .is_err() avoids unwrapping the handle.)
     }
 
     // ── PacketProcessor::process dispatch (device-free) ─────────────────

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,7 +122,10 @@ pub struct Cli {
     #[arg(long, value_name = "RANGE", default_value = "5060-5061")]
     pub portrange: String,
 
-    /// Capture on all available interfaces.
+    /// Capture on the selected interfaces given as a comma-separated list to
+    /// `-d` (e.g. `-d eth0,docker0 --multi-device`), opening one capture per
+    /// interface. Without this flag, the zero-argument default already sniffs
+    /// ALL interfaces via the "any" pseudo-device.
     #[arg(long)]
     pub multi_device: bool,
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1967" data-suffix="">1967</span>
+        <span class="arch-stat" data-count="1992" data-suffix="">1992</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Two capture-path fixes, each TDD'd and validated end-to-end on a 3-interface host (`lo`/`eth0`/`docker0`).

### 1. Validate the selected-interface list for multi-device capture (`40d55d3`)

Default capture already sniffs **all** interfaces on Linux via the `any` pseudo-device. The selected-interface path (`-d a,b --multi-device`), though, split the comma list with **no validation** — a stray/doubled comma (`eth0,,docker0`), an empty spec, or a NUL byte produced confusing low-level pcap "no such device" errors, the existing `is_empty()` guard was dead code (`split` never yields an empty vec), and there was no trim/dedup.

- Add `capture::device::parse_device_list()`: trims, dedups (first-seen order), and rejects empty specs, empty entries from stray/leading/trailing commas, and embedded NUL bytes (which truncate in libpcap's C API). Unusual-but-valid names (Windows NPF paths, dotted names) pass through.
- Wire it into `start_multi_capture` so a malformed spec fails with a precise message **before** any thread spawns.
- Fix the misleading `--multi-device` help text (claimed "all available interfaces"; actually captures the `-d` list).

### 2. Stop `--duration` / Ctrl-C hanging on an idle live capture (`7317fe4`)

The loop only re-checked its termination conditions **after** `next_packet()` returned. In blocking mode pcap's read timeout is unreliable on the `any` device and some drivers, so an idle interface blocks `next_packet()` forever — `sipnab --duration 30s` on a quiet link ran indefinitely, and Ctrl-C took effect only on the next packet.

Drive loop liveness ourselves: `immediate_mode(true)` + `setnonblock()` + `wait_readable(fd, 100ms)` (poll the fd before each read; on timeout re-check shutdown/count/duration). EINTR -> timeout (prompt shutdown); POLLNVAL -> error (no hot-spin). `poll_timeout_millis()` clamps the `Duration` to `[0, c_int::MAX]` so a large value can't wrap negative (= "block forever"). Unix-gated; other platforms keep the prior path.

## Testing

- **+25 unit tests** (16 device/multi-device incl. adversarial empty/comma/NUL; 9 pipe-based for the poll helpers incl. the idle-times-out regression and invalid-fd-errors).
- Full suite **1005 lib tests pass**; clippy clean (`-Dwarnings`) on default / `--all-features` / `--no-default-features`; `cargo fmt` clean.
- **End-to-end on real hardware:** default captures lo+eth0; `-d lo,eth0 --multi-device` opens both; `-d lo` restricts to loopback and excludes eth0; malformed/nonexistent specs exit 1; idle `--duration 3s` now exits at 3s (was: hung); with traffic still captures and stops on time; `--count` stops early; SIGINT on idle exits promptly.

## Notes
- The non-Unix (Windows) live-capture path keeps the original blocking behavior — not exercised on this Linux box; a `WaitForSingleObject`-based equivalent would be a follow-up if Windows live capture is needed.