### PR TITLE
From/To display modes, filter fix, name persistence, help/docs reconcile (v0.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-06-19
+
+### Added
+- Cycleable From/To column display (press `u`): when a SIP URI has no username
+  the column now falls back to the host (and optional port) instead of a bare
+  `-`. Four modes — default (user else host:port), host:port, user, and
+  user@host:port. Set the startup default with `--from-to-mode` or
+  `[display] from_to`. IP-literal hosts are name-resolved like Source/Dest.
+- Name mappings can be persisted into sipnabrc: `[names] persist_to_config`
+  writes `N`-dialog edits into a `[names.manual]` table (comments and other
+  sections preserved), and that table is loaded at startup. Mappings continue to
+  embed into PCAP-NG Name Resolution Blocks on save.
+- The in-TUI F1 help now documents every keybinding (including name resolution
+  `n`/`N`, statistics `s`, open `O`, settings `F8`, audio `Shift+P`, and the new
+  `u`) and is scrollable (`↑`/`↓`/`PgUp`/`PgDn`). A test guards against future
+  keybinding/help drift.
+
+### Fixed
+- Filter dialog: SIP method checkboxes now start **all checked** (show
+  everything) and toggling them actually filters. Unchecking every method shows
+  nothing; clearing (`F9`) restores show-all.
+- Corrected the `Ctrl+L` documentation (it clears calls, same as `F5`).
+
 ## [0.4.3] - 2026-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3682,7 +3682,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,7 +2903,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3726,6 +3726,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "toml_edit 0.22.27",
  "tower",
  "tracing",
  "tracing-log",
@@ -4151,11 +4152,17 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -4168,6 +4175,18 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
@@ -4175,10 +4194,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4187,8 +4206,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -4323,7 +4348,7 @@ dependencies = [
  "serde",
  "shlex",
  "snapbox",
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -5021,6 +5046,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [package]
 name = "sipnab"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Norm Brandinger"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ libc = { version = "0.2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"
+# Format-preserving TOML editing for surgical writes to the user's sipnabrc
+# (updates the [names.manual] table without clobbering comments/other sections).
+toml_edit = "0.22"
 pcap-file = { version = "2", optional = true }
 nom = "8"
 indexmap = "2"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -96,6 +96,7 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--show-empty` | -- | off | Show messages with empty bodies |
 | `--line-buffer` | -- | off | Flush output after each line (useful for piping) |
 | `--color` | `<WHEN>` | `auto` | Color output mode: `auto`, `always`, `never` |
+| `--from-to-mode` | `<MODE>` | `default` | Default TUI From/To column display: `default` (user else host:port), `host-port`, `user`, `user-host-port`. Cycle at runtime with `u`. Overrides `[display] from_to` |
 | `--payload-limit` | `<BYTES>` | -- | Maximum payload bytes to display |
 | `-T`, `--text-dump` | -- | off | Dump raw SIP message text (like sipgrep `-T`) |
 | `--no-cli-print` | -- | off | Suppress per-message CLI output (useful with `--report` / `--call-report` so only the post-capture summary reaches stdout) |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -54,12 +54,14 @@ Output and TUI display settings.
 | `color` | string | `"auto"` | Color mode: `"auto"`, `"always"`, `"never"` |
 | `payload_limit` | integer | -- | Maximum payload bytes to display |
 | `delta_time` | boolean | `false` | Show delta time between messages by default |
+| `from_to` | string | `"default"` | From/To column display: `"default"` (user else host:port), `"host-port"`, `"user"`, `"user-host-port"`. Cycle at runtime with `u`; `--from-to-mode` overrides this |
 
 ```toml
 [display]
 color = "always"
 payload_limit = 4096
 delta_time = true
+from_to = "user-host-port"
 ```
 
 ### [filter]
@@ -145,12 +147,20 @@ Address name-resolution settings (display `host:port` instead of `ip:port`).
 | `enabled` | boolean | `false` | Start with name resolution on (offline sources) |
 | `reverse_dns` | boolean | `false` | Also use reverse DNS (PTR) lookups |
 | `hosts_file` | string | -- | `/etc/hosts`-format file of IP → name mappings to preload |
+| `persist_to_config` | boolean | `false` | When set, in-TUI `N` edits are also written into the `[names.manual]` table below, preserving the rest of this file |
+| `manual` | table | -- | Inline `"IP" = "name"` mappings, loaded at startup (highest-priority manual layer) |
 
 ```toml
 [names]
 enabled = true
 reverse_dns = false
 hosts_file = "/etc/sipnab/hosts"
+persist_to_config = true
+
+# Inline mappings (also written here when persist_to_config = true):
+[names.manual]
+"10.0.0.1" = "sbc-edge"
+"2001:db8::1" = "core6"
 ```
 
 ### [theme]

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -9,7 +9,7 @@ Keys marked with **(configurable)** can be remapped via the `[keybindings]` conf
 | Key | Action |
 |-----|--------|
 | Ctrl+C | Force quit |
-| Ctrl+L | Redraw screen |
+| Ctrl+L | Clear all calls (same as F5) |
 | v | Show version (with git commit) in the status line |
 | n | Cycle name resolution (Off / Static / DNS) |
 | N | Name the selected address (map IP → host/FQDN) |
@@ -36,9 +36,11 @@ Keys marked with **(configurable)** can be remapped via the `[keybindings]` conf
 | i | Clear non-matching dialogs |
 | I | Clear matching dialogs |
 | t | Cycle timestamp mode (absolute / delta-prev / delta-first) |
+| u | Cycle From/To column display (default / host:port / user / user@host:port) |
 | r / F6 | Show raw SIP message for selected dialog |
 | s | Switch to Statistics view |
 | O | Open pcap file (File Open dialog) |
+| F8 | Open Settings popup **(configurable: `settings`)** |
 | Tab | Switch to RTP Streams view |
 | F1 | Help **(configurable: `help`)** |
 | F2 | Save capture **(configurable: `save`)** |
@@ -75,6 +77,8 @@ Keys marked with **(configurable)** can be remapped via the `[keybindings]` conf
 | M | Clear mark |
 | E | Export Mermaid sequence diagram to clipboard |
 | x / F4 | Toggle extended multi-leg flow **(configurable: `extended_flow`)** |
+| r | Jump to RTP Streams view |
+| N | Name the selected message's source address (map IP → host/FQDN) |
 | F1 | Help **(configurable: `help`)** |
 | F2 | Save **(configurable: `save`)** |
 | F5 | Start compare mode **(configurable: `clear_calls`)** |
@@ -118,10 +122,23 @@ detail pane regardless of focus.
 | Down / j | Navigate down |
 | Home | Jump to first stream |
 | End | Jump to last stream |
+| Enter | Open stream detail |
 | Tab | Switch to Call List |
 | Esc | Back to Call List |
+| N | Name the selected stream's source address (map IP → host/FQDN) |
 | F1 | Help **(configurable: `help`)** |
 | F7 | Open filter dialog **(configurable: `filter`)** |
+
+## Stream Detail
+
+| Key | Action |
+|-----|--------|
+| Up / k | Scroll up |
+| Down / j | Scroll down |
+| PgUp / PgDn | Page scroll |
+| Home | Scroll to top |
+| Shift+P | Play / stop the stream's audio (G.711; requires the `audio` build) |
+| Esc | Back to RTP Streams |
 
 ## Statistics
 
@@ -241,6 +258,19 @@ type a host/FQDN and press Enter (an empty name clears the mapping). Naming an
 address turns resolution on automatically, and the mapping is saved to
 `$XDG_CONFIG_HOME/sipnab/hosts` (`~/.config/sipnab/hosts`) so it persists
 across runs.
+
+Mappings can also be persisted into your **sipnabrc**: set
+`[names] persist_to_config = true` and `N`-dialog edits are written into the
+`[names.manual]` table of `~/.config/sipnab/sipnab.toml` (comments and other
+sections are preserved). You can also pre-declare mappings there by hand:
+
+```toml
+[names.manual]
+"10.0.0.1" = "sbc-edge"
+```
+
+When saving a capture as **PCAP-NG** with resolution active, the mappings are
+embedded as a Name Resolution Block (and read back when the file is reopened).
 
 Related flags: `--resolve` (start with resolution on), `--reverse-dns` (enable
 PTR lookups; implies `--resolve`), `--names <FILE>` (preload an

--- a/docs/research/capture-performance.md
+++ b/docs/research/capture-performance.md
@@ -1,0 +1,114 @@
+# Capture performance roadmap — lower-level packet capture
+
+Future-work TODO for improving packet-capture throughput / loss on highly loaded
+systems. This is a **research roadmap, not committed work**. Phases are ordered
+cheapest-first; each later phase has an explicit trigger condition so we only pay
+the complexity when the previous phase proves insufficient.
+
+## Current state (baseline)
+
+sipnab captures via **libpcap** (the `pcap` crate). Live loop in
+`src/capture/live.rs:99-249`:
+
+- `immediate_mode(true)` is set (`live.rs:120`) — packets delivered without extra
+  libpcap buffering latency.
+- A kernel **BPF filter** is applied when provided (`live.rs:133-141`) — the only
+  in-kernel optimization currently in use.
+- Default kernel buffer **2 MiB** (`src/capture/mod.rs:84-97`, `--buffer-mb`).
+- `poll(2)` with a 100 ms interval (`live.rs:25,183-245`), then `next_packet()`.
+
+**Where loss happens under load (not the NIC — the pipeline):**
+
+1. **Channel backpressure (primary):** capture→processing is a
+   `crossbeam_channel::bounded(10_000)` (`src/main.rs:428`). When processing
+   (TUI render, RTP analysis, audio export) lags, the queue fills and
+   `tx.send` stalls the capture thread → kernel drops. ~10k RTP pps fills it in
+   ~1 s; bursts fill it far faster.
+2. **Per-packet allocation:** every packet does `pkt.data.to_vec()`
+   (`live.rs:221`, `src/capture/packet.rs:39-42`) — heap alloc + memcpy per packet.
+3. **Buffer size:** 2 MiB default fills in ~10 ms at a few hundred Mbps of media.
+4. **No kernel acceleration beyond libpcap defaults** (typically TPACKET_V2);
+   no AF_PACKET ring, AF_XDP, or XDP/eBPF prefilter.
+
+**Workload note:** SIP signaling is low-PPS and must be lossless; RTP media is
+high-PPS and can tolerate sampling. The dominant cost is the *processing
+pipeline*, not raw I/O — so in-kernel filtering/sampling (deliver only SIP +
+selected RTP) is often a bigger win than faster raw capture.
+
+---
+
+## Phase 1 — libpcap / pipeline tuning  ·  ~1–2 days  ·  portable  ·  do first
+
+Low risk, no backend change, helps every platform. Expected ~20–30% throughput
+and a large cut in pipeline-induced drops.
+
+- [ ] Raise default kernel buffer 2 MiB → 64 MiB (`--buffer-mb` default in
+      `src/capture/mod.rs`); document a 128 MiB recommendation for gigabit media.
+- [ ] Raise the capture→processing channel 10_000 → 100_000 (`src/main.rs:428`),
+      and/or make it configurable.
+- [ ] Buffer pool to eliminate per-packet `to_vec()` (`live.rs:221`) — recycle
+      fixed buffers instead of allocating per packet.
+- [ ] Stronger default auto-BPF filter when none supplied (push more drops into
+      the kernel; e.g. SIP ports + configured RTP ranges).
+- [ ] Investigate whether the `pcap` crate v2 exposes **TPACKET_V3**
+      (`pcap_set_protocol`); if so add `--capture-mode auto|tpacket_v3|tpacket_v2`.
+- [ ] Benchmark harness: replay a 100+ call sustained-RTP capture; measure
+      `ethtool -S <iface> | grep rx_dropped`, CPU, RSS; record a baseline.
+
+## Phase 2 — AF_PACKET + TPACKET_V3 ring  ·  ~3–5 days  ·  Linux-only
+
+**Trigger:** Phase 1 still shows >5% loss on sustained ~1 Gbps RTP.
+Expected +40–60% throughput, ~30% lower latency; zero-copy within the ring.
+
+- [ ] New `src/capture/af_packet.rs`: `AF_PACKET`/`SOCK_RAW` + `PACKET_RX_RING`
+      (PACKET_MMAP), TPACKET_V3 block handling; `SO_ATTACH_FILTER` for the BPF.
+- [ ] `--capture-backend libpcap|af_packet`; reuse `CaptureConfig` + the channel;
+      keep libpcap as the macOS/BSD fallback.
+- [ ] Pre-allocated buffer pool on the copy-out path.
+- [ ] Requires `CAP_NET_RAW`; Linux 3.2+. Custom `libc` bindings (no off-the-shelf
+      TPACKET_V3 crate). Careful mmap/error-recovery handling + tests.
+
+## Phase 3 — eBPF / XDP in-kernel filter + sample  ·  ~10–20 days  ·  Linux-only
+
+**Trigger:** media volume so high the pipeline saturates even with raw capture
+optimized, and RTP sampling (keep 1-in-N) is acceptable. Expected 50–90%
+userspace CPU reduction; wire-rate capture feasible.
+
+- [ ] XDP program (Rust via **`aya`**) parsing UDP + SIP/RTP heuristics; `XDP_DROP`
+      non-matching; forward SIP via `bpf_ringbuf_output`; sample RTP 1-in-N.
+- [ ] Userspace ring-buffer reader feeding the existing channel; behind a
+      `--features xdp` flag.
+- [ ] Requires `CAP_BPF`+`CAP_PERFMON`, Linux 5.8+ (ringbuf), clang/bpftool build
+      toolchain, CO-RE. Main risks: verifier limits, kernel-version compatibility,
+      correlating sampled RTP back to calls.
+- [ ] Rust eBPF ecosystem: `aya` (pure-Rust, mature), `libbpf-rs` (libbpf
+      bindings, mature); avoid `redbpf` (unmaintained).
+
+## Phase 4 — AF_XDP (XSK)  ·  ~15–25 days  ·  likely NOT needed
+
+**Trigger:** capturing 10+ Gbps with call-grade analysis (rare for SIP/RTP).
+~10x I/O throughput, sub-ms latency, true zero-copy.
+
+- [ ] XDP redirect program + AF_XDP socket (UMEM/RX rings) via `aya` + `afxdp`/
+      `xsk-rs`. Linux 4.18+ (5.8+ for full features), `CAP_BPF`, NIC/driver XDP
+      support; incompatible with the `any` pseudo-device.
+- [ ] **Assessment:** skip unless benchmarks prove raw *capture* (not processing)
+      is the bottleneck and Phase 3 sampling isn't enough. SIP is never 10 Gbps;
+      RTP analysis is CPU-bound.
+
+## Not recommended — PF_RING / DPDK
+
+Wrong fit: require driver binding (UIO) / kernel patches, dedicate the NIC away
+from normal networking, and target wire-rate forwarding rather than on-box
+SIP/RTP analysis. Note for completeness only.
+
+---
+
+## References
+
+- Linux AF_XDP: https://www.kernel.org/doc/html/latest/networking/af_xdp.html
+- TPACKET_V3 (PACKET_MMAP): https://www.kernel.org/doc/html/latest/networking/packet_mmap.html
+- `aya` (Rust eBPF): https://github.com/aya-rs/aya
+- `libbpf-rs`: https://github.com/libbpf/libbpf-rs
+- `afxdp-rs`: https://github.com/redhat-et/afxdp-rs · `xsk-rs`: https://github.com/alessandrococco/xsk-rs
+- libpcap (TPACKET_V3 support since 1.10): https://github.com/the-tcpdump-group/libpcap

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -537,6 +537,59 @@ pub fn parse_split(split: &str) -> Result<(Option<u64>, Option<std::time::Durati
 mod tests {
     use super::*;
 
+    /// A Name Resolution Block written into a PCAP-NG capture must survive a
+    /// round trip: reading the file back recovers the IP → name mappings. This
+    /// is the write half of the name-resolution feature (the read half powers
+    /// loading names from a capture on open).
+    #[test]
+    fn pcapng_name_resolution_block_round_trips() {
+        use std::collections::HashMap;
+        use std::net::IpAddr;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("names.pcapng");
+        let entries: Vec<(IpAddr, Vec<String>)> = vec![
+            ("10.0.0.1".parse().unwrap(), vec!["sbc-edge".to_string()]),
+            ("2001:db8::1".parse().unwrap(), vec!["core6".to_string()]),
+        ];
+        {
+            let mut w = PcapWriter::with_format(&path, 1, None, None, true, PcapExportMode::Raw)
+                .expect("create pcapng writer");
+            w.write_name_resolution_block(&entries).expect("write NRB");
+            w.finish().expect("finish");
+        }
+
+        let meta = crate::capture::pcapng_meta::read_pcapng_metadata(&path).expect("read metadata");
+        let names: HashMap<IpAddr, String> = meta.names.into_iter().collect();
+        assert_eq!(
+            names
+                .get(&"10.0.0.1".parse::<IpAddr>().unwrap())
+                .map(String::as_str),
+            Some("sbc-edge")
+        );
+        assert_eq!(
+            names
+                .get(&"2001:db8::1".parse::<IpAddr>().unwrap())
+                .map(String::as_str),
+            Some("core6")
+        );
+    }
+
+    /// Writing a Name Resolution Block to a plain (non-PCAP-NG) capture is a
+    /// no-op, not an error — NRBs only exist in the -ng format.
+    #[test]
+    fn name_resolution_block_skipped_for_plain_pcap() {
+        use std::net::IpAddr;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plain.pcap");
+        let mut w = PcapWriter::with_format(&path, 1, None, None, false, PcapExportMode::Raw)
+            .expect("create pcap writer");
+        let entries: Vec<(IpAddr, Vec<String>)> =
+            vec![("10.0.0.1".parse().unwrap(), vec!["x".to_string()])];
+        assert!(w.write_name_resolution_block(&entries).is_ok());
+        w.finish().expect("finish");
+    }
+
     /// ENOSPC regression tests using /dev/full, which fails every write
     /// with "No space left on device" without filling a real disk.
     #[cfg(target_os = "linux")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,6 +198,11 @@ pub struct Cli {
     #[arg(long = "names", value_name = "FILE")]
     pub names: Vec<String>,
 
+    /// Default From/To column display mode in the TUI. Cycled at runtime with
+    /// the `u` key. Overrides the `[display] from_to` config value.
+    #[arg(long = "from-to-mode", value_enum, value_name = "MODE")]
+    pub from_to_mode: Option<FromToModeArg>,
+
     /// Write a copy of the input pcapng (`-I`) to this path with all decryption
     /// secrets (DSBs) removed, then exit. The input is never modified.
     #[arg(long = "strip-secrets", value_name = "OUTPUT")]
@@ -658,6 +663,31 @@ pub struct Cli {
     pub bpf_filter: Vec<String>,
 }
 
+/// From/To column display mode selectable on the command line.
+///
+/// clap renders the variants in kebab-case (`default`, `host-port`, `user`,
+/// `user-host-port`), matching the `[display] from_to` config spellings and
+/// `tui::FromToMode::as_config_str`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum FromToModeArg {
+    Default,
+    HostPort,
+    User,
+    UserHostPort,
+}
+
+impl FromToModeArg {
+    /// The canonical config/string spelling for this mode.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::HostPort => "host-port",
+            Self::User => "user",
+            Self::UserHostPort => "user-host-port",
+        }
+    }
+}
+
 impl Cli {
     /// Parse CLI arguments from the real process arguments.
     pub fn parse_args() -> Self {
@@ -795,6 +825,18 @@ mod tests {
             cli.names,
             vec!["/etc/hosts".to_string(), "/tmp/names".to_string()]
         );
+    }
+
+    #[test]
+    fn from_to_mode_flag_parses_and_rejects_invalid() {
+        let cli = Cli::parse_from_args(["sipnab", "--from-to-mode", "host-port"]);
+        assert_eq!(cli.from_to_mode, Some(FromToModeArg::HostPort));
+        let cli = Cli::parse_from_args(["sipnab", "--from-to-mode", "user-host-port"]);
+        assert_eq!(cli.from_to_mode, Some(FromToModeArg::UserHostPort));
+        // Absent → None (falls back to config/default).
+        assert_eq!(Cli::parse_from_args(["sipnab"]).from_to_mode, None);
+        // Invalid value is rejected by clap (I4).
+        assert!(Cli::try_parse_from(["sipnab", "--from-to-mode", "bogus"]).is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -198,6 +198,9 @@ pub struct DisplayConfig {
     /// When set, only the listed columns are shown; unlisted columns are hidden.
     /// When unset, all columns are visible (the default).
     pub visible_columns: Option<Vec<String>>,
+    /// Default From/To column display mode. One of `"default"`, `"host-port"`,
+    /// `"user"`, `"user-host-port"`. Cycled at runtime with the `u` key.
+    pub from_to: Option<String>,
 }
 
 /// Filter presets.
@@ -614,6 +617,17 @@ device = "eth0"
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.capture.device.as_deref(), Some("eth0"));
         assert!(config.display.color.is_none());
+        assert!(config.display.from_to.is_none());
+    }
+
+    #[test]
+    fn parse_display_from_to() {
+        let toml_str = r#"
+[display]
+from_to = "user-host-port"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.display.from_to.as_deref(), Some("user-host-port"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@
 //! compatibility when configs are shared across versions.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 /// Known valid keys per config section.
@@ -35,7 +35,14 @@ fn known_keys() -> HashMap<&'static str, &'static [&'static str]> {
     );
     m.insert(
         "display",
-        ["color", "payload_limit", "delta_time", "visible_columns"].as_slice(),
+        [
+            "color",
+            "payload_limit",
+            "delta_time",
+            "visible_columns",
+            "from_to",
+        ]
+        .as_slice(),
     );
     m.insert("filter", ["from", "to", "expression"].as_slice());
     m.insert(
@@ -64,7 +71,17 @@ fn known_keys() -> HashMap<&'static str, &'static [&'static str]> {
         .as_slice(),
     );
     m.insert("privilege", ["user", "no_priv_drop", "chroot"].as_slice());
-    m.insert("names", ["enabled", "reverse_dns", "hosts_file"].as_slice());
+    m.insert(
+        "names",
+        [
+            "enabled",
+            "reverse_dns",
+            "hosts_file",
+            "manual",
+            "persist_to_config",
+        ]
+        .as_slice(),
+    );
     m.insert(
         "theme",
         [
@@ -319,6 +336,18 @@ pub struct NamesConfig {
     pub reverse_dns: Option<bool>,
     /// `/etc/hosts`-format file of IP -> name mappings to preload.
     pub hosts_file: Option<String>,
+    /// Inline IP -> name mappings, loaded at startup (highest-priority manual
+    /// layer). Written by the in-TUI `N` dialog when [`persist_to_config`] is on.
+    ///
+    /// ```toml
+    /// [names.manual]
+    /// "10.0.0.1" = "sbc-edge"
+    /// ```
+    pub manual: Option<BTreeMap<String, String>>,
+    /// When true, editing a name in the TUI (`N`) also writes the mapping back
+    /// into the `[names.manual]` table of the user's sipnabrc, preserving the
+    /// rest of the file. Defaults to off (mappings persist to the hosts file).
+    pub persist_to_config: Option<bool>,
 }
 
 /// TUI theme configuration — semantic color slots.
@@ -577,6 +606,44 @@ impl Config {
     }
 }
 
+/// Surgically update the `[names.manual]` table of a sipnabrc document.
+///
+/// Parses `existing` (the current file contents; may be empty), replaces the
+/// `[names.manual]` table with `entries` (IP string → name), and returns the
+/// new document text with all comments, key ordering, and other sections
+/// preserved. The previous manual mappings are fully replaced so deletions
+/// propagate.
+///
+/// IP keys are emitted as quoted strings because they contain `.`/`:`, which
+/// would otherwise be parsed as dotted (nested) keys.
+pub fn upsert_manual_mappings(
+    existing: &str,
+    entries: &[(String, String)],
+) -> Result<String, crate::Error> {
+    use toml_edit::{DocumentMut, Item, Table, value};
+
+    let mut doc = existing
+        .parse::<DocumentMut>()
+        .map_err(|e| crate::Error::ConfigInvalid(format!("sipnabrc is not valid TOML: {e}")))?;
+
+    // Ensure [names] exists and is a table.
+    if doc.get("names").is_none() {
+        doc["names"] = Item::Table(Table::new());
+    }
+    let names = doc["names"]
+        .as_table_mut()
+        .ok_or_else(|| crate::Error::ConfigInvalid("[names] is not a table".into()))?;
+
+    // Rebuild the manual sub-table from scratch so removed mappings disappear.
+    let mut manual = Table::new();
+    for (ip, name) in entries {
+        manual[ip.as_str()] = value(name.as_str());
+    }
+    names["manual"] = Item::Table(manual);
+
+    Ok(doc.to_string())
+}
+
 /// Return the default config file search paths (items 3-5).
 fn default_config_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
@@ -593,6 +660,31 @@ fn default_config_paths() -> Vec<PathBuf> {
 /// Get the user's home directory.
 fn home_dir() -> Option<PathBuf> {
     std::env::var("HOME").ok().map(PathBuf::from)
+}
+
+/// The user's preferred sipnabrc path (`~/.config/sipnab/sipnab.toml`), used as
+/// the write target when persisting name mappings into the config.
+pub fn default_user_config_path() -> Option<PathBuf> {
+    home_dir().map(|h| h.join(".config").join("sipnab").join("sipnab.toml"))
+}
+
+/// Write the current manual name mappings into the `[names.manual]` table of the
+/// sipnabrc at `path`, preserving the rest of the file (see
+/// [`upsert_manual_mappings`]). Creates the file and parent directory if needed.
+pub fn write_manual_mappings_file(
+    path: &Path,
+    entries: &[(String, String)],
+) -> Result<(), crate::Error> {
+    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    let updated = upsert_manual_mappings(&existing, entries)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            crate::Error::ConfigInvalid(format!("create {}: {e}", parent.display()))
+        })?;
+    }
+    std::fs::write(path, updated)
+        .map_err(|e| crate::Error::ConfigInvalid(format!("write {}: {e}", path.display())))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -618,6 +710,99 @@ device = "eth0"
         assert_eq!(config.capture.device.as_deref(), Some("eth0"));
         assert!(config.display.color.is_none());
         assert!(config.display.from_to.is_none());
+    }
+
+    #[test]
+    fn upsert_manual_preserves_comments_and_other_sections() {
+        let existing = r#"# my sipnab config
+[capture]
+device = "eth0"  # capture NIC
+
+[names]
+enabled = true
+"#;
+        let entries = vec![
+            ("10.0.0.1".to_string(), "sbc-edge".to_string()),
+            ("2001:db8::1".to_string(), "core6".to_string()),
+        ];
+        let out = upsert_manual_mappings(existing, &entries).expect("valid toml");
+        // Comments and the unrelated section survive.
+        assert!(out.contains("# my sipnab config"));
+        assert!(out.contains("device = \"eth0\"  # capture NIC"));
+        assert!(out.contains("enabled = true"));
+        // The manual table is present with quoted IP keys (dots/colons need quoting).
+        assert!(out.contains("[names.manual]"), "got:\n{out}");
+        assert!(out.contains(r#""10.0.0.1" = "sbc-edge""#), "got:\n{out}");
+        assert!(out.contains(r#""2001:db8::1" = "core6""#), "got:\n{out}");
+        // Re-parsing yields the same mappings (round-trip).
+        let cfg: Config = toml::from_str(&out).unwrap();
+        let manual = cfg.names.manual.unwrap();
+        assert_eq!(manual.get("10.0.0.1").map(String::as_str), Some("sbc-edge"));
+        assert_eq!(manual.get("2001:db8::1").map(String::as_str), Some("core6"));
+    }
+
+    #[test]
+    fn upsert_manual_into_empty_and_replaces_existing() {
+        // Empty input → creates [names.manual] from scratch.
+        let out =
+            upsert_manual_mappings("", &[("1.2.3.4".to_string(), "host".to_string())]).unwrap();
+        assert!(out.contains("[names.manual]"));
+        assert!(out.contains(r#""1.2.3.4" = "host""#));
+
+        // Existing manual entries are fully replaced by the new set.
+        let existing = "[names.manual]\n\"9.9.9.9\" = \"old\"\n";
+        let out = upsert_manual_mappings(existing, &[("1.1.1.1".to_string(), "new".to_string())])
+            .unwrap();
+        assert!(out.contains(r#""1.1.1.1" = "new""#));
+        assert!(
+            !out.contains("9.9.9.9"),
+            "stale entries must be removed:\n{out}"
+        );
+    }
+
+    #[test]
+    fn upsert_manual_rejects_invalid_toml() {
+        assert!(upsert_manual_mappings("this is = = not toml", &[]).is_err());
+    }
+
+    #[test]
+    fn write_manual_mappings_file_creates_dirs_and_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        // Nested path exercises parent-dir creation.
+        let path = dir.path().join("nested/sipnab.toml");
+        write_manual_mappings_file(&path, &[("10.0.0.1".to_string(), "sbc".to_string())]).unwrap();
+        let cfg = Config::load(Some(path.to_str().unwrap()), false)
+            .unwrap()
+            .config;
+        assert_eq!(
+            cfg.names
+                .manual
+                .as_ref()
+                .unwrap()
+                .get("10.0.0.1")
+                .map(String::as_str),
+            Some("sbc")
+        );
+
+        // A second write replaces the set (deletion propagates).
+        write_manual_mappings_file(&path, &[("10.0.0.2".to_string(), "core".to_string())]).unwrap();
+        let cfg = Config::load(Some(path.to_str().unwrap()), false)
+            .unwrap()
+            .config;
+        let m = cfg.names.manual.unwrap();
+        assert_eq!(m.get("10.0.0.2").map(String::as_str), Some("core"));
+        assert!(!m.contains_key("10.0.0.1"));
+    }
+
+    #[test]
+    fn parse_names_manual_table() {
+        let toml_str = r#"
+[names.manual]
+"10.0.0.1" = "sbc"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let manual = config.names.manual.expect("manual table");
+        assert_eq!(manual.get("10.0.0.1").map(String::as_str), Some("sbc"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1031,6 +1031,22 @@ fn run_tui_mode(
     let keymap = sipnab::tui::Keymap::from_config(&config.keybindings);
     let name_setup = build_name_setup(&cli, &config);
 
+    // From/To column default: CLI flag wins, then the [display] from_to config
+    // value (warned + ignored if invalid), else the built-in Default.
+    let from_to_mode = cli
+        .from_to_mode
+        .map(|a| sipnab::tui::FromToMode::parse(a.as_str()).unwrap_or_default())
+        .or_else(|| {
+            config.display.from_to.as_deref().and_then(|s| {
+                let m = sipnab::tui::FromToMode::parse(s);
+                if m.is_none() {
+                    tracing::warn!("ignoring invalid [display] from_to = {s:?}");
+                }
+                m
+            })
+        })
+        .unwrap_or_default();
+
     // Run TUI on the main thread
     if let Err(e) = sipnab::tui::run_tui_with_pause(
         Arc::clone(&dialog_store),
@@ -1040,6 +1056,7 @@ fn run_tui_mode(
         keymap,
         config.display.visible_columns.clone(),
         name_setup,
+        from_to_mode,
     ) {
         tracing::error!("TUI error: {e}");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -765,7 +765,8 @@ fn build_name_setup(cli: &Cli, config: &Config) -> sipnab::tui::NameSetup {
         || reverse
         || cfg.enabled.unwrap_or(false)
         || !cli.names.is_empty()
-        || cfg.hosts_file.is_some();
+        || cfg.hosts_file.is_some()
+        || cfg.manual.as_ref().is_some_and(|m| !m.is_empty());
 
     let resolver = Arc::new(NameResolver::with_reverse_dns(reverse));
     // System hosts table (offline, cheap).
@@ -779,11 +780,29 @@ fn build_name_setup(cli: &Cli, config: &Config) -> sipnab::tui::NameSetup {
     if let Some(hf) = &cfg.hosts_file {
         let _ = resolver.load_manual_file(std::path::Path::new(hf));
     }
+    // Inline [names.manual] table from the config (highest-priority manual layer).
+    if let Some(manual) = &cfg.manual {
+        for (ip_str, name) in manual {
+            match ip_str.parse::<std::net::IpAddr>() {
+                Ok(ip) if sipnab::names::is_valid_name(name) => {
+                    resolver.set_manual(ip, name.clone());
+                }
+                Ok(_) => tracing::warn!("ignoring invalid name for {ip_str:?} in [names.manual]"),
+                Err(_) => tracing::warn!("ignoring invalid IP key {ip_str:?} in [names.manual]"),
+            }
+        }
+    }
     // Default persistence file for the in-TUI `N` dialog; preload it.
     let save_path = default_names_path();
     if let Some(p) = &save_path {
         let _ = resolver.load_manual_file(p);
     }
+    // Opt-in: also persist `N`-dialog edits into the user's sipnabrc.
+    let config_path = if cfg.persist_to_config.unwrap_or(false) {
+        sipnab::config::default_user_config_path()
+    } else {
+        None
+    };
 
     let mode = if reverse {
         NameMode::Dns
@@ -796,6 +815,7 @@ fn build_name_setup(cli: &Cli, config: &Config) -> sipnab::tui::NameSetup {
         resolver,
         mode,
         save_path,
+        config_path,
     }
 }
 

--- a/src/sip/dialog.rs
+++ b/src/sip/dialog.rs
@@ -75,6 +75,10 @@ pub struct SipDialog {
     pub from_user: Option<String>,
     /// User part extracted from the To URI.
     pub to_user: Option<String>,
+    /// Host (with optional `:port`) extracted from the From URI.
+    pub from_host: Option<String>,
+    /// Host (with optional `:port`) extracted from the To URI.
+    pub to_host: Option<String>,
     /// Tag parameter from the From header.
     pub from_tag: Option<String>,
     /// Tag parameter from the To header.
@@ -167,6 +171,8 @@ impl SipDialog {
             call_id,
             from_user: msg.from_user(),
             to_user: msg.to_user(),
+            from_host: msg.from_host(),
+            to_host: msg.to_host(),
             from_tag: msg.from_tag().map(str::to_string),
             to_tag: msg.to_tag().map(str::to_string),
             from_display: msg.from_display(),

--- a/src/sip/dsl.rs
+++ b/src/sip/dsl.rs
@@ -172,6 +172,32 @@ pub fn expand_alias(alias: &str) -> Option<&'static str> {
 // ── FilterExpr public API ───────────────────────────────────────────
 
 impl FilterExpr {
+    /// An expression that matches **no** dialog.
+    ///
+    /// Used to represent "show nothing" — e.g. the filter dialog with every SIP
+    /// method unchecked — so the call-list filter path keeps funnelling through
+    /// a single `Option<FilterExpr>` instead of growing a special case.
+    ///
+    /// `one_way` is a concrete per-dialog boolean, so requiring it to be both
+    /// `true` and `false` is unsatisfiable for every dialog.
+    #[must_use]
+    pub fn never() -> Self {
+        FilterExpr {
+            root: Expr::And(
+                Box::new(Expr::Compare(
+                    Field::OneWay,
+                    Operator::Eq,
+                    Value::Bool(true),
+                )),
+                Box::new(Expr::Compare(
+                    Field::OneWay,
+                    Operator::Eq,
+                    Value::Bool(false),
+                )),
+            ),
+        }
+    }
+
     /// Parse a filter expression string into a compiled [`FilterExpr`].
     ///
     /// The grammar is:
@@ -1427,6 +1453,38 @@ mod tests {
         // one_way is false with no streams, so == false matches.
         let filter = FilterExpr::parse("one_way == false").expect("should parse");
         assert!(filter.matches_dialog(&dialog, &[]));
+    }
+
+    #[test]
+    fn partial_method_filter_excludes_unlisted_method() {
+        // C1: a dialog whose initial method is not one of the filter checkboxes
+        // (e.g. BYE) must be HIDDEN by a partial method selection — only the
+        // explicitly-checked methods are shown. (All-checked yields no filter at
+        // the dialog layer, so such dialogs are shown then.)
+        let bye = make_dialog("1001", "2002", "BYE");
+        let partial = FilterExpr::parse("(method == 'REGISTER' OR method == 'INVITE')")
+            .expect("should parse");
+        assert!(
+            !partial.matches_dialog(&bye, &[]),
+            "a partial method selection must not match an unlisted-method dialog"
+        );
+        // And it does match a dialog whose method IS in the selection.
+        let invite = make_dialog("1001", "2002", "INVITE");
+        assert!(partial.matches_dialog(&invite, &[]));
+    }
+
+    #[test]
+    fn never_matches_no_dialog() {
+        // `FilterExpr::never()` represents "show nothing" — it must reject every
+        // dialog regardless of method, users, or RTP state.
+        let never = FilterExpr::never();
+        for method in ["INVITE", "REGISTER", "BYE", "OPTIONS"] {
+            let dialog = make_dialog("1001", "2002", method);
+            assert!(
+                !never.matches_dialog(&dialog, &[]),
+                "never() must not match a {method} dialog"
+            );
+        }
     }
 
     // ── compare_str: every operator + type mismatch ─────────────────────

--- a/src/sip/message.rs
+++ b/src/sip/message.rs
@@ -164,6 +164,20 @@ impl SipMessage {
         extract_uri_user(self.to_header()?)
     }
 
+    /// Extract the host (with optional `:port`) from the `From` URI.
+    ///
+    /// For `From: <sip:1001@example.com:5060>;tag=abc` returns
+    /// `Some("example.com:5060")`. Returns `None` for URIs without a host
+    /// (e.g. `tel:`).
+    pub fn from_host(&self) -> Option<String> {
+        extract_uri_host_port(self.from_header()?)
+    }
+
+    /// Extract the host (with optional `:port`) from the `To` URI.
+    pub fn to_host(&self) -> Option<String> {
+        extract_uri_host_port(self.to_header()?)
+    }
+
     /// Extract the `tag` parameter from the `From` header.
     pub fn from_tag(&self) -> Option<&str> {
         extract_tag(self.from_header()?)
@@ -215,6 +229,43 @@ fn extract_uri_user(header_value: &str) -> Option<String> {
         return None;
     }
     Some(user.to_string())
+}
+
+/// Extract the host (with optional `:port`) from a SIP URI inside a header value.
+///
+/// Handles `<sip:user@host:port;params>`, bare `sip:host`, and bracketed IPv6
+/// hosts (`sip:user@[2001:db8::1]:5060`). Returns `None` for non-SIP URIs (e.g.
+/// `tel:`) or when no host is present (RFC 3261 § 19.1).
+fn extract_uri_host_port(header_value: &str) -> Option<String> {
+    let scheme_pos = header_value
+        .find("<sip:")
+        .or_else(|| header_value.find("<sips:"))
+        .or_else(|| header_value.find("sip:"))
+        .or_else(|| header_value.find("sips:"))?;
+
+    let after_scheme = &header_value[scheme_pos..];
+    // Skip past the scheme name to just after its ':'.
+    let colon_pos = after_scheme.find(':')?;
+    let mut rest = &after_scheme[colon_pos + 1..];
+
+    // Drop the userinfo (everything up to and including the first '@'). Hosts
+    // never contain '@', and IPv6 literals are bracketed, so this is safe.
+    if let Some(at) = rest.find('@') {
+        rest = &rest[at + 1..];
+    }
+
+    // host[:port] ends at the first URI delimiter: ';' (uri-parameters), '>'
+    // (end of angle form), '?' (headers), ',' (next header value), or
+    // whitespace. ':' is left intact so it can carry the port (and IPv6 colons).
+    let end = rest
+        .find(|c: char| matches!(c, ';' | '>' | '?' | ',') || c.is_whitespace())
+        .unwrap_or(rest.len());
+    let host_port = rest[..end].trim();
+
+    if host_port.is_empty() {
+        return None;
+    }
+    Some(host_port.to_string())
 }
 
 /// Extract the display name from a SIP From/To header value.
@@ -352,6 +403,86 @@ mod tests {
         assert_eq!(
             extract_uri_user("Alice <sip:alice@host>"),
             Some("alice".to_string())
+        );
+    }
+
+    // ── extract_uri_host_port ────────────────────────────────────────
+
+    #[test]
+    fn host_port_with_user_and_port() {
+        assert_eq!(
+            extract_uri_host_port(r#""Alice" <sip:1001@example.com:5060>;tag=abc"#),
+            Some("example.com:5060".to_string())
+        );
+    }
+
+    #[test]
+    fn host_port_no_port() {
+        assert_eq!(
+            extract_uri_host_port("<sip:1002@example.com>"),
+            Some("example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn host_port_no_user() {
+        // A URI with no userinfo (e.g. a registrar/domain target).
+        assert_eq!(
+            extract_uri_host_port("<sip:example.com:5061>"),
+            Some("example.com:5061".to_string())
+        );
+    }
+
+    #[test]
+    fn host_port_ipv6_bracketed_with_port() {
+        assert_eq!(
+            extract_uri_host_port("<sip:bob@[2001:db8::1]:5060>;transport=udp"),
+            Some("[2001:db8::1]:5060".to_string())
+        );
+    }
+
+    #[test]
+    fn host_port_ipv6_no_port() {
+        assert_eq!(
+            extract_uri_host_port("<sip:[2001:db8::1]>"),
+            Some("[2001:db8::1]".to_string())
+        );
+    }
+
+    #[test]
+    fn host_port_strips_uri_params() {
+        assert_eq!(
+            extract_uri_host_port("<sip:1001@10.0.0.1:5060;transport=tcp;lr>"),
+            Some("10.0.0.1:5060".to_string())
+        );
+    }
+
+    #[test]
+    fn host_port_bare_uri() {
+        assert_eq!(
+            extract_uri_host_port("sip:alice@host.example:5070"),
+            Some("host.example:5070".to_string())
+        );
+        assert_eq!(
+            extract_uri_host_port("sips:bob@secure.example"),
+            Some("secure.example".to_string())
+        );
+    }
+
+    #[test]
+    fn host_port_tel_uri_has_no_host() {
+        // tel: URIs carry no host — fall back to None (caller shows user or '-').
+        assert_eq!(extract_uri_host_port("<tel:+15551234567>"), None);
+    }
+
+    #[test]
+    fn host_port_empty_or_garbage() {
+        assert_eq!(extract_uri_host_port(""), None);
+        assert_eq!(extract_uri_host_port("not a uri at all"), None);
+        // Backslash / odd chars must not panic.
+        assert_eq!(
+            extract_uri_host_port(r"<sip:a\b@ho\st>"),
+            Some(r"ho\st".to_string())
         );
     }
 }

--- a/src/tui/call_list.rs
+++ b/src/tui/call_list.rs
@@ -300,6 +300,7 @@ pub struct CallListDisplay<'a> {
     pub filter: Option<&'a FilterExpr>,
     pub search_query: &'a str,
     pub timestamp_mode: TimestampMode,
+    pub from_to_mode: super::FromToMode,
     pub theme: &'a super::Theme,
     pub resolver: &'a crate::names::NameResolver,
     pub name_mode: crate::names::NameMode,
@@ -557,8 +558,20 @@ pub fn render_call_list(
             let all_cells = [
                 Cell::from(Span::raw(format!("{}{}", checkbox, idx + 1))),
                 Cell::from(Span::styled(dialog.method.as_str(), method_style)),
-                Cell::from(Span::raw(dialog.from_user.as_deref().unwrap_or("-"))),
-                Cell::from(Span::raw(dialog.to_user.as_deref().unwrap_or("-"))),
+                Cell::from(Span::raw(format_from_to(
+                    display.from_to_mode,
+                    dialog.from_user.as_deref(),
+                    dialog.from_host.as_deref(),
+                    display.resolver,
+                    display.name_mode,
+                ))),
+                Cell::from(Span::raw(format_from_to(
+                    display.from_to_mode,
+                    dialog.to_user.as_deref(),
+                    dialog.to_host.as_deref(),
+                    display.resolver,
+                    display.name_mode,
+                ))),
                 Cell::from(Span::raw(
                     display
                         .resolver
@@ -815,11 +828,170 @@ fn state_style(state: &DialogState, theme: &super::Theme) -> Style {
     }
 }
 
+/// Resolve an IP-literal host (with optional `:port`) through the name resolver
+/// so the From/To columns stay consistent with the Source/Dest columns. FQDN
+/// hosts, and IP hosts with no mapping, are returned unchanged.
+fn resolve_host_label(
+    host: &str,
+    resolver: &crate::names::NameResolver,
+    name_mode: crate::names::NameMode,
+) -> String {
+    use std::net::IpAddr;
+    if name_mode == crate::names::NameMode::Off {
+        return host.to_string();
+    }
+    // Bracketed IPv6: `[addr]` or `[addr]:port`.
+    if let Some(rest) = host.strip_prefix('[') {
+        if let Some(close) = rest.find(']') {
+            let addr = &rest[..close];
+            let suffix = &rest[close + 1..]; // ":5060" or ""
+            if let Ok(ip) = addr.parse::<IpAddr>()
+                && let Some(name) = resolver.name(ip, name_mode)
+            {
+                return format!("{name}{suffix}");
+            }
+        }
+        return host.to_string();
+    }
+    // IPv4 / hostname with an optional numeric `:port`.
+    let (addr, suffix) = match host.rsplit_once(':') {
+        Some((a, p)) if !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()) => {
+            (a, format!(":{p}"))
+        }
+        _ => (host, String::new()),
+    };
+    if let Ok(ip) = addr.parse::<IpAddr>()
+        && let Some(name) = resolver.name(ip, name_mode)
+    {
+        return format!("{name}{suffix}");
+    }
+    host.to_string()
+}
+
+/// Format a From/To column cell for the given [`FromToMode`](super::FromToMode),
+/// resolving IP-literal hosts through the name resolver.
+fn format_from_to(
+    mode: super::FromToMode,
+    user: Option<&str>,
+    host: Option<&str>,
+    resolver: &crate::names::NameResolver,
+    name_mode: crate::names::NameMode,
+) -> String {
+    let resolved = host.map(|h| resolve_host_label(h, resolver, name_mode));
+    mode.format(user, resolved.as_deref())
+}
+
 // ── Tests ───────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::names::{NameMode, NameResolver};
+    use std::net::IpAddr;
+
+    #[test]
+    fn format_from_to_shows_host_when_user_missing() {
+        let r = NameResolver::new();
+        // Default mode: username present wins.
+        assert_eq!(
+            format_from_to(
+                super::super::FromToMode::Default,
+                Some("1001"),
+                Some("pbx.example:5060"),
+                &r,
+                NameMode::Off
+            ),
+            "1001"
+        );
+        // Default mode: no username → host[:port] instead of a bare dash.
+        assert_eq!(
+            format_from_to(
+                super::super::FromToMode::Default,
+                None,
+                Some("pbx.example:5060"),
+                &r,
+                NameMode::Off
+            ),
+            "pbx.example:5060"
+        );
+        // No user and no host → dash.
+        assert_eq!(
+            format_from_to(
+                super::super::FromToMode::Default,
+                None,
+                None,
+                &r,
+                NameMode::Off
+            ),
+            "-"
+        );
+    }
+
+    #[test]
+    fn format_from_to_user_host_combines_long_value() {
+        let r = NameResolver::new();
+        // UserHostPort with a bracketed IPv6 host must build a single long
+        // string without panicking (column truncation is ratatui's job).
+        let out = format_from_to(
+            super::super::FromToMode::UserHostPort,
+            Some("1001"),
+            Some("[2001:db8::1]:5060"),
+            &r,
+            NameMode::Off,
+        );
+        assert_eq!(out, "1001@[2001:db8::1]:5060");
+    }
+
+    #[test]
+    fn resolve_host_label_maps_ip_literals_preserving_port() {
+        let r = NameResolver::new();
+        r.set_manual(
+            "10.0.0.7".parse::<IpAddr>().unwrap(),
+            "sbc-edge".to_string(),
+        );
+        // IPv4 with port → name + port.
+        assert_eq!(
+            resolve_host_label("10.0.0.7:5060", &r, NameMode::Names),
+            "sbc-edge:5060"
+        );
+        // IPv4 no port → bare name.
+        assert_eq!(
+            resolve_host_label("10.0.0.7", &r, NameMode::Names),
+            "sbc-edge"
+        );
+        // Off mode → never resolves.
+        assert_eq!(
+            resolve_host_label("10.0.0.7", &r, NameMode::Off),
+            "10.0.0.7"
+        );
+        // Unmapped IP → unchanged.
+        assert_eq!(
+            resolve_host_label("10.0.0.99:5060", &r, NameMode::Names),
+            "10.0.0.99:5060"
+        );
+        // FQDN host → never touched.
+        assert_eq!(
+            resolve_host_label("pbx.example:5060", &r, NameMode::Names),
+            "pbx.example:5060"
+        );
+    }
+
+    #[test]
+    fn resolve_host_label_maps_bracketed_ipv6() {
+        let r = NameResolver::new();
+        r.set_manual(
+            "2001:db8::1".parse::<IpAddr>().unwrap(),
+            "core6".to_string(),
+        );
+        assert_eq!(
+            resolve_host_label("[2001:db8::1]:5060", &r, NameMode::Names),
+            "core6:5060"
+        );
+        assert_eq!(
+            resolve_host_label("[2001:db8::1]", &r, NameMode::Names),
+            "core6"
+        );
+    }
 
     #[test]
     fn call_list_state_move_up_from_zero_stays() {

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1529,6 +1529,15 @@ pub(super) fn is_rtcp_offline(data: &[u8], dst_port: u16) -> bool {
 
 /// Apply the filter dialog state: build a DSL expression, parse it, and set the active filter.
 pub(super) fn apply_filter_dialog(app: &mut App) {
+    // No SIP methods selected => show nothing. This is the explicit "mute
+    // everything" state (distinct from all-checked, which shows everything).
+    if !app.filter_dialog.any_method_checked() {
+        app.active_filter = Some(FilterExpr::never());
+        app.active_filter_text = "(no methods selected)".to_string();
+        app.status_error = None;
+        app.active_popup = None;
+        return;
+    }
     match app.filter_dialog.build_filter_expression() {
         Some(expr_text) => match FilterExpr::parse(&expr_text) {
             Ok(expr) => {

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -909,7 +909,16 @@ pub(super) fn handle_help_key(app: &mut App, key: KeyEvent) {
     match key.code {
         k if k == KeyCode::Esc || k == app.keymap.help || k == app.keymap.quit => {
             app.current_view = View::CallList;
+            app.help_scroll = 0; // start at the top next time
         }
+        // The help can exceed the screen; allow scrolling. render() clamps the
+        // offset to the content height, so over-scrolling self-corrects.
+        KeyCode::Down | KeyCode::Char('j') => app.help_scroll = app.help_scroll.saturating_add(1),
+        KeyCode::Up | KeyCode::Char('k') => app.help_scroll = app.help_scroll.saturating_sub(1),
+        KeyCode::PageDown => app.help_scroll = app.help_scroll.saturating_add(10),
+        KeyCode::PageUp => app.help_scroll = app.help_scroll.saturating_sub(10),
+        KeyCode::Home => app.help_scroll = 0,
+        KeyCode::End => app.help_scroll = u16::MAX, // clamped to content in render
         _ => {}
     }
 }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -137,6 +137,11 @@ pub(super) fn handle_call_list_key(app: &mut App, key: KeyEvent) {
             app.timestamp_mode = app.timestamp_mode.next();
             app.status_error = Some(app.timestamp_mode.label().to_string());
         }
+        // u — Cycle From/To column display (user / host:port / both)
+        KeyCode::Char('u') => {
+            app.from_to_mode = app.from_to_mode.next();
+            app.status_error = Some(app.from_to_mode.label().to_string());
+        }
         // F10 — Column selector popup
         k if k == app.keymap.column_selector => {
             app.call_list.column_selector_open = true;
@@ -2057,6 +2062,26 @@ mod tests {
     fn open_call_flow(app: &mut App) {
         handle_call_list_key(app, key(KeyCode::Enter));
         assert!(matches!(app.current_view, View::CallFlow(_)));
+    }
+
+    #[test]
+    fn call_list_u_cycles_from_to_mode() {
+        let mut app = App::new_test();
+        assert_eq!(app.from_to_mode(), crate::tui::FromToMode::Default);
+        handle_call_list_key(&mut app, key(KeyCode::Char('u')));
+        assert_eq!(app.from_to_mode(), crate::tui::FromToMode::HostPort);
+        // Status line reflects the new mode.
+        assert!(
+            app.status_error
+                .as_deref()
+                .unwrap_or("")
+                .contains("From/To")
+        );
+        // Cycles through all four back to Default.
+        handle_call_list_key(&mut app, key(KeyCode::Char('u')));
+        handle_call_list_key(&mut app, key(KeyCode::Char('u')));
+        handle_call_list_key(&mut app, key(KeyCode::Char('u')));
+        assert_eq!(app.from_to_mode(), crate::tui::FromToMode::Default);
     }
 
     // ── handle_key_event: dispatch & global ──────────────────────────

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1843,6 +1843,22 @@ fn apply_name_dialog(app: &mut App) {
     {
         app.status_error = Some(format!("Named, but couldn't save {}: {e}", path.display()));
     }
+    // Opt-in: also persist the full manual table into the user's sipnabrc,
+    // preserving comments and other sections.
+    if let Some(path) = app.names_config_path.clone() {
+        let entries: Vec<(String, String)> = app
+            .resolver
+            .manual_entries()
+            .into_iter()
+            .map(|(ip, n)| (ip.to_string(), n))
+            .collect();
+        if let Err(e) = crate::config::write_manual_mappings_file(&path, &entries) {
+            app.status_error = Some(format!(
+                "Named, but couldn't update {}: {e}",
+                path.display()
+            ));
+        }
+    }
 }
 
 /// Count dialogs visible after applying the active filter.

--- a/src/tui/help.rs
+++ b/src/tui/help.rs
@@ -30,10 +30,16 @@ CALL LIST:
   F1               This help
   F2               Save capture (PCAP/PCAP-NG/TXT)
   F3               Search (same as /)
-  F5               Clear calls
-  F6               Show raw SIP message
+  F5, Ctrl+L       Clear calls
+  r, F6            Show raw SIP message
   F7               Filter dialog
+  F8               Settings
   t                Cycle timestamps (absolute / delta-prev / delta-first)
+  u                Cycle From/To column (user / host:port / both)
+  n                Cycle name resolution (off / static / DNS)
+  N                Name selected address (IP -> host / FQDN)
+  O                Open pcap file
+  s                Statistics view
   F9               Clear active filter
   F10              Column selector
   Tab              Switch to RTP Streams
@@ -52,11 +58,16 @@ CALL FLOW:
   t                Cycle timestamps (absolute / delta-prev / delta-first)
   c                Cycle colors (method / call-id / cseq)
   R                Toggle detail panel
+  m / M            Mark message / clear marks
+  e                Fold / expand retransmits
+  E                Export Mermaid sequence diagram
   9/0, +/-, ←/→    Resize ladder/detail split
   [ / ]            Scroll detail panel (any focus)
   F2               Save
   F4, x            Extended multi-leg flow
   F6               Toggle RTP display
+  r                Jump to RTP Streams
+  N                Name selected address (IP -> host / FQDN)
 
 RAW MESSAGE:
   \u{2191}/\u{2193}             Scroll
@@ -68,15 +79,28 @@ RAW MESSAGE:
 
 RTP STREAMS (Tab):
   \u{2191}/\u{2193}             Navigate streams
+  Enter            Stream detail
   Tab              Switch to Call List
   F1               Help
   F7               Filter
+  N                Name selected address (IP -> host / FQDN)
   Esc              Back to Call List
+
+STREAM DETAIL:
+  \u{2191}/\u{2193}             Scroll
+  Shift+P          Play / stop audio (G.711, audio build)
+  Esc              Back to RTP Streams
 
 Press Esc or F1 to close this help.";
 
 /// Render the help view.
-pub fn render_help(frame: &mut Frame, area: Rect, theme: &super::Theme, version: &str) {
+pub fn render_help(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &super::Theme,
+    version: &str,
+    scroll: u16,
+) {
     // Inner width inside the bordered block (one column per side border). The
     // version line is constrained to this width so a long version string
     // (tag + commit + "-dirty" + the full feature list) cannot wrap onto a
@@ -86,13 +110,20 @@ pub fn render_help(frame: &mut Frame, area: Rect, theme: &super::Theme, version:
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(" Help (Esc to close) ");
+        .title(" Help (\u{2191}/\u{2193} scroll, Esc to close) ");
 
     let paragraph = Paragraph::new(lines)
         .block(block)
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
 
     frame.render_widget(paragraph, area);
+}
+
+/// Number of rendered help lines (one per `HELP_TEXT` line, plus the version
+/// line inserted under the title). Used to clamp the scroll offset.
+pub fn help_line_count() -> usize {
+    HELP_TEXT.lines().count() + 1
 }
 
 /// Build styled help lines from the help text.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -751,6 +751,8 @@ pub struct App {
     call_flow_scroll: usize,
     /// Scroll offset for raw message view.
     raw_msg_scroll: u16,
+    /// Scroll offset for the F1 help view (clamped to content height in render).
+    help_scroll: u16,
     /// Search query for inline search.
     search_query: String,
     /// Whether search input mode is active.
@@ -893,6 +895,7 @@ impl App {
             status_error: None,
             call_flow_scroll: 0,
             raw_msg_scroll: 0,
+            help_scroll: 0,
             search_query: String::new(),
             search_active: false,
             capture_mode: "Online (any)".to_string(),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -339,7 +339,7 @@ struct NameDialogState {
 }
 
 /// Structured state for the sngrep-style filter dialog.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct FilterDialogState {
     /// SIP From header filter text.
     sip_from: String,
@@ -360,7 +360,30 @@ pub struct FilterDialogState {
     cursor_pos: usize,
 }
 
+impl Default for FilterDialogState {
+    fn default() -> Self {
+        Self {
+            sip_from: String::new(),
+            sip_to: String::new(),
+            source: String::new(),
+            destination: String::new(),
+            payload: String::new(),
+            // All SIP methods checked by default == show every message. The
+            // method filter only narrows once the user unchecks something.
+            methods: [true; 10],
+            focused_field: 0,
+            cursor_pos: 0,
+        }
+    }
+}
+
 impl FilterDialogState {
+    /// Whether at least one SIP method checkbox is checked. When none are
+    /// checked the call list shows nothing (see `apply_filter_dialog`).
+    fn any_method_checked(&self) -> bool {
+        self.methods.iter().any(|&v| v)
+    }
+
     /// Get a reference to the text field at the given index (0-4).
     fn text_field(&self, idx: usize) -> &str {
         match idx {
@@ -535,7 +558,9 @@ impl FilterDialogState {
         self.source.clear();
         self.destination.clear();
         self.payload.clear();
-        self.methods = [false; 10];
+        // Re-check every method so "clear filter" means show all, matching the
+        // dialog's default state.
+        self.methods = [true; 10];
         self.focused_field = 0;
         self.cursor_pos = 0;
     }
@@ -553,7 +578,8 @@ impl FilterDialogState {
             && self.source.is_empty()
             && self.destination.is_empty()
             && self.payload.is_empty()
-            && self.methods.iter().all(|&v| !v)
+            // All methods checked == no method narrowing == an "empty" filter.
+            && self.methods.iter().all(|&v| v)
     }
 }
 
@@ -1055,6 +1081,14 @@ impl App {
     pub fn open_path_clear_for_test(&mut self) {
         self.open_path.clear();
         self.open_cursor = 0;
+    }
+
+    /// Set the filter-dialog SIP-method checkboxes and apply the filter, exactly
+    /// as pressing Enter in the dialog would (test helper for set/unset scenarios).
+    #[doc(hidden)]
+    pub fn apply_method_filter_for_test(&mut self, methods: [bool; 10]) {
+        self.filter_dialog.methods = methods;
+        apply_filter_dialog(self);
     }
 
     #[doc(hidden)]
@@ -1600,26 +1634,70 @@ mod tests {
     }
 
     #[test]
-    fn filter_dialog_toggle_and_build_expression() {
-        let mut st = FilterDialogState::default();
-        // Empty → no expression.
+    fn filter_dialog_default_all_methods_checked() {
+        // SIP messages must be checked by default → no narrowing → no expression.
+        let st = FilterDialogState::default();
+        assert!(
+            st.methods.iter().all(|&v| v),
+            "all methods should default to checked"
+        );
+        assert!(st.any_method_checked());
+        assert!(
+            st.is_empty(),
+            "all-checked + empty text == no active filter"
+        );
         assert!(st.build_filter_expression().is_none());
+    }
+
+    #[test]
+    fn filter_dialog_clear_resets_to_all_checked() {
+        let mut st = FilterDialogState::default();
+        st.methods = [false; 10];
+        st.sip_from = "x".to_string();
+        st.clear();
+        assert!(
+            st.methods.iter().all(|&v| v),
+            "clear() must re-check all methods (show all)"
+        );
         assert!(st.is_empty());
+    }
 
-        // Toggle INVITE checkbox (index 2).
-        st.focused_field = FILTER_TEXT_FIELD_COUNT + 2;
+    #[test]
+    fn filter_dialog_any_method_checked_tracks_state() {
+        let mut st = FilterDialogState::default();
+        assert!(st.any_method_checked());
+        st.methods = [false; 10];
+        assert!(
+            !st.any_method_checked(),
+            "no methods checked → show nothing"
+        );
+        st.methods[3] = true;
+        assert!(st.any_method_checked());
+    }
+
+    #[test]
+    fn filter_dialog_uncheck_one_excludes_that_method() {
+        // From the all-checked default, unchecking INVITE (index 2) must produce
+        // a method filter over the OTHER nine and exclude INVITE.
+        let mut st = FilterDialogState::default();
+        st.focused_field = FILTER_TEXT_FIELD_COUNT + 2; // INVITE
         st.toggle_checkbox();
-        assert!(st.methods[2]);
-        let expr = st.build_filter_expression().expect("some methods checked");
-        assert!(expr.contains("method == 'INVITE'"));
+        assert!(!st.methods[2], "INVITE now unchecked");
+        let expr = st
+            .build_filter_expression()
+            .expect("partial selection → expression");
+        assert!(
+            !expr.contains("'INVITE'"),
+            "unchecked INVITE must be excluded: {expr}"
+        );
+        assert!(expr.contains("method == 'REGISTER'"));
+        assert!(expr.contains(" OR "));
 
-        // Add text fields → AND-joined.
+        // Text fields AND-join with the method clause.
         st.sip_from = "1001".to_string();
         st.source = "10.0.0.1".to_string();
         let expr = st.build_filter_expression().unwrap();
-        assert!(expr.contains("from.user"));
-        assert!(expr.contains("src.ip"));
-        assert!(expr.contains(" AND "));
+        assert!(expr.contains("from.user") && expr.contains("src.ip") && expr.contains(" AND "));
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -149,6 +149,82 @@ impl ColorMode {
     }
 }
 
+/// How the call-list From/To columns render a SIP address.
+///
+/// Cycled with the `u` key. The username is often absent (e.g. domain-only or
+/// device URIs), so the default falls back to the host instead of a bare `-`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FromToMode {
+    /// Username if present, else host[:port] (else `-`).
+    #[default]
+    Default,
+    /// Host[:port] only (else `-`).
+    HostPort,
+    /// Username only (else `-`) — the legacy behavior.
+    User,
+    /// `user@host:port` when both exist, else whichever exists (else `-`).
+    UserHostPort,
+}
+
+impl FromToMode {
+    /// Cycle to the next mode.
+    fn next(self) -> Self {
+        match self {
+            Self::Default => Self::HostPort,
+            Self::HostPort => Self::User,
+            Self::User => Self::UserHostPort,
+            Self::UserHostPort => Self::Default,
+        }
+    }
+
+    /// Human-readable label for the status bar.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Default => "From/To: Default (user or host)",
+            Self::HostPort => "From/To: Host:port",
+            Self::User => "From/To: User only",
+            Self::UserHostPort => "From/To: User@host:port",
+        }
+    }
+
+    /// Stable string used in config (`[display] from_to = ...`) and the CLI.
+    pub fn as_config_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::HostPort => "host-port",
+            Self::User => "user",
+            Self::UserHostPort => "user-host-port",
+        }
+    }
+
+    /// Parse a config/CLI value into a mode. Returns `None` for unknown values.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "default" => Some(Self::Default),
+            "host-port" => Some(Self::HostPort),
+            "user" => Some(Self::User),
+            "user-host-port" => Some(Self::UserHostPort),
+            _ => None,
+        }
+    }
+
+    /// Format a From/To cell from the (already name-resolved) user and host.
+    fn format(self, user: Option<&str>, host: Option<&str>) -> String {
+        const DASH: &str = "-";
+        match self {
+            Self::Default => user.or(host).unwrap_or(DASH).to_string(),
+            Self::HostPort => host.unwrap_or(DASH).to_string(),
+            Self::User => user.unwrap_or(DASH).to_string(),
+            Self::UserHostPort => match (user, host) {
+                (Some(u), Some(h)) => format!("{u}@{h}"),
+                (Some(u), None) => u.to_string(),
+                (None, Some(h)) => h.to_string(),
+                (None, None) => DASH.to_string(),
+            },
+        }
+    }
+}
+
 /// A single entry in the file-open browser's directory listing.
 #[derive(Debug, Clone)]
 struct FileEntry {
@@ -740,6 +816,8 @@ pub struct App {
     timestamp_mode: TimestampMode,
     /// Color mode for arrows (Method / CallId / CSeq).
     color_mode: ColorMode,
+    /// How the call-list From/To columns render (user / host:port / both).
+    from_to_mode: FromToMode,
     /// Whether the raw preview split is active in call flow view.
     /// Default is `true` (matching sngrep: split view on by default).
     raw_preview: bool,
@@ -842,6 +920,7 @@ impl App {
             sdp_display_mode: SdpDisplayMode::default(),
             timestamp_mode: TimestampMode::default(),
             color_mode: ColorMode::default(),
+            from_to_mode: FromToMode::default(),
             raw_preview: true,
             raw_preview_pct: 40,
             selected_msg_index: 0,
@@ -954,6 +1033,7 @@ pub fn run_tui(
         Keymap::default(),
         None,
         NameSetup::default(),
+        FromToMode::default(),
     )
 }
 
@@ -970,6 +1050,7 @@ pub fn run_tui_with_pause(
     keymap: Keymap,
     visible_columns: Option<Vec<String>>,
     name_setup: NameSetup,
+    from_to_mode: FromToMode,
 ) -> Result<()> {
     // Setup terminal
     terminal::enable_raw_mode()?;
@@ -995,6 +1076,7 @@ pub fn run_tui_with_pause(
     if let Some(ref cols) = visible_columns {
         app.call_list.apply_visible_columns(cols);
     }
+    app.set_from_to_mode(from_to_mode);
     app.set_resolver(name_setup.resolver);
     app.set_name_mode(name_setup.mode);
     app.set_names_save_path(name_setup.save_path);
@@ -1140,6 +1222,17 @@ impl App {
     /// Return the current timestamp display mode.
     pub fn timestamp_mode(&self) -> TimestampMode {
         self.timestamp_mode
+    }
+
+    /// Return the current From/To column display mode.
+    pub fn from_to_mode(&self) -> FromToMode {
+        self.from_to_mode
+    }
+
+    /// Set the From/To column display mode (used to apply the startup default
+    /// from config/CLI).
+    pub fn set_from_to_mode(&mut self, mode: FromToMode) {
+        self.from_to_mode = mode;
     }
 
     /// Current name-resolution display mode.
@@ -1651,9 +1744,11 @@ mod tests {
 
     #[test]
     fn filter_dialog_clear_resets_to_all_checked() {
-        let mut st = FilterDialogState::default();
-        st.methods = [false; 10];
-        st.sip_from = "x".to_string();
+        let mut st = FilterDialogState {
+            methods: [false; 10],
+            sip_from: "x".to_string(),
+            ..Default::default()
+        };
         st.clear();
         assert!(
             st.methods.iter().all(|&v| v),
@@ -1679,8 +1774,10 @@ mod tests {
     fn filter_dialog_uncheck_one_excludes_that_method() {
         // From the all-checked default, unchecking INVITE (index 2) must produce
         // a method filter over the OTHER nine and exclude INVITE.
-        let mut st = FilterDialogState::default();
-        st.focused_field = FILTER_TEXT_FIELD_COUNT + 2; // INVITE
+        let mut st = FilterDialogState {
+            focused_field: FILTER_TEXT_FIELD_COUNT + 2, // INVITE
+            ..Default::default()
+        };
         st.toggle_checkbox();
         assert!(!st.methods[2], "INVITE now unchecked");
         let expr = st
@@ -1736,6 +1833,75 @@ mod tests {
         };
         st.sync_cursor();
         assert_eq!(st.cursor_pos, 5);
+    }
+
+    // ── FromToMode ───────────────────────────────────────────────────
+
+    #[test]
+    fn from_to_mode_default_prefers_user_then_host() {
+        let m = FromToMode::Default;
+        assert_eq!(m.format(Some("1001"), Some("h:5060")), "1001");
+        assert_eq!(m.format(None, Some("h:5060")), "h:5060");
+        assert_eq!(m.format(None, None), "-");
+    }
+
+    #[test]
+    fn from_to_mode_host_port_only() {
+        let m = FromToMode::HostPort;
+        assert_eq!(m.format(Some("1001"), Some("h:5060")), "h:5060");
+        assert_eq!(
+            m.format(Some("1001"), None),
+            "-",
+            "host mode ignores the user"
+        );
+    }
+
+    #[test]
+    fn from_to_mode_user_only_is_legacy_behavior() {
+        let m = FromToMode::User;
+        assert_eq!(m.format(Some("1001"), Some("h")), "1001");
+        assert_eq!(
+            m.format(None, Some("h")),
+            "-",
+            "user mode shows '-' when no user"
+        );
+    }
+
+    #[test]
+    fn from_to_mode_user_host_combines() {
+        let m = FromToMode::UserHostPort;
+        assert_eq!(m.format(Some("1001"), Some("h:5060")), "1001@h:5060");
+        assert_eq!(m.format(Some("1001"), None), "1001");
+        assert_eq!(m.format(None, Some("h:5060")), "h:5060");
+        assert_eq!(m.format(None, None), "-");
+    }
+
+    #[test]
+    fn from_to_mode_cycle_is_four_states() {
+        let m = FromToMode::default();
+        assert_eq!(m, FromToMode::Default);
+        assert_eq!(m.next(), FromToMode::HostPort);
+        assert_eq!(m.next().next(), FromToMode::User);
+        assert_eq!(m.next().next().next(), FromToMode::UserHostPort);
+        assert_eq!(
+            m.next().next().next().next(),
+            FromToMode::Default,
+            "cycles back to Default"
+        );
+    }
+
+    #[test]
+    fn from_to_mode_parse_roundtrip_and_invalid() {
+        for m in [
+            FromToMode::Default,
+            FromToMode::HostPort,
+            FromToMode::User,
+            FromToMode::UserHostPort,
+        ] {
+            assert_eq!(FromToMode::parse(m.as_config_str()), Some(m));
+        }
+        assert_eq!(FromToMode::parse("bogus"), None);
+        assert_eq!(FromToMode::parse(""), None);
     }
 
     // ── App state setters ───────────────────────────────────────────

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -809,6 +809,9 @@ pub struct App {
     resolver: Arc<NameResolver>,
     /// Path the manual mappings persist to (set from config/CLI).
     names_save_path: Option<PathBuf>,
+    /// When `Some`, `N`-dialog edits are also written into this sipnabrc's
+    /// `[names.manual]` table (opt-in via `[names] persist_to_config`).
+    names_config_path: Option<PathBuf>,
     /// "Name Address" popup state.
     name_dialog: NameDialogState,
     sdp_display_mode: SdpDisplayMode,
@@ -916,6 +919,7 @@ impl App {
             name_mode: NameMode::default(),
             resolver: Arc::new(NameResolver::new()),
             names_save_path: None,
+            names_config_path: None,
             name_dialog: NameDialogState::default(),
             sdp_display_mode: SdpDisplayMode::default(),
             timestamp_mode: TimestampMode::default(),
@@ -1009,6 +1013,9 @@ pub struct NameSetup {
     pub mode: NameMode,
     /// Where the TUI persists manual mappings edited via the `N` dialog.
     pub save_path: Option<PathBuf>,
+    /// When `Some`, `N`-dialog edits are ALSO written into the `[names.manual]`
+    /// table of this sipnabrc (opt-in via `[names] persist_to_config`).
+    pub config_path: Option<PathBuf>,
 }
 
 impl Default for NameSetup {
@@ -1017,6 +1024,7 @@ impl Default for NameSetup {
             resolver: Arc::new(NameResolver::new()),
             mode: NameMode::Off,
             save_path: None,
+            config_path: None,
         }
     }
 }
@@ -1080,6 +1088,7 @@ pub fn run_tui_with_pause(
     app.set_resolver(name_setup.resolver);
     app.set_name_mode(name_setup.mode);
     app.set_names_save_path(name_setup.save_path);
+    app.set_names_config_path(name_setup.config_path);
 
     // Main event loop
     loop {
@@ -1258,6 +1267,12 @@ impl App {
     /// Where to persist manual name mappings when edited in the TUI.
     pub fn set_names_save_path(&mut self, path: Option<PathBuf>) {
         self.names_save_path = path;
+    }
+
+    /// When `Some`, `N`-dialog edits also persist into this sipnabrc's
+    /// `[names.manual]` table.
+    pub fn set_names_config_path(&mut self, path: Option<PathBuf>) {
+        self.names_config_path = path;
     }
 
     /// Count dialogs visible after applying the active filter.

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -103,6 +103,7 @@ pub(super) fn render_app(frame: &mut ratatui::Frame, app: &mut App) {
                         filter: app.active_filter.as_ref(),
                         search_query: &app.search_query,
                         timestamp_mode: app.timestamp_mode,
+                        from_to_mode: app.from_to_mode,
                         theme: &app.theme,
                         resolver: app.resolver.as_ref(),
                         name_mode: app.name_mode,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -321,7 +321,12 @@ pub(super) fn render_app(frame: &mut ratatui::Frame, app: &mut App) {
             }
         }
         View::Help => {
-            help::render_help(frame, main_area, &app.theme, &app.version);
+            // Clamp the scroll to the content height so you can't scroll past
+            // the end (self-corrects an over-eager PgDn on the next frame).
+            let visible = main_area.height.saturating_sub(2) as usize;
+            let max_scroll = help::help_line_count().saturating_sub(visible) as u16;
+            app.help_scroll = app.help_scroll.min(max_scroll);
+            help::render_help(frame, main_area, &app.theme, &app.version, app.help_scroll);
         }
         View::Statistics => {
             render_statistics(frame, main_area, app);

--- a/tests/keybinding_drift_test.rs
+++ b/tests/keybinding_drift_test.rs
@@ -1,0 +1,166 @@
+//! Guard against drift between the keybindings sipnab actually HANDLES and the
+//! in-TUI F1 help (`HELP_TEXT`). The help is the primary discovery surface, so a
+//! handled key that isn't documented there is a real bug.
+//!
+//! This is intentionally a conservative, source-scraping guard (the alternative
+//! — a single keybinding registry driving dispatch + help + this test — is a
+//! larger refactor). It catches the common regression: adding a `KeyCode::Char`
+//! command handler without documenting it. Truly new keys must be either added
+//! to the help or added to `ALLOWED_UNDOCUMENTED` with a reason.
+#![cfg(feature = "tui")]
+
+use std::collections::HashSet;
+
+use crossterm::event::KeyCode;
+use sipnab::tui::Keymap;
+use sipnab::tui::help::HELP_TEXT;
+
+/// Display token for a key as it appears in the help's key column.
+fn token_for(kc: KeyCode) -> String {
+    match kc {
+        KeyCode::Char(c) => c.to_string(),
+        KeyCode::F(n) => format!("F{n}"),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Collect the set of key tokens documented in `HELP_TEXT`.
+///
+/// Binding lines look like `  Esc, q           Quit` — the key column is
+/// everything before the first run of 2+ spaces. Keys are separated by `/` or
+/// `,` (e.g. `↑/↓, j/k`, `F4, x`), so split on those plus whitespace.
+fn documented_tokens() -> HashSet<String> {
+    let mut set = HashSet::new();
+    for line in HELP_TEXT.lines() {
+        let t = line.trim_start();
+        let Some(gap) = t.find("  ") else { continue };
+        let key_part = &t[..gap];
+        // Split on whitespace/comma into chunks, then split each chunk on '/'
+        // (e.g. "↑/↓", "9/0") — but keep a lone "/" (the search key) intact.
+        for chunk in key_part.split([',', ' ', '\t']) {
+            let chunk = chunk.trim();
+            if chunk.is_empty() {
+                continue;
+            }
+            if chunk == "/" {
+                set.insert("/".to_string());
+                continue;
+            }
+            for tok in chunk.split('/') {
+                if !tok.is_empty() {
+                    set.insert(tok.to_string());
+                }
+            }
+        }
+    }
+    set
+}
+
+/// Literal single-character command keys handled in the event dispatcher,
+/// scraped from the source. `KeyCode::Char('x')` matches; the catch-all
+/// `KeyCode::Char(c)` text-entry handlers (no quote) do not.
+fn scraped_char_keys() -> HashSet<char> {
+    let full = include_str!("../src/tui/events.rs");
+    // Only scan production code, not the `#[cfg(test)]` module (whose tests use
+    // arbitrary keys like 'z'/'Q' to assert unknown keys are ignored).
+    let src = full.split("#[cfg(test)]").next().unwrap_or(full);
+    let pat = "KeyCode::Char('";
+    let mut keys = HashSet::new();
+    let mut idx = 0;
+    while let Some(p) = src[idx..].find(pat) {
+        let start = idx + p + pat.len();
+        if let Some(ch) = src[start..].chars().next() {
+            let after = src[start + ch.len_utf8()..].chars().next();
+            if after == Some('\'') {
+                keys.insert(ch);
+            }
+        }
+        idx = start + 1;
+    }
+    keys
+}
+
+/// Char keys that are intentionally NOT documented as their own help line, with
+/// the reason. Navigation/scroll/resize keys are covered by combined lines
+/// (`↑/↓, j/k`, `9/0, +/-`), and a few are aliases or modifier combos.
+fn allowed_undocumented(ch: char) -> Option<&'static str> {
+    match ch {
+        ' ' => Some("documented as 'Space'"),
+        '=' => Some("resize alias of '+', documented as '9/0, +/-'"),
+        'V' => Some("uppercase alias of 'v' (show version)"),
+        'P' => Some("audio playback, documented as 'Shift+P' (audio feature)"),
+        'l' => Some("Ctrl+L, documented as 'Ctrl+L' (clear calls)"),
+        'h' => Some("vi-style left nav alias"),
+        _ => None,
+    }
+}
+
+#[test]
+fn keymap_default_keys_are_documented() {
+    let docs = documented_tokens();
+    let km = Keymap::default();
+    for (action, kc) in [
+        ("quit", km.quit),
+        ("help", km.help),
+        ("save", km.save),
+        ("search", km.search),
+        ("filter", km.filter),
+        ("settings", km.settings),
+        ("pause", km.pause),
+        ("autoscroll", km.autoscroll),
+        ("extended_flow", km.extended_flow),
+        ("clear_calls", km.clear_calls),
+        ("column_selector", km.column_selector),
+    ] {
+        let tok = token_for(kc);
+        assert!(
+            docs.contains(&tok),
+            "keymap action '{action}' (key {tok}) is not documented in the F1 help"
+        );
+    }
+}
+
+#[test]
+fn important_command_keys_are_documented() {
+    let docs = documented_tokens();
+    // Keys the user must be able to discover from F1 (the ones the drift fix
+    // added, plus the long-standing display/command keys).
+    for tok in [
+        "n",       // cycle name resolution
+        "N",       // name selected address (IP -> host/FQDN)
+        "O",       // open pcap
+        "s",       // statistics
+        "u",       // From/To display mode
+        "r",       // raw message / jump to RTP (section-specific)
+        "v",       // version
+        "t",       // timestamps
+        "c",       // colors
+        "d",       // SDP display
+        "Shift+P", // audio playback
+        "Ctrl+L",  // clear calls
+    ] {
+        assert!(
+            docs.contains(tok),
+            "expected key '{tok}' to be documented in the F1 help; have: {docs:?}"
+        );
+    }
+}
+
+#[test]
+fn every_handled_char_key_is_documented_or_allowlisted() {
+    let docs = documented_tokens();
+    let mut undocumented = Vec::new();
+    for ch in scraped_char_keys() {
+        let tok = ch.to_string();
+        if docs.contains(&tok) || allowed_undocumented(ch).is_some() {
+            continue;
+        }
+        undocumented.push(ch);
+    }
+    undocumented.sort_unstable();
+    assert!(
+        undocumented.is_empty(),
+        "these handled KeyCode::Char keys are neither in the F1 help nor allow-listed: {undocumented:?}\n\
+         Document them in src/tui/help.rs HELP_TEXT, or add them to allowed_undocumented() with a reason."
+    );
+}

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__filter_dialog_popup.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__filter_dialog_popup.snap
@@ -12,11 +12,11 @@ expression: output
   If reading│  Destination: [                                   ]  │
   Press 'q' │  Payload:     [                                   ]  │
             │  ──────────────────────────────────────────────────  │
-            │  REGISTER  [ ]             OPTIONS   [ ]             │
-            │  INVITE    [ ]             PUBLISH   [ ]             │
-            │  SUBSCRIBE [ ]             MESSAGE   [ ]             │
-            │  NOTIFY    [ ]             REFER     [ ]             │
-            │  INFO      [ ]             UPDATE    [ ]             │
+            │  REGISTER  [*]             OPTIONS   [*]             │
+            │  INVITE    [*]             PUBLISH   [*]             │
+            │  SUBSCRIBE [*]             MESSAGE   [*]             │
+            │  NOTIFY    [*]             REFER     [*]             │
+            │  INFO      [*]             UPDATE    [*]             │
             │                                                      │
             │     [ Filter ]                 [ Cancel ]            │
             │                                                      │

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__help_view.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__help_view.snap
@@ -5,7 +5,7 @@ expression: output
  Current Mode: Online (any)    Dialogs: 0 (0 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-┌ Help (Esc to close) ─────────────────────────────────────────────────────────┐
+┌ Help (↑/↓ scroll, Esc to close) ─────────────────────────────────────────────┐
 │sipnab — Keyboard Shortcuts                                                   │
 │v0.0.0-test                                                                   │
 │                                                                              │
@@ -26,19 +26,19 @@ expression: output
 │  F1                This help                                                 │
 │  F2                Save capture (PCAP/PCAP-NG/TXT)                           │
 │  F3                Search (same as /)                                        │
-│  F5                Clear calls                                               │
-│  F6                Show raw SIP message                                      │
+│  F5, Ctrl+L        Clear calls                                               │
+│  r, F6             Show raw SIP message                                      │
 │  F7                Filter dialog                                             │
+│  F8                Settings                                                  │
 │  t                 Cycle timestamps (absolute / delta-prev / delta-first)    │
+│  u                 Cycle From/To column (user / host:port / both)            │
+│  n                 Cycle name resolution (off / static / DNS)                │
+│  N                 Name selected address (IP -> host / FQDN)                 │
+│  O                 Open pcap file                                            │
+│  s                 Statistics view                                           │
 │  F9                Clear active filter                                       │
 │  F10               Column selector                                           │
 │  Tab               Switch to RTP Streams                                     │
 │  v                 Show version / git commit                                 │
-│                                                                              │
-│CALL FLOW:                                                                    │
-│  ↑/↓               Navigate messages (detail panel updates)                  │
-│  PgUp/PgDn         Page through messages                                     │
-│  Home/End          First/last message                                        │
-│  Enter             Full-screen raw message                                   │
 └──────────────────────────────────────────────────────────────────────────────┘
 Esc Back

--- a/tests/tui_snapshot_test.rs
+++ b/tests/tui_snapshot_test.rs
@@ -444,10 +444,11 @@ mod tui_snapshots {
     /// list, e.g. a dirty build sitting on a release tag) must not wrap inside
     /// the help box and shove the last keybinding off the bottom. Regression
     /// test for the non-deterministic `help_view` snapshot: the version line is
-    /// truncated to a single row, so every binding stays visible regardless of
-    /// how long the version string is.
+    /// truncated to a single row so it can never wrap and shove the rest of the
+    /// help down. (The help itself is scrollable, so not every binding is on
+    /// screen at once — this asserts the *version line* behavior specifically.)
     #[test]
-    fn help_view_long_version_keeps_all_bindings() {
+    fn help_view_long_version_does_not_wrap() {
         let backend = TestBackend::new(80, 40);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new_test();
@@ -459,20 +460,46 @@ mod tui_snapshots {
         terminal.draw(|frame| app.render(frame)).unwrap();
         let output = buffer_to_string(&terminal);
 
-        // The last keybinding in the help text must survive the long version.
+        // The version line is present (truncated to one row).
         assert!(
-            output.contains("Full-screen raw message"),
-            "long version pushed the last keybinding off the help box:\n{output}"
+            output.contains("v0.4.3 (v0.4.3 a84ac0ca-dirty) features:"),
+            "version line missing from help box:\n{output}"
         );
-        // The wrapped tail of the feature list must not leak onto its own row.
+        // It must NOT wrap: the feature-list tail must not leak onto its own row.
         assert!(
             !output.contains("\u{2502}native,tui"),
             "version line wrapped instead of being truncated:\n{output}"
         );
-        // The version line is still present (truncated with an ellipsis).
+        // Because the version stayed on one row, the first section header is
+        // still visible immediately below it (not pushed off by a wrap).
         assert!(
-            output.contains("v0.4.3 (v0.4.3 a84ac0ca-dirty) features:"),
-            "version line missing from help box:\n{output}"
+            output.contains("CALL LIST:"),
+            "a wrapped version line pushed the help body down:\n{output}"
+        );
+    }
+
+    /// The F1 help exceeds an 80x40 screen, so it must be scrollable: bindings
+    /// in later sections become visible after scrolling down.
+    #[test]
+    fn help_view_scrolls_to_later_sections() {
+        let backend = TestBackend::new(80, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new_test();
+        app.handle_key(crossterm::event::KeyCode::F(1)); // open help
+
+        // At the top, a CALL FLOW-only binding is below the fold.
+        terminal.draw(|frame| app.render(frame)).unwrap();
+        assert!(!buffer_to_string(&terminal).contains("Export Mermaid sequence diagram"));
+
+        // Scroll down a page; the later section comes into view.
+        for _ in 0..40 {
+            app.handle_key(crossterm::event::KeyCode::PageDown);
+        }
+        terminal.draw(|frame| app.render(frame)).unwrap();
+        let scrolled = buffer_to_string(&terminal);
+        assert!(
+            scrolled.contains("Export Mermaid sequence diagram"),
+            "scrolling did not reveal the later help section:\n{scrolled}"
         );
     }
 

--- a/tests/tui_state_test.rs
+++ b/tests/tui_state_test.rs
@@ -360,6 +360,98 @@ mod tui_state {
         assert_eq!(app.visible_dialog_count(), 3);
     }
 
+    // ── SIP method checkbox set/unset scenarios ──────────────────────────
+    // All three fixture dialogs are INVITEs. INVITE is checkbox index 2.
+    const INVITE_IDX: usize = 2;
+
+    #[test]
+    fn filter_default_open_apply_shows_all_messages() {
+        // SIP messages are checked by default → applying with nothing changed
+        // shows every dialog (the reported bug was the opposite).
+        let mut app = app_with_three_dialogs();
+        app.handle_key(KeyCode::F(7));
+        app.handle_key(KeyCode::Enter); // apply with all methods still checked
+        assert_eq!(app.active_popup(), None);
+        assert_eq!(app.visible_dialog_count(), 3);
+    }
+
+    #[test]
+    fn filter_uncheck_all_methods_shows_nothing() {
+        let mut app = app_with_three_dialogs();
+        app.apply_method_filter_for_test([false; 10]);
+        assert_eq!(
+            app.visible_dialog_count(),
+            0,
+            "no methods selected → show nothing"
+        );
+    }
+
+    #[test]
+    fn filter_only_invite_checked_shows_invite_dialogs() {
+        let mut app = app_with_three_dialogs();
+        let mut methods = [false; 10];
+        methods[INVITE_IDX] = true; // only INVITE
+        app.apply_method_filter_for_test(methods);
+        assert_eq!(app.visible_dialog_count(), 3, "all fixtures are INVITE");
+    }
+
+    #[test]
+    fn filter_uncheck_invite_hides_invite_dialogs() {
+        let mut app = app_with_three_dialogs();
+        let mut methods = [true; 10];
+        methods[INVITE_IDX] = false; // everything except INVITE
+        app.apply_method_filter_for_test(methods);
+        assert_eq!(
+            app.visible_dialog_count(),
+            0,
+            "INVITE excluded → none of the fixtures match"
+        );
+    }
+
+    #[test]
+    fn filter_recheck_all_after_unchecking_shows_all_again() {
+        let mut app = app_with_three_dialogs();
+        app.apply_method_filter_for_test([false; 10]);
+        assert_eq!(app.visible_dialog_count(), 0);
+        app.apply_method_filter_for_test([true; 10]);
+        assert_eq!(
+            app.visible_dialog_count(),
+            3,
+            "re-checking all methods shows everything"
+        );
+    }
+
+    #[test]
+    fn filter_space_toggles_method_via_keys() {
+        // Drive the real key path: F7, move focus to the INVITE checkbox, Space
+        // to uncheck it, Enter to apply. With INVITE unchecked the INVITE
+        // fixtures must disappear.
+        let mut app = app_with_three_dialogs();
+        app.handle_key(KeyCode::F(7));
+        // Focus starts on text field 0. Tab advances one element at a time:
+        // 5 text fields then the checkboxes, so 7 Tabs lands on checkbox index 2
+        // (INVITE).
+        for _ in 0..7 {
+            app.handle_key(KeyCode::Tab);
+        }
+        app.handle_key(KeyCode::Char(' ')); // uncheck INVITE
+        app.handle_key(KeyCode::Enter);
+        assert_eq!(
+            app.visible_dialog_count(),
+            0,
+            "unchecking INVITE hid the INVITE dialogs"
+        );
+    }
+
+    #[test]
+    fn filter_f9_clears_method_filter_to_show_all() {
+        let mut app = app_with_three_dialogs();
+        app.apply_method_filter_for_test([false; 10]);
+        assert_eq!(app.visible_dialog_count(), 0);
+        app.handle_key(KeyCode::F(9)); // clear filter
+        assert_eq!(app.visible_dialog_count(), 3, "F9 clear restores show-all");
+    }
+
     // ── Filter dialog checkbox grid navigation ─────────────────────────
 
     #[test]

--- a/website/config.toml
+++ b/website/config.toml
@@ -22,7 +22,7 @@ enabled = true
 theme = "ayu-dark"
 
 [extra]
-version = "0.4.2"
+version = "0.4.4"
 github_url = "https://github.com/NormB/sipnab"
 author = "Norm Brandinger"
 linkedin_url = "https://www.linkedin.com/in/nbrandinger"

--- a/website/content/docs/cli.md
+++ b/website/content/docs/cli.md
@@ -175,6 +175,7 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | `--show-empty` | -- | off | Show messages with empty bodies |
 | `--line-buffer` | -- | off | Flush output after each line (useful for piping) |
 | `--color` | `<WHEN>` | `auto` | Color output mode: `auto`, `always`, `never` |
+| `--from-to-mode` | `<MODE>` | `default` | Default TUI From/To column display: `default` (user else host:port), `host-port`, `user`, `user-host-port`. Cycle at runtime with `u` |
 | `--payload-limit` | `<BYTES>` | -- | Maximum payload bytes to display |
 | `-T`, `--text-dump` | -- | off | Dump raw SIP message text |
 | `--wireshark` | -- | off | Launch Wireshark with a display filter for the current capture |

--- a/website/content/docs/config.md
+++ b/website/content/docs/config.md
@@ -60,6 +60,7 @@ Output and TUI display settings.
 | `color` | string | `"auto"` | Color mode: `"auto"`, `"always"`, `"never"` |
 | `payload_limit` | integer | -- | Maximum payload bytes to display |
 | `delta_time` | boolean | `false` | Show delta time between messages by default |
+| `from_to` | string | `"default"` | From/To column display: `"default"` (user else host:port), `"host-port"`, `"user"`, `"user-host-port"`. Cycle at runtime with `u`; `--from-to-mode` overrides |
 | `visible_columns` | array of strings | all columns | Columns to display in the Call List (persisted across sessions). Values (case-insensitive, must match `COLUMN_LABELS` in `src/tui/call_list.rs`): `"#"`, `"method"`, `"from"`, `"to"`, `"source"`, `"destination"`, `"state"`, `"msgs"`, `"date"`, `"pdd"` |
 
 ```toml

--- a/website/content/docs/keybindings.md
+++ b/website/content/docs/keybindings.md
@@ -233,6 +233,7 @@ Toggle display options without leaving the TUI.
 | i | Clear non-matching dialogs |
 | I | Clear matching dialogs |
 | t | Cycle timestamp mode (absolute / delta-prev / delta-first) |
+| u | Cycle From/To column display (default / host:port / user / user@host:port) |
 | r / F6 | Show raw SIP message for selected dialog |
 | s | Switch to Statistics view |
 | O | Open pcap file (File Open dialog) |
@@ -323,6 +324,7 @@ Toggle display options without leaving the TUI.
 | Down / j | Scroll down |
 | PgUp | Page up |
 | PgDn | Page down |
+| Shift+P | Play / stop the stream's audio (G.711; requires the `audio` build) |
 | Esc | Back to RTP Streams list or Call Flow |
 
 The Stream Detail view shows comprehensive per-stream quality data: MOS score, jitter statistics, quality intervals, burst/gap analysis (RFC 3611), silence detection, and sparkline graphs for MOS and jitter trends over the stream's lifetime.

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -173,7 +173,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,010 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,032 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2010" data-suffix="">2010</span>
+        <span class="arch-stat" data-count="2032" data-suffix="">2032</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -173,7 +173,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 1,858 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,010 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="1998" data-suffix="">1998</span>
+        <span class="arch-stat" data-count="2010" data-suffix="">2010</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -173,7 +173,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,039 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,043 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2039" data-suffix="">2039</span>
+        <span class="arch-stat" data-count="2043" data-suffix="">2043</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -173,7 +173,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,032 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,039 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2032" data-suffix="">2032</span>
+        <span class="arch-stat" data-count="2039" data-suffix="">2039</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Implements four related TUI improvements (serialized commits, TDD throughout) plus a v0.4.4 bump.

## Changes

**Filter dialog fix** (`12e680d`) — SIP method checkboxes now default to **all-checked** (show everything); toggling actually filters. Unchecking all shows nothing (`FilterExpr::never()`); `F9` clear restores show-all. Full set/unset scenario suite + orphan-method behavior made explicit.

**From/To display modes** (`1927e82`) — when a SIP URI has no username the column falls back to host[:port] instead of `-`. Cycle with `u`: default / host:port / user / user@host:port. `extract_uri_host_port` handles IPv6/params/tel. Startup default via `--from-to-mode` (clap `ValueEnum`) or `[display] from_to`. IP-literal hosts are name-resolved like Source/Dest.

**Name-mapping persistence** (`a3e375a`) — `[names] persist_to_config` writes `N`-dialog edits into a `[names.manual]` table via `toml_edit` (preserving comments/other sections); the table is loaded at startup. PCAP-NG NRB embedding already existed — added a write→read round-trip test. (pcapng + per-address UI editing were already present; only sipnabrc persistence is new.)

**Help/docs reconcile + drift guard** (`8ab0ca4`) — the F1 help was missing ~8 handled keys (notably name resolution `n`/`N`, which the user could not discover). Documented every key, added a STREAM DETAIL section (`Shift+P` audio), made the help **scrollable** (it now exceeds 80×40), reconciled `docs/` + the website copies, fixed the `Ctrl+L` doc, and added `tests/keybinding_drift_test.rs` (resolves `Keymap::default()`, scrapes production `events.rs`, fails on any undocumented char key).

**Release** (`842be3f`) — bump to **0.4.4**; CHANGELOG entry; also fixed the stale website version (0.4.2→0.4.4).

Plus a standalone capture-performance research roadmap (`26feffc`, `docs/research/`) from the eBPF investigation — future work, not implemented here.

## Verification
- `cargo test --features full`: 2043 passing (1998 → 2043, +45 across the four items). Homepage `data-count` bumped each commit; the pre-commit gate passed on every commit.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean (full + no-tui).

## Notes
- `docs/` auto-syncs to the Wiki on merge to `main`; `docs/research/capture-performance.md` will publish there too — say the word if you want it kept out of the Wiki.