### PR TITLE
capture: make headless pcapng export self-describing (SNB-0001)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -53,7 +53,7 @@ CLI flags always override config file values. Boolean flags default to `off` (fa
 
 | Flag | Value | Default | Description |
 |------|-------|---------|-------------|
-| `--resolve` | -- | off | Start the TUI with name resolution on (manual mappings + `/etc/hosts`). Press `n` to cycle Off / Static / DNS |
+| `--resolve` | -- | off | Turn name resolution on (manual mappings + `/etc/hosts`). In the TUI, press `n` to cycle Off / Static / DNS; in headless `-O --pcapng` export it embeds a Name Resolution Block |
 | `--reverse-dns` | -- | off | Also use reverse DNS (PTR) lookups. Implies `--resolve`. Emits DNS queries for captured IPs |
 | `--names` | `<FILE>` | -- | Preload IP → name mappings from an `/etc/hosts`-format file. Repeatable |
 
@@ -66,8 +66,12 @@ See the [Name Resolution](keybindings.md#name-resolution) keys for in-TUI naming
 | `--strip-secrets` | `<OUTPUT>` | -- | With `-I <input>`, write a copy of the input pcapng to `<OUTPUT>` with all Decryption Secrets Blocks removed (the `editcap --discard-all-secrets` analog), then exit. The input is never modified; the output is written atomically. |
 
 Note: name mappings are saved into a pcapng Name Resolution Block when saving with
-resolution active, and embedded NRB names / DSB TLS secrets are read back (and
-used for decryption) when a pcapng is opened. See
+resolution active — both the TUI save path and headless `-O --pcapng` export
+(when `--resolve`/`--names` are set). Headless pcapng exports are also
+self-describing: the Section Header Block records the producing application
+(`sipnab <version>`) and OS, and the Interface Description Block records the
+capture source as the interface name. Embedded NRB names / DSB TLS secrets are
+read back (and used for decryption) when a pcapng is opened. See
 [the design doc](design/pcapng-metadata.md).
 
 ## Diagnostic Aliases

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -14,9 +14,13 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use pcap_file::DataLink;
+use pcap_file::Endianness;
 use pcap_file::pcapng::PcapNgWriter as PcapFileNgWriter;
 use pcap_file::pcapng::blocks::enhanced_packet::EnhancedPacketBlock;
-use pcap_file::pcapng::blocks::interface_description::InterfaceDescriptionBlock;
+use pcap_file::pcapng::blocks::interface_description::{
+    InterfaceDescriptionBlock, InterfaceDescriptionOption,
+};
+use pcap_file::pcapng::blocks::section_header::{SectionHeaderBlock, SectionHeaderOption};
 
 use super::packet::Packet;
 use crate::signals;
@@ -95,6 +99,8 @@ pub struct PcapWriter {
     export_mode: PcapExportMode,
     /// Whether a DSB has already been written to the current file.
     dsb_written: bool,
+    /// Capture interface name embedded in pcapng IDBs (carried across rotation).
+    interface_name: Option<String>,
 }
 
 impl PcapWriter {
@@ -126,7 +132,8 @@ impl PcapWriter {
     ///
     /// When `pcapng` is `true`, the output uses PCAP-NG format; otherwise
     /// standard pcap. The `export_mode` controls whether DSB blocks are
-    /// written for TLS key material.
+    /// written for TLS key material. The capture interface is left unrecorded;
+    /// use [`with_interface`](Self::with_interface) to embed it.
     pub fn with_format(
         path: &Path,
         link_type: i32,
@@ -134,6 +141,31 @@ impl PcapWriter {
         max_file_duration: Option<std::time::Duration>,
         pcapng: bool,
         export_mode: PcapExportMode,
+    ) -> Result<Self> {
+        Self::with_interface(
+            path,
+            link_type,
+            max_file_bytes,
+            max_file_duration,
+            pcapng,
+            export_mode,
+            None,
+        )
+    }
+
+    /// As [`with_format`](Self::with_format), but records the capture
+    /// `interface` name in the pcapng Interface Description Block so the export
+    /// is self-describing (SNB-0001). Pass the capture device for live capture
+    /// or the input source for replay; `None` (or empty) records no name.
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_interface(
+        path: &Path,
+        link_type: i32,
+        max_file_bytes: Option<u64>,
+        max_file_duration: Option<std::time::Duration>,
+        pcapng: bool,
+        export_mode: PcapExportMode,
+        interface: Option<&str>,
     ) -> Result<Self> {
         // M5: Warn on path traversal components
         if path
@@ -146,8 +178,10 @@ impl PcapWriter {
             );
         }
 
+        let interface_name = interface.filter(|n| !n.is_empty()).map(|n| n.to_string());
+
         let backend = if pcapng {
-            create_pcapng_backend(path, link_type)?
+            create_pcapng_backend(path, link_type, interface_name.as_deref())?
         } else {
             let linktype = pcap::Linktype(link_type);
             WriterBackend::Pcap(create_savefile(path, linktype)?)
@@ -176,6 +210,7 @@ impl PcapWriter {
             max_file_duration,
             export_mode,
             dsb_written: false,
+            interface_name,
         })
     }
 
@@ -420,7 +455,11 @@ impl PcapWriter {
 
         // Drop the old backend (flushes and closes) by replacing it
         self.backend = if self.use_pcapng {
-            create_pcapng_backend(&new_path, self.link_type_raw)?
+            create_pcapng_backend(
+                &new_path,
+                self.link_type_raw,
+                self.interface_name.as_deref(),
+            )?
         } else {
             let linktype = pcap::Linktype(self.link_type_raw);
             WriterBackend::Pcap(create_savefile(&new_path, linktype)?)
@@ -472,19 +511,53 @@ fn create_savefile(path: &Path, linktype: pcap::Linktype) -> Result<pcap::Savefi
 }
 
 /// Create a PCAP-NG writer backend at the given path.
-fn create_pcapng_backend(path: &Path, link_type: i32) -> Result<WriterBackend> {
+/// Producer string embedded in exported pcapng metadata (SHB UserApplication,
+/// IDB description), e.g. `"sipnab 0.4.4"`.
+fn app_version() -> String {
+    format!("sipnab {}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Create a PCAP-NG backend whose Section Header and Interface Description
+/// blocks carry self-describing metadata (SNB-0001): the producing application
+/// and OS in the SHB, and the OS, a human description, and — when known — the
+/// capture interface name in the IDB. Without this, `tshark` shows
+/// `Interface name: unknown` and `capinfos` reports no application/OS.
+fn create_pcapng_backend(
+    path: &Path,
+    link_type: i32,
+    interface: Option<&str>,
+) -> Result<WriterBackend> {
     let file = std::fs::File::create(path)
         .with_context(|| format!("Failed to create output file '{}'", path.display()))?;
     let buf_writer = BufWriter::new(file);
 
-    let mut writer = PcapFileNgWriter::new(buf_writer)
+    // Section Header Block with producer + OS, so the file is self-describing.
+    let section = SectionHeaderBlock {
+        endianness: Endianness::native(),
+        options: vec![
+            SectionHeaderOption::UserApplication(Cow::Owned(app_version())),
+            SectionHeaderOption::OS(Cow::Borrowed(std::env::consts::OS)),
+        ],
+        ..Default::default()
+    };
+    let mut writer = PcapFileNgWriter::with_section_header(buf_writer, section)
         .map_err(|e| anyhow::anyhow!("Failed to create PCAP-NG writer: {e}"))?;
 
-    // Write the Interface Description Block
+    // Interface Description Block: OS + description always, interface name when
+    // the caller knows it (capture device for live, input source for replay).
+    let mut options = vec![
+        InterfaceDescriptionOption::IfDescription(Cow::Owned(format!("{} capture", app_version()))),
+        InterfaceDescriptionOption::IfOs(Cow::Borrowed(std::env::consts::OS)),
+    ];
+    if let Some(name) = interface.filter(|n| !n.is_empty()) {
+        options.push(InterfaceDescriptionOption::IfName(Cow::Owned(
+            name.to_string(),
+        )));
+    }
     let idb = InterfaceDescriptionBlock {
         linktype: DataLink::from(link_type as u32),
         snaplen: 0xFFFF,
-        options: vec![],
+        options,
     };
     writer
         .write_pcapng_block(idb)
@@ -911,6 +984,151 @@ mod tests {
             }
             assert_eq!(v4_names, vec!["sbc-edge".to_string()]);
             assert_eq!(v6_count, 2, "IPv6 record should carry both names");
+        }
+
+        /// Read back the SHB UserApplication/OS and the first IDB's
+        /// IfName/IfDescription/IfOs options (owned), for metadata assertions.
+        #[allow(clippy::type_complexity)]
+        fn read_export_metadata(
+            path: &Path,
+        ) -> (
+            (Option<String>, Option<String>), // (shb_user_app, shb_os)
+            (Option<String>, Option<String>, Option<String>), // (if_name, if_desc, if_os)
+        ) {
+            use pcap_file::pcapng::PcapNgReader;
+            use pcap_file::pcapng::blocks::interface_description::InterfaceDescriptionOption;
+            use pcap_file::pcapng::blocks::section_header::SectionHeaderOption;
+
+            let bytes = std::fs::read(path).unwrap();
+            let mut reader = PcapNgReader::new(&bytes[..]).unwrap();
+            let (mut app, mut os) = (None, None);
+            // The Section Header Block is parsed in `new()` and exposed here;
+            // `next_block()` yields only the blocks that follow it.
+            for opt in &reader.section().options {
+                match opt {
+                    SectionHeaderOption::UserApplication(s) => app = Some(s.to_string()),
+                    SectionHeaderOption::OS(s) => os = Some(s.to_string()),
+                    _ => {}
+                }
+            }
+            let (mut if_name, mut if_desc, mut if_os) = (None, None, None);
+            while let Some(Ok(block)) = reader.next_block() {
+                if let Some(idb) = block.into_interface_description() {
+                    for opt in &idb.options {
+                        match opt {
+                            InterfaceDescriptionOption::IfName(s) => if_name = Some(s.to_string()),
+                            InterfaceDescriptionOption::IfDescription(s) => {
+                                if_desc = Some(s.to_string())
+                            }
+                            InterfaceDescriptionOption::IfOs(s) => if_os = Some(s.to_string()),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            ((app, os), (if_name, if_desc, if_os))
+        }
+
+        #[test]
+        fn pcapng_export_embeds_app_and_os_metadata() {
+            // SNB-0001: a headless pcapng export must be self-describing — the SHB
+            // carries the producing application + OS, and the IDB an OS + a
+            // human description (so capinfos/tshark show real metadata).
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("meta.pcapng");
+            {
+                let mut w =
+                    PcapWriter::with_format(&path, 1, None, None, true, PcapExportMode::Raw)
+                        .unwrap();
+                w.write(&pkt(0, 40)).unwrap();
+                w.finish().unwrap();
+            }
+            let ((app, os), (_if_name, if_desc, if_os)) = read_export_metadata(&path);
+            let app = app.expect("SHB UserApplication must be set");
+            assert!(app.contains("sipnab"), "app = {app:?}");
+            assert!(
+                app.contains(env!("CARGO_PKG_VERSION")),
+                "app has version: {app:?}"
+            );
+            assert_eq!(os.as_deref(), Some(std::env::consts::OS), "SHB OS");
+            assert_eq!(if_os.as_deref(), Some(std::env::consts::OS), "IDB IfOs");
+            let desc = if_desc.expect("IDB IfDescription must be set");
+            assert!(desc.contains("sipnab"), "desc = {desc:?}");
+        }
+
+        #[test]
+        fn pcapng_export_records_interface_name() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("iface.pcapng");
+            {
+                let mut w = PcapWriter::with_interface(
+                    &path,
+                    1,
+                    None,
+                    None,
+                    true,
+                    PcapExportMode::Raw,
+                    Some("eth0"),
+                )
+                .unwrap();
+                w.write(&pkt(0, 40)).unwrap();
+                w.finish().unwrap();
+            }
+            let (_, (if_name, _, _)) = read_export_metadata(&path);
+            assert_eq!(if_name.as_deref(), Some("eth0"), "IDB IfName");
+        }
+
+        #[test]
+        fn pcapng_export_interface_name_special_chars_round_trip() {
+            // Adversarial: a device/source name with unicode, spaces, a
+            // backslash, and a tab must round-trip verbatim, never truncate.
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("weird.pcapng");
+            let weird = "réseau 0\\1\tπ";
+            {
+                let mut w = PcapWriter::with_interface(
+                    &path,
+                    1,
+                    None,
+                    None,
+                    true,
+                    PcapExportMode::Raw,
+                    Some(weird),
+                )
+                .unwrap();
+                w.write(&pkt(0, 40)).unwrap();
+                w.finish().unwrap();
+            }
+            let (_, (if_name, _, _)) = read_export_metadata(&path);
+            assert_eq!(if_name.as_deref(), Some(weird));
+        }
+
+        #[test]
+        fn pcapng_export_empty_interface_records_no_name() {
+            // Boundary: an empty interface name records no IfName (avoids an
+            // empty, misleading option) but still carries the description/OS.
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("emptyiface.pcapng");
+            {
+                let mut w = PcapWriter::with_interface(
+                    &path,
+                    1,
+                    None,
+                    None,
+                    true,
+                    PcapExportMode::Raw,
+                    Some(""),
+                )
+                .unwrap();
+                w.write(&pkt(0, 40)).unwrap();
+                w.finish().unwrap();
+            }
+            let (_, (if_name, if_desc, _)) = read_export_metadata(&path);
+            assert!(
+                if_name.is_none(),
+                "empty interface → no IfName, got {if_name:?}"
+            );
+            assert!(if_desc.is_some(), "description still present");
         }
 
         #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -748,17 +748,15 @@ fn parse_autostop(s: &str) -> Result<(Option<std::time::Duration>, Option<u64>),
     }
 }
 
-// ── TUI mode ────────────────────────────────────────────────────────
-
-/// Run sipnab in interactive TUI mode.
-///
-/// Wraps stores in `Arc<RwLock>`, spawns a processing thread, and runs
-/// the TUI event loop on the main thread.
-#[cfg(feature = "tui")]
-/// Build the TUI name-resolution setup from CLI flags and config:
-/// construct the resolver (with a reverse-DNS worker when requested), load the
-/// system hosts file plus any operator mapping files, and pick the initial mode.
-fn build_name_setup(cli: &Cli, config: &Config) -> sipnab::tui::NameSetup {
+/// Build a name resolver and the active name mode from CLI flags + config,
+/// usable in any mode (TUI or headless). Loads the system hosts table, any
+/// operator `--names` mapping files, the configured hosts file, and the inline
+/// `[names.manual]` table. The TUI layer ([`build_name_setup`]) adds its own
+/// persistence-file handling on top of this.
+fn build_resolver(
+    cli: &Cli,
+    config: &Config,
+) -> (Arc<sipnab::names::NameResolver>, sipnab::names::NameMode) {
     use sipnab::names::{NameMode, NameResolver};
 
     let cfg = &config.names;
@@ -794,6 +792,31 @@ fn build_name_setup(cli: &Cli, config: &Config) -> sipnab::tui::NameSetup {
             }
         }
     }
+
+    let mode = if reverse {
+        NameMode::Dns
+    } else if resolve {
+        NameMode::Names
+    } else {
+        NameMode::Off
+    };
+    (resolver, mode)
+}
+
+// ── TUI mode ────────────────────────────────────────────────────────
+
+/// Run sipnab in interactive TUI mode.
+///
+/// Wraps stores in `Arc<RwLock>`, spawns a processing thread, and runs
+/// the TUI event loop on the main thread.
+#[cfg(feature = "tui")]
+/// Build the TUI name-resolution setup from CLI flags and config:
+/// construct the resolver (with a reverse-DNS worker when requested), load the
+/// system hosts file plus any operator mapping files, and pick the initial mode.
+fn build_name_setup(cli: &Cli, config: &Config) -> sipnab::tui::NameSetup {
+    let cfg = &config.names;
+    let (resolver, mode) = build_resolver(cli, config);
+
     // Default persistence file for the in-TUI `N` dialog; preload it.
     let save_path = default_names_path();
     if let Some(p) = &save_path {
@@ -806,13 +829,6 @@ fn build_name_setup(cli: &Cli, config: &Config) -> sipnab::tui::NameSetup {
         None
     };
 
-    let mode = if reverse {
-        NameMode::Dns
-    } else if resolve {
-        NameMode::Names
-    } else {
-        NameMode::Off
-    };
     sipnab::tui::NameSetup {
         resolver,
         mode,
@@ -956,13 +972,17 @@ fn run_tui_mode(
                 if writer.is_none()
                     && let Some(ref output_path) = cli_clone.output
                 {
-                    match PcapWriter::with_format(
+                    // Record the capture source as the pcapng interface name
+                    // (SNB-0001): the capture device for live, input for replay.
+                    let capture_source = cli_clone.device.as_deref().or(cli_clone.input.as_deref());
+                    match PcapWriter::with_interface(
                         &PathBuf::from(output_path),
                         packet.link_type,
                         policy.split_bytes,
                         policy.split_duration,
                         cli_clone.pcapng,
                         tui_export_mode,
+                        capture_source,
                     ) {
                         Ok(mut w) => {
                             // Write DSB with keylog content if mode requires it
@@ -1476,13 +1496,17 @@ fn run_batch_mode(
         if writer.is_none()
             && let Some(ref output_path) = cli.output
         {
-            match PcapWriter::with_format(
+            // Record the capture source as the pcapng interface name (SNB-0001):
+            // the capture device for live, the input file for replay.
+            let capture_source = cli.device.as_deref().or(cli.input.as_deref());
+            match PcapWriter::with_interface(
                 &PathBuf::from(output_path),
                 packet.link_type,
                 split_bytes,
                 split_duration,
                 use_pcapng,
                 export_mode,
+                capture_source,
             ) {
                 Ok(mut w) => {
                     // Write DSB with keylog content if mode requires it
@@ -1490,6 +1514,19 @@ fn run_batch_mode(
                         && let Err(e) = w.maybe_write_keylog_dsb(std::path::Path::new(keylog_path))
                     {
                         tracing::warn!("Failed to write DSB: {e}");
+                    }
+                    // Embed a Name Resolution Block when name resolution is active
+                    // (SNB-0001): headless `--names`/`--resolve` should travel with
+                    // the capture, mirroring the TUI save path. Before packets.
+                    if use_pcapng {
+                        let (resolver, mode) = build_resolver(&cli, config);
+                        if mode != sipnab::names::NameMode::Off {
+                            let include_dns = mode == sipnab::names::NameMode::Dns;
+                            let entries = resolver.nrb_entries(include_dns);
+                            if let Err(e) = w.write_name_resolution_block(&entries) {
+                                tracing::warn!("Failed to write name resolution block: {e}");
+                            }
+                        }
                     }
                     writer = Some(w);
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -287,3 +287,59 @@ fn text_dump_shows_raw_sip() {
         "text dump should contain Call-ID header"
     );
 }
+
+// ── Self-describing pcapng export (SNB-0001) ────────────────────────
+
+#[test]
+fn headless_pcapng_export_is_self_describing() {
+    // SNB-0001: a headless `-O --pcapng` export must be self-describing —
+    // carrying a Name Resolution Block when `--names/--resolve` are active, the
+    // capture source as the interface name, and the producing app/OS — so
+    // tshark/capinfos no longer show "unknown"/no application. Pre-fix, none of
+    // these were written by the headless path.
+    let dir = std::env::temp_dir().join(format!("sipnab-snb0001-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let names = dir.join("names.hosts");
+    std::fs::write(&names, "1.2.3.4 sbc-edge.example\n").unwrap();
+    let out = dir.join("export.pcapng");
+    let fixture = sip_call_fixture();
+
+    let (_stdout, stderr, code) = run_sipnab(&[
+        "-N",
+        "-I",
+        fixture.to_str().unwrap(),
+        "-O",
+        out.to_str().unwrap(),
+        "--pcapng",
+        "--names",
+        names.to_str().unwrap(),
+        "--resolve",
+        "-q",
+    ]);
+    assert_eq!(code, 0, "sipnab should exit 0; stderr:\n{stderr}");
+
+    let bytes = std::fs::read(&out).expect("export file should exist");
+    let hay = String::from_utf8_lossy(&bytes);
+
+    // (1) NRB present with sipnab's producer comment + the resolved record.
+    assert!(
+        hay.contains("name resolution added by sipnab"),
+        "NRB producer comment missing from export"
+    );
+    assert!(
+        hay.contains("sbc-edge.example"),
+        "NRB should carry the resolved name record"
+    );
+    // (2) SHB carries the producing application (capinfos "Capture application").
+    assert!(
+        hay.contains(&format!("sipnab {}", env!("CARGO_PKG_VERSION"))),
+        "SHB UserApplication (app+version) missing"
+    );
+    // (3) IDB interface name = capture source (no longer "unknown" in tshark).
+    assert!(
+        hay.contains("sip_call.pcap"),
+        "IDB interface name (input source) missing"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2065" data-suffix="">2065</span>
+        <span class="arch-stat" data-count="2070" data-suffix="">2070</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
## Problem (SNB-0001, surfaced by siptest 0001-options-basic)

A headless `-O --pcapng` export carried no metadata:
- IDB had empty options → `tshark` showed `Interface name: unknown`
- SHB had no producer/OS → `capinfos` showed no application/OS
- **no Name Resolution Block** was written even with `--names`/`--resolve` — the resolver was TUI-only, so headless exports never embedded names.

## Fix

- **writer**: the pcapng backend now writes an SHB with the producing application (`sipnab <version>`) + OS, and an IDB with OS, a description, and — via a new `with_interface` constructor — the capture interface name (stored on the writer so it survives rotation). `with_format` is unchanged (delegates with no interface), so all existing callers and the TUI save path gain the SHB/IDB metadata for free.
- **main**: extract a non-TUI `build_resolver` (shared with `build_name_setup`) and use it in the headless batch path to embed an NRB *before* the packets when name resolution is active; pass the capture source (device for live, input for replay) as the interface name in both export paths.
- **docs**: `cli-reference` documents headless `--resolve`/`--names` NRB export and the self-describing SHB/IDB metadata.

This implements the headless slice of `docs/design/pcapng-metadata.md` §2 (opt-in NRB, `shb_userappl`, no silent write).

## Tests (TDD: red → green)

Writer unit tests: SHB app/OS + IDB description/OS; interface name incl. a **unicode/backslash/tab adversarial round-trip** and an **empty-name boundary**. Plus an end-to-end integration test asserting a headless export carries the NRB record, producer app, and interface name.

Verified: 2070 tests pass · clippy `--all-features --all-targets -Dwarnings` clean · all CI feature combos compile · the original SNB-0001 repro now shows the NRB, a real interface name, and `Capture application: sipnab <version>`.