### PR TITLE
json: flag structurally-malformed SIP messages (SNB-0003)

### DIFF
--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -44,6 +44,13 @@ Responses carry `status_code` and `reason` instead of `method`, plus
 `response_context` (`"<num> <method>"`, what the response answers) — now
 redundant with `cseq` and retained only for backward compatibility.
 
+`malformed` is a list of structural-defect diagnostics, present **only** when a
+message is malformed (a well-formed message omits the field). It surfaces crafted
+or broken input rather than silently accepting it: missing mandatory headers
+(`Call-ID`/`CSeq`/`From`/`To`/`Via`), an unparseable `CSeq`, a `Content-Length`
+larger than the body actually present (truncated/lying length), and control/NUL
+bytes in a header. Example: `"malformed": ["missing mandatory header: Call-ID"]`.
+
 `schema_version` increments on breaking field changes — pin your
 consumers to it.
 

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -48,6 +48,11 @@ struct MessageJson<'a> {
     /// backward compatibility under schema_version 1. Prefer `cseq`.
     #[serde(skip_serializing_if = "Option::is_none")]
     response_context: Option<String>,
+    /// Structural-malformation diagnostics (SNB-0003, spec §5.2): present and
+    /// non-empty only when the message is malformed (missing mandatory header,
+    /// content-length mismatch, control bytes, …). A well-formed message omits it.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    malformed: Vec<String>,
 }
 
 /// JSON representation of a parsed `CSeq` header.
@@ -189,6 +194,7 @@ pub fn message_to_json(msg: &SipMessage) -> String {
         ua: msg.user_agent(),
         cseq,
         response_context,
+        malformed: msg.malformations(),
     };
 
     // serde_json::to_string should not fail on these well-typed fields
@@ -565,6 +571,46 @@ mod tests {
         let parsed = parsed_json(&msg);
         assert_eq!(parsed["cseq"]["number"], 4294967295u32);
         assert_eq!(parsed["cseq"]["method"], "OPTIONS");
+    }
+
+    #[test]
+    fn message_to_json_flags_malformed() {
+        // SNB-0003: a malformed message (missing mandatory Call-ID) carries a
+        // `malformed` diagnostic array naming the defect.
+        let msg = req_with_headers(&[
+            "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1",
+            "From: <sip:a@x>;tag=1",
+            "To: <sip:b@x>",
+            "CSeq: 1 REGISTER",
+            "Content-Length: 0",
+        ]);
+        let parsed = parsed_json(&msg);
+        let m = parsed["malformed"]
+            .as_array()
+            .expect("malformed should be an array");
+        assert!(
+            m.iter()
+                .any(|r| r.as_str().unwrap_or("").contains("Call-ID")),
+            "expected a Call-ID reason, got {m:?}"
+        );
+    }
+
+    #[test]
+    fn message_to_json_well_formed_omits_malformed() {
+        let msg = req_with_headers(&[
+            "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1",
+            "From: <sip:a@x>;tag=1",
+            "To: <sip:b@x>",
+            "Call-ID: clean@x",
+            "CSeq: 1 REGISTER",
+            "Content-Length: 0",
+        ]);
+        let parsed = parsed_json(&msg);
+        assert!(
+            parsed.get("malformed").is_none(),
+            "well-formed message must omit `malformed`, got {:?}",
+            parsed.get("malformed")
+        );
     }
 
     #[test]

--- a/src/sip/message.rs
+++ b/src/sip/message.rs
@@ -150,6 +150,55 @@ impl SipMessage {
             .collect()
     }
 
+    /// Detect structural malformations (SNB-0003, spec §5.2): defects that make
+    /// this a crafted/broken message rather than valid SIP. Returns a list of
+    /// human-readable reasons (empty for a well-formed message). The doctrine is
+    /// "detect & highlight" — surface the anomaly, never silently accept it.
+    ///
+    /// Checks: missing mandatory headers (`Call-ID`/`CSeq`/`From`/`To`/`Via`,
+    /// RFC 3261 §8.1.1/§8.2), an unparseable `CSeq`, a `Content-Length` larger
+    /// than the body actually present (truncated/lying length), and control/NUL
+    /// bytes in a header name or value (injection / parser-abuse). Tab (LWS) is
+    /// allowed; CR/LF cannot survive line parsing.
+    pub fn malformations(&self) -> Vec<String> {
+        let mut reasons = Vec::new();
+
+        for (name, present) in [
+            ("Call-ID", self.header("Call-ID").is_some()),
+            ("CSeq", self.header("CSeq").is_some()),
+            ("From", self.header("From").is_some()),
+            ("To", self.header("To").is_some()),
+            ("Via", !self.via_headers().is_empty()),
+        ] {
+            if !present {
+                reasons.push(format!("missing mandatory header: {name}"));
+            }
+        }
+
+        if self.header("CSeq").is_some() && self.cseq().is_none() {
+            reasons.push("malformed CSeq header (not '<number> <method>')".to_string());
+        }
+
+        if let Some(declared) = self
+            .header("Content-Length")
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            && declared > self.body.len()
+        {
+            reasons.push(format!(
+                "content-length mismatch: declared {declared}, body {} bytes present",
+                self.body.len()
+            ));
+        }
+
+        for h in &self.headers {
+            if has_control_bytes(&h.name) || has_control_bytes(&h.value) {
+                reasons.push(format!("control character in header: {}", h.name));
+            }
+        }
+
+        reasons
+    }
+
     /// Extract the user part from the `From` URI.
     ///
     /// For `From: "Alice" <sip:1001@example.com>;tag=abc` returns `Some("1001")`.
@@ -202,6 +251,13 @@ impl SipMessage {
     pub fn to_display(&self) -> Option<String> {
         extract_display_name(self.to_header()?)
     }
+}
+
+/// True if `s` contains a C0 control byte or DEL — excluding tab (`\t`), which
+/// is legal linear whitespace in a header value. CR/LF never survive line
+/// parsing, so their presence here would also be anomalous.
+fn has_control_bytes(s: &str) -> bool {
+    s.bytes().any(|b| (b < 0x20 && b != b'\t') || b == 0x7f)
 }
 
 /// Extract the user part from a SIP URI inside a header value.
@@ -321,6 +377,169 @@ fn extract_tag(header_value: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── malformation detection (SNB-0003, spec §5.2) ───────────────────
+    fn ts() -> DateTime<Utc> {
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 6, 15, 12, 0, 0).unwrap()
+    }
+
+    fn parse_msg(first: &str, headers: &[&str], body: &[u8]) -> SipMessage {
+        let raw = crate::test_utils::build_sip_message(first, headers, body);
+        let lo = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+        crate::sip::parser::parse_sip(&raw, ts(), lo, lo, 5060, 5060, TransportProto::Udp)
+            .expect("should parse")
+    }
+
+    /// A complete, well-formed OPTIONS request.
+    fn well_formed() -> SipMessage {
+        parse_msg(
+            "OPTIONS sip:a@example.com SIP/2.0",
+            &[
+                "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1",
+                "From: <sip:a@example.com>;tag=1",
+                "To: <sip:b@example.com>",
+                "Call-ID: ok@example.com",
+                "CSeq: 1 OPTIONS",
+                "Content-Length: 0",
+            ],
+            b"",
+        )
+    }
+
+    #[test]
+    fn well_formed_has_no_malformations() {
+        assert!(well_formed().malformations().is_empty());
+    }
+
+    #[test]
+    fn well_formed_invite_with_sdp_no_false_positive() {
+        let sdp = b"v=0\r\no=- 0 0 IN IP4 10.0.0.1\r\ns=-\r\nc=IN IP4 10.0.0.1\r\nt=0 0\r\nm=audio 40000 RTP/AVP 0\r\n";
+        let msg = parse_msg(
+            "INVITE sip:b@example.com SIP/2.0",
+            &[
+                "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK2",
+                "From: <sip:a@example.com>;tag=1",
+                "To: <sip:b@example.com>",
+                "Call-ID: invite@example.com",
+                "CSeq: 1 INVITE",
+                "Content-Type: application/sdp",
+                &format!("Content-Length: {}", sdp.len()),
+            ],
+            sdp,
+        );
+        assert!(
+            msg.malformations().is_empty(),
+            "got {:?}",
+            msg.malformations()
+        );
+    }
+
+    #[test]
+    fn missing_mandatory_headers_flagged() {
+        for drop in ["Call-ID", "CSeq", "From", "To", "Via"] {
+            let hdrs: Vec<&str> = [
+                "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1",
+                "From: <sip:a@example.com>;tag=1",
+                "To: <sip:b@example.com>",
+                "Call-ID: x@example.com",
+                "CSeq: 1 OPTIONS",
+                "Content-Length: 0",
+            ]
+            .into_iter()
+            .filter(|h| !h.starts_with(drop))
+            .collect();
+            let msg = parse_msg("OPTIONS sip:a@example.com SIP/2.0", &hdrs, b"");
+            let m = msg.malformations();
+            assert!(
+                m.iter().any(|r| r.contains(drop)),
+                "dropping {drop} should flag it; got {m:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn lying_content_length_flagged() {
+        // declares 500 bytes, datagram carries none → truncated/lying length.
+        let msg = parse_msg(
+            "OPTIONS sip:a@example.com SIP/2.0",
+            &[
+                "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1",
+                "From: <sip:a@example.com>;tag=1",
+                "To: <sip:b@example.com>",
+                "Call-ID: cl@example.com",
+                "CSeq: 1 OPTIONS",
+                "Content-Length: 500",
+            ],
+            b"",
+        );
+        let m = msg.malformations();
+        assert!(m.iter().any(|r| r.contains("content-length")), "got {m:?}");
+    }
+
+    #[test]
+    fn nul_in_header_value_flagged() {
+        let msg = parse_msg(
+            "OPTIONS sip:a@example.com SIP/2.0",
+            &[
+                "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1",
+                "From: <sip:a@example.com>;tag=1\u{0}BAD",
+                "To: <sip:b@example.com>",
+                "Call-ID: nul@example.com",
+                "CSeq: 1 OPTIONS",
+                "Content-Length: 0",
+            ],
+            b"",
+        );
+        let m = msg.malformations();
+        assert!(
+            m.iter().any(|r| r.to_lowercase().contains("control")),
+            "embedded NUL must be flagged; got {m:?}"
+        );
+    }
+
+    #[test]
+    fn malformed_cseq_flagged() {
+        let msg = parse_msg(
+            "OPTIONS sip:a@example.com SIP/2.0",
+            &[
+                "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1",
+                "From: <sip:a@example.com>;tag=1",
+                "To: <sip:b@example.com>",
+                "Call-ID: badcseq@example.com",
+                "CSeq: not-a-number OPTIONS",
+                "Content-Length: 0",
+            ],
+            b"",
+        );
+        let m = msg.malformations();
+        assert!(
+            m.iter().any(|r| r.to_lowercase().contains("cseq")),
+            "got {m:?}"
+        );
+    }
+
+    #[test]
+    fn tab_in_header_value_is_not_flagged() {
+        // a tab is legal linear whitespace inside a header value (not a control bug)
+        let msg = parse_msg(
+            "OPTIONS sip:a@example.com SIP/2.0",
+            &[
+                "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1",
+                "From: <sip:a@example.com>;tag=1",
+                "To: <sip:b@example.com>",
+                "Call-ID: tab@example.com",
+                "CSeq: 1 OPTIONS",
+                "User-Agent: my\tagent",
+                "Content-Length: 0",
+            ],
+            b"",
+        );
+        assert!(
+            msg.malformations().is_empty(),
+            "tab is LWS, not malformed; got {:?}",
+            msg.malformations()
+        );
+    }
 
     #[test]
     fn extract_user_with_display_name() {

--- a/tests/schemas/message.schema.json
+++ b/tests/schemas/message.schema.json
@@ -40,6 +40,7 @@
         "method": { "type": "string" }
       }
     },
-    "response_context": { "type": "string" }
+    "response_context": { "type": "string" },
+    "malformed": { "type": "array", "items": { "type": "string" } }
   }
 }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2070" data-suffix="">2070</span>
+        <span class="arch-stat" data-count="2079" data-suffix="">2079</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
## Problem (SNB-0003, §5.2)
`--json` silently accepted malformed/crafted SIP — a lying Content-Length, a missing mandatory header, or control/NUL bytes in a header were emitted as if valid, with no diagnostic. A privileged parser of hostile traffic must **detect and highlight** such input, never accept it.

## Fix
- `SipMessage::malformations()` returns structural-defect reasons: missing mandatory headers (Call-ID/CSeq/From/To/Via, RFC 3261 §8.1.1/§8.2), unparseable CSeq, Content-Length larger than the body present (truncated/lying length), control/NUL bytes in a header (tab/LWS allowed).
- `message_to_json` emits a `malformed` array when non-empty; well-formed messages omit it (additive, schema_version stays 1).
- Schema + output-formats.md updated.

## Tests (TDD red→green)
Per-defect unit tests + **no false positives** on a well-formed OPTIONS and an INVITE-with-SDP. Verified end-to-end on the siptest torture corpus (lying-content-length / missing-call-id / embedded-nul all flagged; clean traffic 0 flagged). 2079 tests pass; clippy `--all-features --all-targets -Dwarnings` clean; all feature combos compile.