### PR TITLE
Dynamic auto-grow, capped capture buffer

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -12,6 +12,7 @@ CLI flags always override config file values. Boolean flags default to `off` (fa
 | `-I`, `--input` | `<FILE>` | -- | Read packets from a pcap file instead of live capture |
 | `-O`, `--output` | `<FILE>` | -- | Write captured packets to a pcap file |
 | `-B`, `--buffer` | `<MIB>` | OS default | Kernel capture buffer size in MiB |
+| `--buffer-budget` | `<MIB>` | `64` | Memory budget for the in-flight capture→processing queue. The queue grows under load up to this budget (capped, never OOM) and shrinks when idle; overrides `[capture] buffer_budget_mb` |
 | `--snaplen` | `<BYTES>` | OS default | Snapshot length for packet capture (bytes) |
 | `--portrange` | `<RANGE>` | `5060-5061` | SIP port range to capture |
 | `--multi-device` | -- | off | Capture on all available interfaces |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -34,6 +34,7 @@ Packet capture defaults.
 | `portrange` | string | `"5060-5061"` | SIP port range |
 | `snaplen` | integer | OS default | Snapshot length in bytes |
 | `buffer` | integer | OS default | Kernel capture buffer size in MiB |
+| `buffer_budget_mb` | integer | `64` | Memory budget for the in-flight capture→processing queue. Grows under load up to this budget (capped, never OOM) and shrinks when idle. `--buffer-budget` overrides it |
 | `no_rtp` | boolean | `false` | Disable RTP capture by default |
 
 ```toml
@@ -42,6 +43,7 @@ device = "eth0"
 portrange = "5060-5080"
 snaplen = 65535
 buffer = 16
+buffer_budget_mb = 64
 no_rtp = false
 ```
 

--- a/docs/research/capture-performance.md
+++ b/docs/research/capture-performance.md
@@ -44,8 +44,11 @@ and a large cut in pipeline-induced drops.
 
 - [ ] Raise default kernel buffer 2 MiB → 64 MiB (`--buffer-mb` default in
       `src/capture/mod.rs`); document a 128 MiB recommendation for gigabit media.
-- [ ] Raise the capture→processing channel 10_000 → 100_000 (`src/main.rs:428`),
-      and/or make it configurable.
+- [x] **Done:** the capture→processing channel is now an auto-grow, capped queue
+      (`src/capture/channel.rs`) — unbounded storage (frees segments when idle) +
+      a `bounded(capacity)` semaphore for backpressure. Capacity derives from
+      `[capture] buffer_budget_mb` / `--buffer-budget` (default 64 MiB);
+      `sipnab_capture_queue_depth_packets` / `_backpressure_blocks_total` exported.
 - [ ] Buffer pool to eliminate per-packet `to_vec()` (`live.rs:221`) — recycle
       fixed buffers instead of allocating per packet.
 - [ ] Stronger default auto-BPF filter when none supplied (push more drops into

--- a/src/capture/channel.rs
+++ b/src/capture/channel.rs
@@ -1,0 +1,297 @@
+//! Auto-grow, capped packet channel for the capture → processing pipeline.
+//!
+//! Replaces a fixed `crossbeam_channel::bounded(N)` (which preallocates its ring
+//! and so never shrinks when idle) with a **count-capped semaphore over an
+//! unbounded channel**:
+//!
+//! - storage is [`crossbeam_channel::unbounded`] — its segment list grows under
+//!   load and frees segments as they drain, so idle memory returns to ~0;
+//! - a `bounded::<()>(capacity)` permit pool caps how many packets may be
+//!   in flight at once, providing the same blocking backpressure as a bounded
+//!   channel.
+//!
+//! Crossbeam owns all the blocking, so we inherit correct sender wakeups, prompt
+//! disconnect detection (a dropped [`PacketRx`] makes parked [`PacketTx::send`]
+//! return `Err`, mirroring the old `tx.send(..).is_err()` capture-loop break),
+//! and reasonable fairness — without a hand-rolled `Condvar`. A *count* cap makes
+//! every packet cost exactly one permit, so packet size never matters and there
+//! is no oversized-packet deadlock.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TrySendError, bounded, unbounded};
+
+use super::packet::Packet;
+
+/// Lock-free, cheaply-clonable view of the channel's load, for metrics. Read it
+/// off the hot path (e.g. from the metrics thread); never gated on a lock.
+#[derive(Clone)]
+pub struct CaptureMeter {
+    in_flight: Arc<AtomicUsize>,
+    backpressure_blocks: Arc<AtomicU64>,
+}
+
+impl CaptureMeter {
+    fn new() -> Self {
+        Self {
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            backpressure_blocks: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Packets currently buffered (sent but not yet received).
+    pub fn in_flight(&self) -> usize {
+        self.in_flight.load(Ordering::Relaxed)
+    }
+
+    /// Total times a send had to block because the cap was reached.
+    pub fn backpressure_blocks(&self) -> u64 {
+        self.backpressure_blocks.load(Ordering::Relaxed)
+    }
+}
+
+/// Error returned by [`PacketTx::send`] when the receiver is gone. Zero-sized
+/// (we don't hand the packet back — the channel is dead, so it would be
+/// dropped anyway), which keeps `send`'s `Result` small.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Closed;
+
+/// Sending half. `Clone` (each capture device/thread gets its own handle); all
+/// clones share one permit pool and meter.
+#[derive(Clone)]
+pub struct PacketTx {
+    data_tx: Sender<Packet>,
+    /// "In-flight slots": a `bounded(capacity)` channel used as a semaphore.
+    /// `send` fills a slot (blocks when full = at cap); `recv` frees one.
+    slot_tx: Sender<()>,
+    meter: CaptureMeter,
+}
+
+/// Receiving half (single consumer in both TUI and batch modes).
+pub struct PacketRx {
+    data_rx: Receiver<Packet>,
+    slot_rx: Receiver<()>,
+    meter: CaptureMeter,
+}
+
+/// Create a capped, auto-shrinking packet channel holding at most `capacity`
+/// in-flight packets. Construction is O(1) (no permit pre-fill).
+pub fn packet_channel(capacity: usize) -> (PacketTx, PacketRx) {
+    let capacity = capacity.max(1);
+    let (data_tx, data_rx) = unbounded::<Packet>();
+    // Starts empty; becomes full when `capacity` packets are in flight.
+    let (slot_tx, slot_rx) = bounded::<()>(capacity);
+    let meter = CaptureMeter::new();
+    (
+        PacketTx {
+            data_tx,
+            slot_tx,
+            meter: meter.clone(),
+        },
+        PacketRx {
+            data_rx,
+            slot_rx,
+            meter,
+        },
+    )
+}
+
+impl PacketTx {
+    /// Enqueue a packet, blocking while the cap is reached (backpressure).
+    /// Returns `Err(Closed)` if the receiver has been dropped, so callers can
+    /// break their capture loop exactly as with the old `crossbeam` sender
+    /// (`tx.send(..).is_err()`).
+    pub fn send(&self, packet: Packet) -> Result<(), Closed> {
+        // Claim an in-flight slot (one per packet). Fast path is a non-blocking
+        // try_send; only when the cap is reached do we count a backpressure
+        // block and wait. A dropped receiver drops `slot_rx`, so the wait/try
+        // ends in `Disconnected` and we surface `Err` (capture loop breaks).
+        match self.slot_tx.try_send(()) {
+            Ok(()) => {}
+            Err(TrySendError::Full(())) => {
+                self.meter
+                    .backpressure_blocks
+                    .fetch_add(1, Ordering::Relaxed);
+                if self.slot_tx.send(()).is_err() {
+                    return Err(Closed);
+                }
+            }
+            Err(TrySendError::Disconnected(())) => return Err(Closed),
+        }
+        self.meter.in_flight.fetch_add(1, Ordering::Relaxed);
+        match self.data_tx.send(packet) {
+            Ok(()) => Ok(()),
+            Err(crossbeam_channel::SendError(_)) => {
+                // Receiver gone between claiming the slot and enqueueing.
+                self.meter.in_flight.fetch_sub(1, Ordering::Relaxed);
+                Err(Closed)
+            }
+        }
+    }
+
+    /// A metrics handle for this channel.
+    pub fn meter(&self) -> CaptureMeter {
+        self.meter.clone()
+    }
+}
+
+impl PacketRx {
+    /// Receive a packet, returning its permit to the pool so a blocked sender
+    /// can proceed.
+    pub fn recv_timeout(&self, timeout: Duration) -> Result<Packet, RecvTimeoutError> {
+        let pkt = self.data_rx.recv_timeout(timeout)?;
+        self.meter.in_flight.fetch_sub(1, Ordering::Relaxed);
+        // Free the slot this packet occupied so a blocked sender can proceed.
+        // There is exactly one slot token per in-flight packet, so this never
+        // blocks; ignore the error that arises only if all senders are gone.
+        let _ = self.slot_rx.try_recv();
+        Ok(pkt)
+    }
+
+    /// Drain all immediately-available packets, returning each one's permit.
+    pub fn try_iter(&self) -> impl Iterator<Item = Packet> + '_ {
+        self.data_rx.try_iter().inspect(move |_pkt| {
+            self.meter.in_flight.fetch_sub(1, Ordering::Relaxed);
+            let _ = self.slot_rx.try_recv();
+        })
+    }
+
+    /// A metrics handle for this channel.
+    pub fn meter(&self) -> CaptureMeter {
+        self.meter.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn pkt(size: usize) -> Packet {
+        let ts = chrono::DateTime::from_timestamp(0, 0).unwrap();
+        Packet::new(ts, vec![0u8; size], size, size, None, 1)
+    }
+
+    #[test]
+    fn capacity_blocks_until_a_credit_is_returned() {
+        let (tx, rx) = packet_channel(2);
+        tx.send(pkt(64)).unwrap();
+        tx.send(pkt(64)).unwrap();
+        assert_eq!(tx.meter().in_flight(), 2);
+
+        // Third send must block (cap reached).
+        let tx2 = tx.clone();
+        let h = std::thread::spawn(move || tx2.send(pkt(64)));
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(!h.is_finished(), "send should block at capacity");
+        assert!(tx.meter().backpressure_blocks() >= 1);
+
+        // Receiving one packet returns a credit and unblocks the sender.
+        rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(
+            h.join().unwrap().is_ok(),
+            "send should unblock after a recv"
+        );
+        assert_eq!(tx.meter().in_flight(), 2);
+    }
+
+    #[test]
+    fn drain_restores_the_full_pool() {
+        let (tx, rx) = packet_channel(3);
+        for _ in 0..3 {
+            tx.send(pkt(16)).unwrap();
+        }
+        for _ in 0..3 {
+            rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        }
+        assert_eq!(tx.meter().in_flight(), 0);
+        // Pool fully restored: 3 more sends succeed without blocking.
+        for _ in 0..3 {
+            tx.send(pkt(16)).unwrap();
+        }
+        assert_eq!(tx.meter().in_flight(), 3);
+    }
+
+    #[test]
+    fn dropping_receiver_makes_a_parked_send_return_err() {
+        let (tx, rx) = packet_channel(1);
+        tx.send(pkt(16)).unwrap(); // pool now empty
+        let tx2 = tx.clone();
+        let h = std::thread::spawn(move || tx2.send(pkt(16)));
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(!h.is_finished(), "second send blocks at cap=1");
+        drop(rx); // receiver gone → parked sender must wake with Err
+        assert!(
+            h.join().unwrap().is_err(),
+            "parked send must return Err when the receiver drops"
+        );
+        // A fresh send also errors now.
+        assert!(tx.send(pkt(16)).is_err());
+    }
+
+    #[test]
+    fn dropping_all_senders_disconnects_receiver() {
+        let (tx, rx) = packet_channel(4);
+        drop(tx);
+        assert!(matches!(
+            rx.recv_timeout(Duration::from_millis(50)),
+            Err(RecvTimeoutError::Disconnected)
+        ));
+    }
+
+    #[test]
+    fn cloned_senders_share_one_cap() {
+        let (tx, rx) = packet_channel(3);
+        let tx2 = tx.clone();
+        tx.send(pkt(8)).unwrap();
+        tx2.send(pkt(8)).unwrap();
+        tx.send(pkt(8)).unwrap(); // 3 in flight across both handles
+        let tx3 = tx2.clone();
+        let h = std::thread::spawn(move || tx3.send(pkt(8)));
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(!h.is_finished(), "total in-flight is capped across clones");
+        rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(h.join().unwrap().is_ok());
+    }
+
+    #[test]
+    fn try_iter_drains_and_returns_credits() {
+        let (tx, rx) = packet_channel(5);
+        for _ in 0..5 {
+            tx.send(pkt(8)).unwrap();
+        }
+        let drained: Vec<_> = rx.try_iter().collect();
+        assert_eq!(drained.len(), 5);
+        assert_eq!(tx.meter().in_flight(), 0);
+        // Credits returned → can send a full batch again.
+        for _ in 0..5 {
+            tx.send(pkt(8)).unwrap();
+        }
+    }
+
+    #[test]
+    fn oversized_payload_costs_one_credit() {
+        // A large packet still takes exactly one permit (count cap, not bytes).
+        let (tx, rx) = packet_channel(1);
+        tx.send(pkt(65535)).unwrap();
+        let tx2 = tx.clone();
+        let h = std::thread::spawn(move || tx2.send(pkt(65535)));
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            !h.is_finished(),
+            "cap=1 blocks the second packet regardless of size"
+        );
+        rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(h.join().unwrap().is_ok());
+    }
+
+    #[test]
+    fn zero_capacity_is_clamped_to_one() {
+        let (tx, rx) = packet_channel(0);
+        tx.send(pkt(8)).unwrap(); // cap clamped to >=1, so one send succeeds
+        assert_eq!(tx.meter().in_flight(), 1);
+        rx.recv_timeout(Duration::from_secs(1)).unwrap();
+    }
+}

--- a/src/capture/file.rs
+++ b/src/capture/file.rs
@@ -6,9 +6,9 @@
 
 use std::path::Path;
 
+use super::channel::PacketTx;
 use anyhow::{Context, Result};
 use chrono::{DateTime, TimeZone, Utc};
-use crossbeam_channel::Sender;
 
 use super::CaptureConfig;
 use super::packet::Packet;
@@ -80,7 +80,7 @@ pub fn open_offline(
 pub fn capture_file(
     path: &Path,
     config: &CaptureConfig,
-    tx: Sender<Packet>,
+    tx: PacketTx,
     ready_tx: Option<crossbeam_channel::Sender<Result<(), String>>>,
 ) -> Result<()> {
     // `_gz_guard` owns any decompressed temp file; it must outlive all reads
@@ -207,8 +207,12 @@ fn pcap_ts_to_chrono(ts: libc::timeval) -> DateTime<Utc> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::channel::packet_channel;
     use super::*;
-    use crossbeam_channel::unbounded;
+
+    /// A capacity large enough that `capture_file` (which sends every packet
+    /// before the test drains) never blocks on the cap.
+    const TEST_CAP: usize = 1 << 20;
 
     #[test]
     fn pcap_ts_to_chrono_out_of_range_usec_does_not_panic() {
@@ -249,7 +253,7 @@ mod tests {
 
     /// Read a capture file via `capture_file` and return the packet count.
     fn count_packets(path: &Path) -> usize {
-        let (tx, rx) = unbounded();
+        let (tx, rx) = packet_channel(TEST_CAP);
         capture_file(path, &CaptureConfig::default(), tx, None).unwrap();
         rx.try_iter().count()
     }
@@ -298,7 +302,7 @@ mod tests {
             return;
         }
 
-        let (tx, rx) = unbounded();
+        let (tx, rx) = packet_channel(TEST_CAP);
         let config = CaptureConfig::default();
         capture_file(&path, &config, tx, None).unwrap();
 

--- a/src/capture/hep.rs
+++ b/src/capture/hep.rs
@@ -24,9 +24,9 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, UdpSocket};
 use std::time::{Duration, Instant};
 
+use super::channel::PacketTx;
 use anyhow::{Context, Result, bail, ensure};
 use chrono::{DateTime, TimeZone, Utc};
-use crossbeam_channel::Sender;
 
 use super::CaptureConfig;
 use super::packet::{Packet, PreParsed};
@@ -726,7 +726,7 @@ impl IdleWatch {
 pub fn capture_hep(
     bind_addr: &str,
     config: &CaptureConfig,
-    tx: Sender<Packet>,
+    tx: PacketTx,
     allowlist: &[CidrRange],
     rate_limit: u64,
     ready_tx: Option<crossbeam_channel::Sender<Result<(), String>>>,

--- a/src/capture/live.rs
+++ b/src/capture/live.rs
@@ -5,9 +5,9 @@
 //! the global shutdown flag from [`crate::signals`] and applies optional BPF
 //! filters, packet count limits, and duration limits.
 
+use super::channel::PacketTx;
 use anyhow::{Context, Result};
 use chrono::{DateTime, TimeZone, Utc};
-use crossbeam_channel::Sender;
 
 use super::CaptureConfig;
 use super::packet::Packet;
@@ -99,7 +99,7 @@ fn wait_readable(
 pub fn capture_live(
     device: &str,
     config: &CaptureConfig,
-    tx: Sender<Packet>,
+    tx: PacketTx,
     ready_tx: Option<crossbeam_channel::Sender<Result<(), String>>>,
 ) -> Result<()> {
     // The "any" pseudo-device on Linux does not support promiscuous mode.

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -7,6 +7,7 @@
 
 #[cfg(feature = "native")]
 pub mod atomic;
+#[cfg(feature = "native")]
 pub mod channel;
 #[cfg(feature = "tls")]
 pub mod decrypt;

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -7,6 +7,7 @@
 
 #[cfg(feature = "native")]
 pub mod atomic;
+pub mod channel;
 #[cfg(feature = "tls")]
 pub mod decrypt;
 #[cfg(feature = "native")]
@@ -37,7 +38,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 #[cfg(feature = "native")]
-use crossbeam_channel::Sender;
+use channel::PacketTx;
 #[cfg(feature = "native")]
 use std::thread;
 
@@ -94,6 +95,9 @@ pub struct CaptureConfig {
     pub duration: Option<Duration>,
     /// Replay pcap file with original inter-packet timing.
     pub replay: bool,
+    /// Memory budget (MiB) for the in-flight packet queue between capture and
+    /// processing. Converted to a packet-count cap via [`Self::channel_capacity`].
+    pub buffer_budget_mb: u32,
 }
 
 #[cfg(feature = "native")]
@@ -106,7 +110,29 @@ impl Default for CaptureConfig {
             count: None,
             duration: None,
             replay: false,
+            buffer_budget_mb: 64,
         }
+    }
+}
+
+#[cfg(feature = "native")]
+impl CaptureConfig {
+    /// Assumed average bytes per buffered packet (mixed SIP signaling + small
+    /// RTP) when converting the memory budget to a packet count.
+    const EST_AVG_PACKET_BYTES: usize = 2048;
+    /// Floor so the cap never regresses below the historical fixed default.
+    const MIN_CHANNEL_CAPACITY: usize = 10_000;
+    /// Ceiling so a huge budget can't request an absurd permit pool.
+    const MAX_CHANNEL_CAPACITY: usize = 5_000_000;
+
+    /// Packet-count cap for the capture→processing queue, derived from
+    /// `buffer_budget_mb`. Worst-case memory is `capacity × snaplen`; typical
+    /// memory is far lower (packets are usually 0.2–5 KiB). Clamped to
+    /// `[MIN_CHANNEL_CAPACITY, MAX_CHANNEL_CAPACITY]`.
+    pub fn channel_capacity(&self) -> usize {
+        let budget = (self.buffer_budget_mb as usize).saturating_mul(1024 * 1024);
+        (budget / Self::EST_AVG_PACKET_BYTES)
+            .clamp(Self::MIN_CHANNEL_CAPACITY, Self::MAX_CHANNEL_CAPACITY)
     }
 }
 
@@ -142,7 +168,7 @@ pub struct CaptureHandle {
 pub fn start_capture(
     source: CaptureSource,
     config: CaptureConfig,
-    tx: Sender<Packet>,
+    tx: PacketTx,
     ready_tx: Option<crossbeam_channel::Sender<Result<(), String>>>,
 ) -> Result<CaptureHandle> {
     let source_clone = source.clone();
@@ -206,7 +232,7 @@ pub fn start_capture(
 pub fn start_multi_capture(
     devices: &str,
     config: CaptureConfig,
-    tx: Sender<Packet>,
+    tx: PacketTx,
     ready_tx: Option<crossbeam_channel::Sender<Result<(), String>>>,
 ) -> Result<CaptureHandle> {
     // Parse + validate the selected-interface list up front so a malformed
@@ -492,6 +518,25 @@ mod tests {
         assert!(config.bpf_filter.is_none());
         assert!(config.count.is_none());
         assert!(config.duration.is_none());
+        assert_eq!(config.buffer_budget_mb, 64);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn channel_capacity_derives_from_budget_and_clamps() {
+        let cfg = |mb: u32| CaptureConfig {
+            buffer_budget_mb: mb,
+            ..CaptureConfig::default()
+        };
+        // 64 MiB / 2 KiB = 32768, inside the clamp range.
+        assert_eq!(cfg(64).channel_capacity(), 64 * 1024 * 1024 / 2048);
+        // A tiny budget clamps up to the 10k floor (no regression below today).
+        assert_eq!(cfg(1).channel_capacity(), 10_000);
+        assert_eq!(cfg(0).channel_capacity(), 10_000);
+        // A huge budget clamps to the ceiling.
+        assert_eq!(cfg(1_000_000).channel_capacity(), 5_000_000);
+        // Monotonic in between.
+        assert!(cfg(256).channel_capacity() > cfg(64).channel_capacity());
     }
 
     #[cfg(feature = "native")]
@@ -522,7 +567,7 @@ mod tests {
             return;
         }
 
-        let (pkt_tx, pkt_rx) = crossbeam_channel::unbounded();
+        let (pkt_tx, pkt_rx) = channel::packet_channel(1 << 20);
         let (ready_tx, ready_rx) = crossbeam_channel::bounded::<Result<(), String>>(1);
         let config = CaptureConfig::default();
 
@@ -555,7 +600,7 @@ mod tests {
     fn multi_capture_rejects_malformed_device_spec_before_spawning() {
         // A doubled comma is a validation error: start_multi_capture must
         // return Err immediately, without spawning any capture thread.
-        let (tx, _rx) = crossbeam_channel::unbounded();
+        let (tx, _rx) = channel::packet_channel(1 << 20);
         match start_multi_capture("eth0,,docker0", CaptureConfig::default(), tx, None) {
             Ok(_) => panic!("malformed device spec must be rejected"),
             Err(e) => assert!(e.to_string().contains("empty interface name"), "got: {e}"),
@@ -565,7 +610,7 @@ mod tests {
     #[cfg(feature = "native")]
     #[test]
     fn multi_capture_rejects_empty_device_spec() {
-        let (tx, _rx) = crossbeam_channel::unbounded();
+        let (tx, _rx) = channel::packet_channel(1 << 20);
         assert!(start_multi_capture("   ", CaptureConfig::default(), tx, None).is_err());
         // (Ok(_) is not Debug; .is_err() avoids unwrapping the handle.)
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,6 +114,12 @@ pub struct Cli {
     #[arg(short = 'B', long = "buffer", value_name = "MIB")]
     pub buffer: Option<u32>,
 
+    /// Memory budget in MiB for the in-flight packet queue between capture and
+    /// processing (default 64). The queue grows under load up to this budget and
+    /// shrinks when idle; overrides `[capture] buffer_budget_mb`.
+    #[arg(long = "buffer-budget", value_name = "MIB")]
+    pub buffer_budget: Option<u32>,
+
     /// Snapshot length for packet capture (bytes).
     #[arg(long, value_name = "BYTES")]
     pub snaplen: Option<u32>,
@@ -825,6 +831,26 @@ mod tests {
             cli.names,
             vec!["/etc/hosts".to_string(), "/tmp/names".to_string()]
         );
+    }
+
+    #[test]
+    fn buffer_flags_parse_and_reject_invalid() {
+        // Kernel capture buffer (--buffer / -B).
+        assert_eq!(
+            Cli::parse_from_args(["sipnab", "--buffer", "32"]).buffer,
+            Some(32)
+        );
+        assert_eq!(
+            Cli::parse_from_args(["sipnab", "-B", "16"]).buffer,
+            Some(16)
+        );
+        // In-flight queue memory budget (--buffer-budget).
+        let cli = Cli::parse_from_args(["sipnab", "--buffer-budget", "128"]);
+        assert_eq!(cli.buffer_budget, Some(128));
+        assert_eq!(Cli::parse_from_args(["sipnab"]).buffer_budget, None);
+        // Non-numeric values are rejected by clap.
+        assert!(Cli::try_parse_from(["sipnab", "--buffer-budget", "huge"]).is_err());
+        assert!(Cli::try_parse_from(["sipnab", "--buffer", "huge"]).is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,15 @@ fn known_keys() -> HashMap<&'static str, &'static [&'static str]> {
     );
     m.insert(
         "capture",
-        ["device", "portrange", "snaplen", "buffer", "no_rtp"].as_slice(),
+        [
+            "device",
+            "portrange",
+            "snaplen",
+            "buffer",
+            "buffer_budget_mb",
+            "no_rtp",
+        ]
+        .as_slice(),
     );
     m.insert(
         "display",
@@ -194,6 +202,10 @@ pub struct CaptureConfig {
     pub snaplen: Option<u32>,
     /// Kernel buffer size (MiB).
     pub buffer: Option<u32>,
+    /// Memory budget (MiB) for the in-flight packet queue between capture and
+    /// processing (default 64). Grows under load up to this budget, shrinks when
+    /// idle. `--buffer-budget` overrides this.
+    pub buffer_budget_mb: Option<u32>,
     /// Disable RTP capture by default.
     pub no_rtp: Option<bool>,
 }
@@ -803,6 +815,16 @@ enabled = true
         let config: Config = toml::from_str(toml_str).unwrap();
         let manual = config.names.manual.expect("manual table");
         assert_eq!(manual.get("10.0.0.1").map(String::as_str), Some("sbc"));
+    }
+
+    #[test]
+    fn parse_capture_buffer_budget() {
+        let toml_str = r#"
+[capture]
+buffer_budget_mb = 128
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.capture.buffer_budget_mb, Some(128));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,8 +424,10 @@ fn main() {
         cli.quality_threshold,
     );
 
-    // 14. Create the packet channel
-    let (tx, rx) = crossbeam_channel::bounded(10_000);
+    // 14. Create the packet channel: a capped, auto-shrinking queue. Occupancy
+    //     grows under load up to the cap and the (unbounded) storage frees its
+    //     segments when idle. Capacity is derived from the memory budget.
+    let (tx, rx) = capture::channel::packet_channel(capture_config.channel_capacity());
 
     // 15. Start the capture thread (multi-device aware).
     //     Use a rendezvous channel so the capture thread can signal that the
@@ -837,7 +839,7 @@ fn run_tui_mode(
     config: Config,
     capture_config: CaptureConfig,
     handle: capture::CaptureHandle,
-    rx: crossbeam_channel::Receiver<capture::Packet>,
+    rx: capture::channel::PacketRx,
     policy: CapturePolicy,
     #[cfg(feature = "api")] metrics_bind_addr: Option<std::net::SocketAddr>,
 ) {
@@ -863,6 +865,7 @@ fn run_tui_mode(
             Arc::clone(&dialog_store),
             Arc::clone(&stream_store),
             cli.metrics_auth.clone(),
+            Some(rx.meter()),
         ) {
             Ok(h) => Some(h),
             Err(e) => {
@@ -1100,7 +1103,7 @@ fn run_batch_mode(
     config: &Config,
     capture_config: CaptureConfig,
     handle: capture::CaptureHandle,
-    rx: crossbeam_channel::Receiver<capture::Packet>,
+    rx: capture::channel::PacketRx,
     batch: BatchProcessing,
     policy: CapturePolicy,
 ) {
@@ -2364,6 +2367,12 @@ fn build_capture_config(cli: &Cli, config: &Config) -> CaptureConfig {
 
     let buffer_mb = cli.buffer.or(config.capture.buffer).unwrap_or(2);
 
+    // Memory budget for the in-flight packet queue (capture→processing).
+    let buffer_budget_mb = cli
+        .buffer_budget
+        .or(config.capture.buffer_budget_mb)
+        .unwrap_or(64);
+
     // BPF filter: --bpf-file takes precedence, then positional args
     let bpf_filter = if let Some(ref bpf_file) = cli.bpf_file {
         match std::fs::read_to_string(bpf_file) {
@@ -2399,6 +2408,7 @@ fn build_capture_config(cli: &Cli, config: &Config) -> CaptureConfig {
         count,
         duration,
         replay: cli.replay,
+        buffer_budget_mb,
     }
 }
 

--- a/src/output/prometheus.rs
+++ b/src/output/prometheus.rs
@@ -29,6 +29,10 @@ pub struct PrometheusMetrics {
     pub rtp_streams_total: HashMap<String, u64>,
     /// Total captured packets.
     pub capture_packets_total: u64,
+    /// Packets currently buffered in the capture→processing queue (gauge).
+    pub capture_queue_depth_packets: u64,
+    /// Times a capture send had to block because the queue cap was reached.
+    pub capture_backpressure_blocks_total: u64,
     /// Security alert counts by type (e.g., `"reg_flood"`, `"scanner"`).
     pub security_alerts_total: HashMap<String, u64>,
     /// Post-dial delay observations in seconds for histogram bucketing.
@@ -115,6 +119,32 @@ pub fn format_metrics(metrics: &PrometheusMetrics) -> String {
         out,
         "sipnab_capture_packets_total {}",
         metrics.capture_packets_total
+    );
+    out.push('\n');
+
+    // Capture queue (the dynamic, capped capture→processing buffer)
+    write_help_type(
+        &mut out,
+        "sipnab_capture_queue_depth_packets",
+        "Packets currently buffered between capture and processing",
+        "gauge",
+    );
+    let _ = writeln!(
+        out,
+        "sipnab_capture_queue_depth_packets {}",
+        metrics.capture_queue_depth_packets
+    );
+    out.push('\n');
+    write_help_type(
+        &mut out,
+        "sipnab_capture_backpressure_blocks_total",
+        "Times a capture send blocked because the queue cap was reached",
+        "counter",
+    );
+    let _ = writeln!(
+        out,
+        "sipnab_capture_backpressure_blocks_total {}",
+        metrics.capture_backpressure_blocks_total
     );
     out.push('\n');
 

--- a/src/output/prometheus_server.rs
+++ b/src/output/prometheus_server.rs
@@ -30,6 +30,7 @@ pub fn start_metrics_server(
     dialog_store: Arc<RwLock<DialogStore>>,
     stream_store: Arc<RwLock<StreamStore>>,
     basic_auth: Option<String>,
+    capture_meter: Option<crate::capture::channel::CaptureMeter>,
 ) -> anyhow::Result<std::thread::JoinHandle<()>> {
     let listener = TcpListener::bind(bind_addr)
         .map_err(|e| anyhow::anyhow!("Failed to bind metrics server on {bind_addr}: {e}"))?;
@@ -119,7 +120,8 @@ pub fn start_metrics_server(
                 }
 
                 if path == "/metrics" {
-                    let metrics = collect_metrics(&dialog_store, &stream_store);
+                    let metrics =
+                        collect_metrics(&dialog_store, &stream_store, capture_meter.as_ref());
                     let body = format_metrics(&metrics);
                     let response = format!(
                         "HTTP/1.1 200 OK\r\n\
@@ -223,8 +225,14 @@ fn parse_metrics_addr_inner(addr: &str) -> Result<SocketAddr, String> {
 fn collect_metrics(
     dialog_store: &Arc<RwLock<DialogStore>>,
     stream_store: &Arc<RwLock<StreamStore>>,
+    capture_meter: Option<&crate::capture::channel::CaptureMeter>,
 ) -> PrometheusMetrics {
     let mut metrics = PrometheusMetrics::default();
+
+    if let Some(meter) = capture_meter {
+        metrics.capture_queue_depth_packets = meter.in_flight() as u64;
+        metrics.capture_backpressure_blocks_total = meter.backpressure_blocks();
+    }
 
     // Dialog metrics
     {
@@ -403,6 +411,7 @@ mod tests {
             populated_dialog_store(),
             populated_stream_store(),
             None,
+            None,
         )
         .expect("server should bind");
 
@@ -424,6 +433,7 @@ mod tests {
             Arc::new(RwLock::new(DialogStore::new(10, false))),
             Arc::new(RwLock::new(StreamStore::new(10))),
             None,
+            None,
         )
         .expect("server should bind");
 
@@ -439,6 +449,7 @@ mod tests {
             Arc::new(RwLock::new(DialogStore::new(10, false))),
             Arc::new(RwLock::new(StreamStore::new(10))),
             Some("user:pass".to_string()),
+            None,
         )
         .expect("server should bind");
 
@@ -470,11 +481,34 @@ mod tests {
 
     #[test]
     fn collect_metrics_counts_dialogs_and_active_streams() {
-        let metrics = collect_metrics(&populated_dialog_store(), &populated_stream_store());
+        let metrics = collect_metrics(&populated_dialog_store(), &populated_stream_store(), None);
         // One INVITE dialog was inserted.
         assert!(metrics.messages_total.values().sum::<u64>() >= 1);
         assert!(!metrics.dialogs_total.is_empty());
         // The stream was created with a near-now timestamp, so it counts active.
         assert_eq!(metrics.rtp_streams_active, 1);
+    }
+
+    #[test]
+    fn collect_metrics_reports_capture_queue_depth() {
+        use crate::capture::channel::packet_channel;
+        use crate::capture::packet::Packet;
+
+        let (tx, rx) = packet_channel(8);
+        let ts = chrono::DateTime::from_timestamp(0, 0).unwrap();
+        tx.send(Packet::new(ts, vec![0u8; 32], 32, 32, None, 1))
+            .unwrap();
+        tx.send(Packet::new(ts, vec![0u8; 32], 32, 32, None, 1))
+            .unwrap();
+
+        let m = collect_metrics(
+            &populated_dialog_store(),
+            &populated_stream_store(),
+            Some(&rx.meter()),
+        );
+        assert_eq!(m.capture_queue_depth_packets, 2);
+        // Without a meter the gauge stays at its default 0.
+        let m0 = collect_metrics(&populated_dialog_store(), &populated_stream_store(), None);
+        assert_eq!(m0.capture_queue_depth_packets, 0);
     }
 }

--- a/tests/capture_test.rs
+++ b/tests/capture_test.rs
@@ -7,7 +7,7 @@
 
 use std::path::PathBuf;
 
-use crossbeam_channel::unbounded;
+use sipnab::capture::channel::packet_channel;
 use sipnab::capture::file::capture_file;
 use sipnab::capture::packet::Packet;
 use sipnab::capture::parse::{TransportProto, parse_packet};
@@ -24,7 +24,7 @@ fn fixture_path() -> PathBuf {
 
 /// Collect all packets from a file capture with the given config.
 fn collect_packets(config: CaptureConfig) -> Vec<Packet> {
-    let (tx, rx) = unbounded();
+    let (tx, rx) = packet_channel(1 << 20);
     capture_file(&fixture_path(), &config, tx, None).expect("capture_file should succeed");
     rx.try_iter().collect()
 }
@@ -141,7 +141,7 @@ fn writer_roundtrip() {
     }
 
     // Re-read the written file
-    let (tx, rx) = unbounded();
+    let (tx, rx) = packet_channel(1 << 20);
     capture_file(&output_path, &CaptureConfig::default(), tx, None).expect("re-read");
     let reread: Vec<Packet> = rx.try_iter().collect();
 
@@ -181,7 +181,7 @@ fn writer_with_count_limit() {
     }
 
     // Re-read
-    let (tx, rx) = unbounded();
+    let (tx, rx) = packet_channel(1 << 20);
     capture_file(&output_path, &CaptureConfig::default(), tx, None).expect("re-read");
     let reread: Vec<Packet> = rx.try_iter().collect();
     assert_eq!(
@@ -230,7 +230,7 @@ fn pcap_roundtrip_preserves_linktype_and_magic() {
         "unexpected pcap magic: {magic:02x?}"
     );
 
-    let (tx, rx) = unbounded();
+    let (tx, rx) = packet_channel(1 << 20);
     capture_file(&output_path, &CaptureConfig::default(), tx, None).expect("re-read");
     let reread: Vec<Packet> = rx.try_iter().collect();
     assert_eq!(reread.len(), packets.len(), "count must survive roundtrip");
@@ -269,7 +269,7 @@ fn pcapng_roundtrip_and_magic() {
         "pcapng Section Header Block magic missing"
     );
 
-    let (tx, rx) = unbounded();
+    let (tx, rx) = packet_channel(1 << 20);
     capture_file(&output_path, &CaptureConfig::default(), tx, None).expect("re-read pcapng");
     let reread: Vec<Packet> = rx.try_iter().collect();
     assert_eq!(
@@ -285,7 +285,7 @@ fn pcapng_roundtrip_and_magic() {
 fn start_capture_file_source() {
     use sipnab::capture::{CaptureSource, start_capture};
 
-    let (tx, rx) = unbounded();
+    let (tx, rx) = packet_channel(1 << 20);
     let source = CaptureSource::File {
         path: fixture_path(),
     };

--- a/tests/flag_coverage_test.rs
+++ b/tests/flag_coverage_test.rs
@@ -41,7 +41,6 @@ const KNOWN_UNTESTED: &[&str] = &[
     // ── Root / system services (cannot run in the sandbox) ──────────────────
     "chroot", // requires root to chroot()
     "syslog", // requires a syslog daemon to observe alerts
-    "buffer", // kernel capture-buffer sizing — live capture only
     // ── Standalone servers that need a live source to stay alive ────────────
     "metrics",      // metrics-only process exits after an offline pcap read
     "metrics-auth", // (auth logic is unit-tested in prometheus_server.rs)

--- a/website/content/docs/cli.md
+++ b/website/content/docs/cli.md
@@ -111,6 +111,7 @@ sipnab -N -I capture.pcap --json \
 | `-I`, `--input` | `<FILE>` | -- | Read packets from a pcap file instead of live capture |
 | `-O`, `--output` | `<FILE>` | -- | Write captured packets to a pcap file |
 | `-B`, `--buffer` | `<MIB>` | OS default | Kernel capture buffer size in MiB |
+| `--buffer-budget` | `<MIB>` | `64` | Memory budget for the in-flight capture→processing queue (grows under load up to this, capped; shrinks when idle). Overrides `[capture] buffer_budget_mb` |
 | `--snaplen` | `<BYTES>` | OS default | Snapshot length for packet capture (bytes) |
 | `--portrange` | `<RANGE>` | `5060-5061` | SIP port range to capture |
 | `--multi-device` | -- | off | Capture on all available interfaces |

--- a/website/content/docs/config.md
+++ b/website/content/docs/config.md
@@ -40,6 +40,7 @@ Packet capture defaults.
 | `portrange` | string | `"5060-5061"` | SIP port range |
 | `snaplen` | integer | OS default | Snapshot length in bytes |
 | `buffer` | integer | OS default | Kernel capture buffer size in MiB |
+| `buffer_budget_mb` | integer | `64` | Memory budget for the in-flight capture→processing queue (grows under load up to this, capped; shrinks when idle). `--buffer-budget` overrides |
 | `no_rtp` | boolean | `false` | Disable RTP capture by default |
 
 ```toml

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -173,7 +173,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,043 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,055 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2043" data-suffix="">2043</span>
+        <span class="arch-stat" data-count="2055" data-suffix="">2055</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Makes the capture→processing buffer **dynamic**: it grows under load and shrinks when idle, capped by a memory budget — so highly loaded systems stop dropping packets at the pipeline (the real bottleneck per the capture-performance research) without a rebuild/restart.

## Design (adversarially reviewed)
Replaces the fixed `crossbeam_channel::bounded(10_000)` with a **count-capped semaphore over an unbounded channel** (`src/capture/channel.rs`):
- `unbounded` storage — segments grow under load and are freed as drained, so idle memory returns to ~0 (a `bounded` ring would preallocate and never shrink).
- a `bounded(capacity)` permit pool provides the same blocking backpressure.

A planning-stage adversarial review rejected a hand-rolled `Condvar` byte-budget (missed-wakeup deadlock; parked senders never learning the receiver dropped → shutdown hang; hot-path lock cost). This design lets **crossbeam own all blocking**, so:
- parked senders wake correctly; a dropped `PacketRx` makes `send()` return `Err(Closed)`, mirroring the old `tx.send(..).is_err()` capture-loop break;
- a **count** cap makes packet size irrelevant (no oversized-packet deadlock).

## What changed
- `PacketTx`/`PacketRx`/`packet_channel(cap)` wired through `start_capture`/`start_multi_capture` and the live/file/hep sources; `main.rs` builds the channel from the budget.
- Capacity from a memory budget: `[capture] buffer_budget_mb` + `--buffer-budget` (default **64 MiB**), clamped to `[10_000, 5_000_000]` (never below today’s fixed default).
- Observability: lock-free `CaptureMeter` → `sipnab_capture_queue_depth_packets` (gauge) + `sipnab_capture_backpressure_blocks_total` (counter), snapshotted off the hot path.
- Docs (cli/config + website); roadmap Phase-1 channel item marked done. Also burned `buffer` off the flag-coverage waiver with a real `--buffer` test.

## Verification
- `cargo test --features full`: **2055** passing (2043 → 2055). Channel tests cover cap/block/unblock, **disconnect both directions** (the shutdown-hang the review warned about), multi-sender, `try_iter`, oversized=1-credit, budget→capacity clamp, config/CLI parse, and the metrics gauge.
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check` clean (full + default). Pre-commit gate green on the commit.

## Notes
- Ships as part of the untagged **0.4.4** on `main` (no separate bump).
- The libpcap **kernel** ring is out of scope (can’t resize live; already settable via `[capture] buffer`). `docs/research/capture-performance.md` auto-syncs to the Wiki on merge.