### PR TITLE
build: bump sipnab-audio crate rust pin to 1.94

### DIFF
--- a/crates/sipnab-audio/Cargo.toml
+++ b/crates/sipnab-audio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sipnab-audio"
 version = "0.4.2"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.94"
 authors = ["Norm Brandinger"]
 description = "sipnab audio playback plugin (rodio/ALSA) — dlopen'd by the sipnab binary"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Follow-up to #88 — the sipnab-audio sub-crate was still pinned to rust-version = "1.92" while the workspace root and Dockerfiles moved to 1.94. Aligns it.