### PR TITLE
dialog: rotate (evict-oldest) by default to bound flood memory (SNB-0004)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -114,8 +114,9 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 
 | Flag | Value | Default | Description |
 |------|-------|---------|-------------|
-| `-l`, `--limit` | `<N>` | `100000` | Maximum number of dialogs to track simultaneously |
-| `-R`, `--rotate` | -- | off | Rotate dialog storage when limit is reached (discard oldest) |
+| `-l`, `--limit` | `<N>` | `100000` | Maximum number of dialogs to track simultaneously (the dialog-state memory bound; lower it for untrusted/high-volume capture) |
+| `-R`, `--rotate` | -- | **on** | Evict the oldest dialog at `--limit` capacity (LRU). On by default; kept for back-compat/explicitness |
+| `--no-rotate` | -- | off | Disable rotation: drop *new* dialogs at capacity instead of evicting the oldest (inverts the safe default) |
 | `--dialog-track` | `<METHOD>` | -- | Dialog tracking method: `call-id` or `branch` |
 | `--no-dialog` | -- | off | Disable dialog tracking entirely (message-only mode) |
 | `--tag` | `<TAG>` | -- | Filter dialogs by tag value |

--- a/docs/fault-model.md
+++ b/docs/fault-model.md
@@ -57,7 +57,7 @@ The #1 memory-DoS surface: an attacker invents unlimited unique Call-IDs
 
 | Store | Cap | Policy | Bound proven by |
 |-------|-----|--------|-----------------|
-| `DialogStore` | `--limit` | `--rotate`: LRU evict; else drop-new at cap | `tests/resource_bounds_test.rs` (50k unique Call-IDs, both modes, `len() ≤ cap` at every step) |
+| `DialogStore` | `--limit` | LRU evict oldest at cap (default); `--no-rotate` → drop-new at cap | `tests/resource_bounds_test.rs` (50k unique Call-IDs, both modes, `len() ≤ cap` at every step) |
 | `StreamStore` | `--max-streams` | always evict oldest | same test (50k unique SSRCs) |
 | per-dialog messages | 500 | drop past cap | `dialog_store.rs` unit tests |
 | per-stream audio frames | 1500 | ring buffer | `stream_store.rs` |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -361,9 +361,16 @@ pub struct Cli {
     )]
     pub limit: u64,
 
-    /// Rotate dialog storage when limit is reached (discard oldest).
-    #[arg(short = 'R', long = "rotate")]
+    /// Evict the oldest dialog when the `--limit` capacity is reached (LRU).
+    /// This is the **default**; the flag is kept for back-compat / explicitness.
+    #[arg(short = 'R', long = "rotate", overrides_with = "no_rotate")]
     pub rotate: bool,
+
+    /// Disable dialog rotation: at `--limit` capacity, drop *new* dialogs instead
+    /// of evicting the oldest. Inverts the safe default (which rotates) — only use
+    /// when you must preserve the earliest dialogs and accept losing newer ones.
+    #[arg(long = "no-rotate", overrides_with = "rotate")]
+    pub no_rotate: bool,
 
     /// Track dialogs using this method (e.g., "call-id", "branch").
     #[arg(long, value_name = "METHOD")]
@@ -700,6 +707,13 @@ impl Cli {
         Cli::parse()
     }
 
+    /// Whether the dialog store evicts the oldest dialog at `--limit` capacity.
+    /// Defaults to `true` (SNB-0004): a privileged sniffer must bound dialog
+    /// state safely without dropping new legitimate calls. `--no-rotate` opts out.
+    pub fn rotate_enabled(&self) -> bool {
+        !self.no_rotate
+    }
+
     /// Parse CLI arguments from an iterator (for testing).
     pub fn parse_from_args<I, T>(args: I) -> Self
     where
@@ -806,6 +820,24 @@ mod tests {
         assert_eq!(cli.color, "auto");
         assert!(!cli.no_tui);
         assert!(!cli.setup_caps);
+        // Dialog rotation is ON by default (SNB-0004): at --limit capacity the
+        // store evicts the oldest dialog rather than dropping new legitimate
+        // calls — a privileged sniffer must bound dialog state safely by default.
+        assert!(cli.rotate_enabled(), "rotate must default ON");
+    }
+
+    #[test]
+    fn rotate_defaults_on_and_negation_works() {
+        // default: rotate on
+        assert!(Cli::parse_from_args(["sipnab"]).rotate_enabled());
+        // explicit --rotate / -R: still on (affirms the default, back-compat)
+        assert!(Cli::parse_from_args(["sipnab", "--rotate"]).rotate_enabled());
+        assert!(Cli::parse_from_args(["sipnab", "-R"]).rotate_enabled());
+        // --no-rotate opts out → drop-new-at-capacity
+        assert!(!Cli::parse_from_args(["sipnab", "--no-rotate"]).rotate_enabled());
+        // last flag wins when both are given
+        assert!(!Cli::parse_from_args(["sipnab", "--rotate", "--no-rotate"]).rotate_enabled());
+        assert!(Cli::parse_from_args(["sipnab", "--no-rotate", "--rotate"]).rotate_enabled());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -863,7 +863,7 @@ fn run_tui_mode(
 
     let dialog_store = Arc::new(RwLock::new(DialogStore::new(
         cli.limit as usize,
-        cli.rotate,
+        cli.rotate_enabled(),
     )));
     let stream_store = {
         let mut ss = StreamStore::new(cli.max_streams as usize);
@@ -1168,7 +1168,7 @@ fn run_batch_mode(
     let mut processor = capture::PacketProcessor::with_max_sessions(cli.max_reassembly as usize);
     let dialog_store: Arc<RwLock<DialogStore>> = Arc::new(RwLock::new(DialogStore::new(
         cli.limit as usize,
-        cli.rotate,
+        cli.rotate_enabled(),
     )));
     let no_rtp = cli.no_rtp || config.capture.no_rtp.unwrap_or(false);
     let stream_store: Arc<RwLock<StreamStore>> = {

--- a/src/sip/dialog_store.rs
+++ b/src/sip/dialog_store.rs
@@ -73,11 +73,13 @@ pub struct DialogStore {
 
 /// A dialog idle longer than this has its stored messages compacted.
 ///
-/// Per-dialog message Vecs are capped in *count* but never shrank: with
-/// the default `rotate=false`, a weeks-long capture accumulates idle
-/// dialogs each pinning up to `MAX_MESSAGES_PER_DIALOG` full messages
-/// (raw bytes + bodies) forever. Ten minutes of silence on a dialog
-/// means the call is over or stale; the message tail is enough context.
+/// Per-dialog message Vecs are capped in *count* but never shrank: a
+/// weeks-long capture accumulates idle dialogs each pinning up to
+/// `MAX_MESSAGES_PER_DIALOG` full messages (raw bytes + bodies) forever.
+/// Ten minutes of silence on a dialog means the call is over or stale; the
+/// message tail is enough context. (Dialog *count* is separately bounded by
+/// the store capacity, which evicts the oldest dialog when `rotate` is on —
+/// the default since SNB-0004.)
 pub const IDLE_COMPACT_AFTER: chrono::TimeDelta = chrono::TimeDelta::minutes(10);
 
 /// How many of the most recent messages an idle dialog keeps.

--- a/tests/cli_defaults_test.rs
+++ b/tests/cli_defaults_test.rs
@@ -378,9 +378,14 @@ fn default_limit() {
 }
 
 #[test]
-fn default_rotate_is_false() {
+fn dialog_rotation_is_enabled_by_default() {
+    // SNB-0004: rotation is ON by default — at --limit capacity the store evicts
+    // the oldest dialog (LRU) rather than dropping new legitimate calls. The bare
+    // `--rotate` flag field stays false-by-absence; the effective policy is via
+    // rotate_enabled() (`--no-rotate` opts out).
     let cli = defaults();
-    assert!(!cli.rotate, "rotate should default to false");
+    assert!(cli.rotate_enabled(), "dialog rotation must default ON");
+    assert!(!cli.no_rotate, "--no-rotate is off by default");
 }
 
 #[test]

--- a/tests/cli_flag_behavior_test.rs
+++ b/tests/cli_flag_behavior_test.rs
@@ -320,40 +320,6 @@ fn after_shows_trailing_context() {
 }
 
 #[test]
-fn rotate_discards_oldest_dialog() {
-    // The RTP fixture has two dialogs (1-1966 then 1-1968). --limit 1 keeps the
-    // FIRST; --limit 1 --rotate discards the oldest and keeps the NEWEST.
-    let rtp = "tests/pcap-samples/sip-rtp-g711.pcap";
-    let no_rotate = run(&[
-        "-N",
-        "-I",
-        rtp,
-        "--limit",
-        "1",
-        "--report",
-        "--no-cli-print",
-    ]);
-    assert!(
-        no_rotate.contains("1-1966@") && !no_rotate.contains("1-1968@"),
-        "--limit 1 (no rotate) keeps the first dialog"
-    );
-    let rotated = run(&[
-        "-N",
-        "-I",
-        rtp,
-        "--limit",
-        "1",
-        "--rotate",
-        "--report",
-        "--no-cli-print",
-    ]);
-    assert!(
-        rotated.contains("1-1968@") && !rotated.contains("1-1966@"),
-        "--rotate keeps the newest dialog and discards the oldest"
-    );
-}
-
-#[test]
 fn tag_labels_dialogs() {
     // --tag applies the given tag to dialogs; it shows in the report Tags column.
     let out = run(&[
@@ -368,5 +334,34 @@ fn tag_labels_dialogs() {
     assert!(
         out.contains("burndown-tag"),
         "--tag value must appear in the report:\n{out}"
+    );
+}
+
+/// SNB-0004: dialog rotation is ON by default. With `--limit` below the call
+/// count and no `--rotate` flag, the store must evict the OLDEST dialog (keep the
+/// newest) — not drop new legitimate calls. `--no-rotate` inverts it. This runs
+/// the real binary end-to-end so a miswired call site (there are two) can't pass
+/// silently. The fixture has two sequential calls: 1-1966 (older) then 1-1968.
+#[test]
+fn dialog_rotation_defaults_on_keep_newest() {
+    let fx = "tests/pcap-samples/sip-rtp-g711.pcap";
+    let default = run(&["-N", "-I", fx, "--limit", "1", "--report", "--no-cli-print"]);
+    assert!(
+        default.contains("1-1968@10.0.2.20") && !default.contains("1-1966@10.0.2.20"),
+        "default rotation must keep the NEWEST call (1-1968), evicting 1-1966:\n{default}"
+    );
+    let no_rotate = run(&[
+        "-N",
+        "-I",
+        fx,
+        "--limit",
+        "1",
+        "--no-rotate",
+        "--report",
+        "--no-cli-print",
+    ]);
+    assert!(
+        no_rotate.contains("1-1966@10.0.2.20") && !no_rotate.contains("1-1968@10.0.2.20"),
+        "--no-rotate must keep the OLDEST call (1-1966), dropping 1-1968:\n{no_rotate}"
     );
 }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2079" data-suffix="">2079</span>
+        <span class="arch-stat" data-count="2080" data-suffix="">2080</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Resolves **SNB-0004** (siptest Ph7 scale tier).

Dialog tracking was capped at `--limit` (default 100000) but `rotate` defaulted **off** → at capacity sipnab dropped *new* dialogs and kept the oldest. Under a Call-ID flood an attacker squats the dialog table with stale entries and legitimate new calls go untracked — an availability gap for a privileged sniffer of hostile traffic (robustness/security rank above performance).

**Fix:** rotation is now the **default** (evict oldest / LRU at `--limit` capacity), so recent activity is always tracked and stale flood entries age out. `--limit` stays the tunable memory bound; `--no-rotate` opts back into drop-new-at-capacity.

Both production `DialogStore` call sites (live + offline) now use `Cli::rotate_enabled()` — fixing only one left the offline path on the old behavior, so an end-to-end test (`cli_flag_behavior_test`) exercises the real binary's default on a two-call fixture to guard both sites.