### PR TITLE
Fix: filter dialog's second method column unreachable by arrow keys

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -531,26 +531,39 @@ impl FilterDialogState {
         }
     }
 
-    /// Move checkbox focus down one row (same column).
+    /// Move checkbox focus down one row.
+    ///
+    /// The checkboxes are a 2-column grid (left = even indices, right = odd).
+    /// Down walks a column to its bottom, then continues into the top of the
+    /// next column, then to the buttons — so vertical navigation alone reaches
+    /// every checkbox (the right column was previously unreachable this way).
     fn checkbox_down(&mut self) {
         if let Some(idx) = self.checkbox_index() {
             let next = idx + 2;
             if next < FILTER_METHODS.len() {
+                // Same column, one row down.
                 self.focused_field = FILTER_TEXT_FIELD_COUNT + next;
+            } else if idx % 2 == 0 {
+                // Bottom of the LEFT column -> top of the RIGHT column.
+                self.focused_field = FILTER_TEXT_FIELD_COUNT + 1;
             } else {
-                // Move to buttons row
+                // Bottom of the RIGHT column -> buttons row.
                 self.focused_field = FILTER_BUTTON_IDX;
             }
         }
     }
 
-    /// Move checkbox focus up one row (same column).
+    /// Move checkbox focus up one row (reverse of [`Self::checkbox_down`]).
     fn checkbox_up(&mut self) {
         if let Some(idx) = self.checkbox_index() {
             if idx >= 2 {
+                // Same column, one row up.
                 self.focused_field = FILTER_TEXT_FIELD_COUNT + (idx - 2);
+            } else if idx == 1 {
+                // Top of the RIGHT column -> bottom of the LEFT column.
+                self.focused_field = FILTER_TEXT_FIELD_COUNT + (FILTER_METHODS.len() - 2);
             } else {
-                // Move up to last text field
+                // Top of the LEFT column -> last text field.
                 self.focused_field = FILTER_TEXT_FIELD_COUNT - 1;
                 self.sync_cursor();
             }
@@ -1185,6 +1198,13 @@ impl App {
         apply_filter_dialog(self);
     }
 
+    /// Inspect the filter dialog's focused element and method-checkbox states
+    /// (test helper for navigation/toggle scenarios).
+    #[doc(hidden)]
+    pub fn filter_focus_and_methods_for_test(&self) -> (usize, [bool; 10]) {
+        (self.filter_dialog.focused_field, self.filter_dialog.methods)
+    }
+
     #[doc(hidden)]
     pub fn set_open_dir_for_test(&mut self, dir: PathBuf) {
         self.open_dir = dir;
@@ -1733,15 +1753,31 @@ mod tests {
     }
 
     #[test]
-    fn filter_dialog_checkbox_down_to_buttons() {
+    fn filter_dialog_checkbox_down_traverses_both_columns_then_buttons() {
+        // Down walks the LEFT column to its bottom, then continues into the
+        // RIGHT column, then to the buttons — so the right column is reachable
+        // by vertical navigation.
         let mut st = FilterDialogState {
-            focused_field: FILTER_TEXT_FIELD_COUNT + 8,
+            focused_field: FILTER_TEXT_FIELD_COUNT + 8, // INFO (left col bottom, idx 8)
             ..Default::default()
         };
-        // Last reachable checkbox in a column → down goes to buttons.
-        // index 8 (INFO) -> +2 = 10 (out of range) -> Filter button.
-        st.checkbox_down();
+        st.checkbox_down(); // -> top of RIGHT column (OPTIONS, idx 1)
+        assert_eq!(st.checkbox_index(), Some(1));
+        st.checkbox_down(); // idx 1 -> 3
+        st.checkbox_down(); // 3 -> 5
+        st.checkbox_down(); // 5 -> 7
+        st.checkbox_down(); // 7 -> 9 (UPDATE, right col bottom)
+        assert_eq!(st.checkbox_index(), Some(9));
+        st.checkbox_down(); // bottom of RIGHT column -> buttons
         assert_eq!(st.focused_field(), FILTER_BUTTON_IDX);
+
+        // Up reverses: from OPTIONS (idx 1) back to INFO (idx 8).
+        let mut st = FilterDialogState {
+            focused_field: FILTER_TEXT_FIELD_COUNT + 1,
+            ..Default::default()
+        };
+        st.checkbox_up();
+        assert_eq!(st.checkbox_index(), Some(8));
     }
 
     #[test]

--- a/tests/tui_state_test.rs
+++ b/tests/tui_state_test.rs
@@ -444,6 +444,103 @@ mod tui_state {
     }
 
     #[test]
+    fn filter_right_column_reachable_by_tab_and_toggle() {
+        let mut app = App::new_test();
+        app.handle_key(KeyCode::F(7));
+        // 5 text fields (focus 0..4) then checkbox 0 (focus 5), checkbox 1 (focus 6).
+        for _ in 0..6 {
+            app.handle_key(KeyCode::Tab);
+        }
+        let (focus, _) = app.filter_focus_and_methods_for_test();
+        assert_eq!(
+            focus, 6,
+            "6 Tabs should land on right-column checkbox 1 (OPTIONS)"
+        );
+        app.handle_key(KeyCode::Char(' '));
+        let (_, methods) = app.filter_focus_and_methods_for_test();
+        assert!(
+            !methods[1],
+            "Space should toggle OPTIONS (index 1) off; methods={methods:?}"
+        );
+    }
+
+    #[test]
+    fn filter_right_column_focus_renders_bold() {
+        use ratatui::style::Modifier;
+        let backend = ratatui::backend::TestBackend::new(80, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        let mut app = App::new_test();
+        app.handle_key(KeyCode::F(7));
+        for _ in 0..6 {
+            app.handle_key(KeyCode::Tab); // focus checkbox 1 (OPTIONS, right column)
+        }
+        terminal.draw(|f| app.render(f)).unwrap();
+        // Collect the text of all BOLD cells (the focus highlight is bold+selected).
+        let buf = terminal.backend().buffer();
+        let mut bold = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                let cell = &buf[(x, y)];
+                if cell.modifier.contains(Modifier::BOLD) {
+                    bold.push_str(cell.symbol());
+                }
+            }
+        }
+        assert!(
+            bold.contains("OPTIONS"),
+            "focused right-column checkbox OPTIONS should render bold; bold cells were: {bold:?}"
+        );
+    }
+
+    #[test]
+    fn filter_down_arrow_reaches_second_column() {
+        let mut app = App::new_test();
+        app.handle_key(KeyCode::F(7));
+        // Into the checkbox grid: 5 Tabs -> checkbox 0 (REGISTER, focus 5).
+        for _ in 0..5 {
+            app.handle_key(KeyCode::Tab);
+        }
+        // Down 4 times walks the left column to INFO (idx 8, focus 13).
+        for _ in 0..4 {
+            app.handle_key(KeyCode::Down);
+        }
+        assert_eq!(
+            app.filter_focus_and_methods_for_test().0,
+            5 + 8,
+            "Down reaches INFO (left col bottom)"
+        );
+        // One more Down must enter the SECOND column (OPTIONS, idx 1) rather than
+        // skipping straight to the buttons — otherwise the right column is
+        // unreachable by vertical navigation.
+        app.handle_key(KeyCode::Down);
+        assert_eq!(
+            app.filter_focus_and_methods_for_test().0,
+            5 + 1,
+            "Down from the bottom of column 1 must reach column 2 (OPTIONS)"
+        );
+    }
+
+    #[test]
+    fn filter_right_arrow_reaches_second_column() {
+        let mut app = App::new_test();
+        app.handle_key(KeyCode::F(7));
+        // Tab into the checkbox grid: 5 tabs -> checkbox 0 (REGISTER, focus 5).
+        for _ in 0..5 {
+            app.handle_key(KeyCode::Tab);
+        }
+        assert_eq!(app.filter_focus_and_methods_for_test().0, 5);
+        // Right arrow should move into the second column (checkbox 1, focus 6).
+        app.handle_key(KeyCode::Right);
+        assert_eq!(
+            app.filter_focus_and_methods_for_test().0,
+            6,
+            "Right arrow should move from REGISTER into OPTIONS (second column)"
+        );
+        app.handle_key(KeyCode::Char(' '));
+        assert!(!app.filter_focus_and_methods_for_test().1[1]);
+    }
+
+    #[test]
     fn filter_f9_clears_method_filter_to_show_all() {
         let mut app = app_with_three_dialogs();
         app.apply_method_filter_for_test([false; 10]);
@@ -484,7 +581,16 @@ mod tui_state {
         app.handle_key(KeyCode::Down);
         assert_eq!(app.filter_dialog.focused_field(), 13); // INFO (idx 8)
 
-        // Down from bottom row -> buttons (ff=15)
+        // Down from the bottom of the LEFT column continues into the RIGHT
+        // column (OPTIONS, idx 1, ff=6) so it's reachable by vertical nav.
+        app.handle_key(KeyCode::Down);
+        assert_eq!(app.filter_dialog.focused_field(), 6); // OPTIONS (idx 1)
+        // ...down the right column: PUBLISH(3,8) MESSAGE(5,10) REFER(7,12) UPDATE(9,14)
+        for expected in [8, 10, 12, 14] {
+            app.handle_key(KeyCode::Down);
+            assert_eq!(app.filter_dialog.focused_field(), expected);
+        }
+        // Down from the bottom of the RIGHT column -> buttons (ff=15).
         app.handle_key(KeyCode::Down);
         assert_eq!(app.filter_dialog.focused_field(), 15); // Filter button
     }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -173,7 +173,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,055 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2,059 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2055" data-suffix="">2055</span>
+        <span class="arch-stat" data-count="2059" data-suffix="">2059</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Reported: in the F7 filter dialog, the second column of SIP-method checkboxes (OPTIONS, PUBLISH, MESSAGE, REFER, UPDATE) "cannot be tabbed to or selected/unselected."

## Root cause
The checkboxes are a 2-column grid, but `checkbox_down`/`checkbox_up` moved only **within a column** (`idx ± 2`): pressing Down walked REGISTER→INVITE→SUBSCRIBE→NOTIFY→INFO→buttons and never entered the right column. So a user navigating with the arrow keys could never focus — or therefore toggle — the second column.

## Fix
`Down` now walks the left column to its bottom, **continues into the top of the right column**, then to the buttons; `Up` reverses. `Left`/`Right` still switch columns, and `Tab` still steps through every checkbox individually.

## Investigation note
I verified that `Tab`, `Right`, `Space`, and the focus highlight were **already correct** for the right column (the event loop filters to `KeyEventKind::Press`, popup keys take priority, and the render highlights the focused right-column cell). Those paths are now pinned with regression tests so the column stays reachable/toggleable/visible:
- `filter_right_column_reachable_by_tab_and_toggle`
- `filter_right_column_focus_renders_bold` (inspects cell styles)
- `filter_right_arrow_reaches_second_column`
- `filter_down_arrow_reaches_second_column` (the failing case this PR fixes)

## Verification
`cargo test --features full`: 2059 passing (2055 → 2059). Clippy `-D warnings` + fmt clean; wasm/tls feature combos checked locally.