### PR TITLE
release: v0.4.5 — dialog report Code column + auth-outcome fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-06-22
+
+### Added
+- Dialog report (`--report`) gains a `Code` column showing the terminating SIP
+  response behind each dialog's `State` — `Completed 200`, `Failed 486`,
+  `Cancelled 487` — so the precise outcome (486 busy vs 503 unavailable vs 408
+  timeout …) is visible, not just the generic state word. Backed by a new
+  `SipDialog::final_status_code()` (highest final response on the INVITE CSeq;
+  `-` while the call is still in progress).
+
+### Fixed
+- Auth-challenged calls no longer report the 401/407 challenge as their outcome.
+  An INVITE challenged with 407 (or 401) and then answered now reports `200`
+  (the challenge is an intermediate step); a call that is only ever challenged,
+  with no authenticated retry, still reports the 401/407.
+
 ## [0.4.4] - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,7 +3755,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [package]
 name = "sipnab"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Norm Brandinger"]

--- a/src/output/dialog_report.rs
+++ b/src/output/dialog_report.rs
@@ -23,16 +23,22 @@ pub fn print_dialog_report(dialogs: &[&SipDialog], streams: &[&RtpStream]) -> St
     // ── Dialog summary table ────────────────────────────────────────
     let _ = writeln!(
         out,
-        "{:<32} {:<14} {:<14} {:<12} {:<10} {:<6} {:<8} {:<16}",
-        "Call-ID", "From", "To", "State", "Duration", "Msgs", "PDD", "Tags"
+        "{:<32} {:<14} {:<14} {:<12} {:<6} {:<10} {:<6} {:<8} {:<16}",
+        "Call-ID", "From", "To", "State", "Code", "Duration", "Msgs", "PDD", "Tags"
     );
-    let _ = writeln!(out, "{}", "-".repeat(114));
+    let _ = writeln!(out, "{}", "-".repeat(121));
 
     for dialog in dialogs {
         let call_id = truncate_str(&dialog.call_id, 30);
         let from = dialog.from_user.as_deref().unwrap_or("-");
         let to = dialog.to_user.as_deref().unwrap_or("-");
         let state = state_str(dialog.state());
+        // The precise SIP response behind the State word (486/503/487/200);
+        // "-" while the call is still in progress (no final response yet).
+        let code = dialog
+            .final_status_code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "-".to_string());
         let duration = format_duration(dialog);
         let msg_count = dialog.messages.len();
         let pdd = dialog
@@ -48,8 +54,8 @@ pub fn print_dialog_report(dialogs: &[&SipDialog], streams: &[&RtpStream]) -> St
 
         let _ = writeln!(
             out,
-            "{:<32} {:<14} {:<14} {:<12} {:<10} {:<6} {:<8} {:<16}",
-            call_id, from, to, state, duration, msg_count, pdd, tags
+            "{:<32} {:<14} {:<14} {:<12} {:<6} {:<10} {:<6} {:<8} {:<16}",
+            call_id, from, to, state, code, duration, msg_count, pdd, tags
         );
     }
 
@@ -278,6 +284,190 @@ mod tests {
         assert!(
             report.contains("Msgs"),
             "should contain message count header"
+        );
+    }
+
+    /// Build an INVITE dialog and drive it with the given follow-up messages
+    /// (each: start-line + CSeq), so we can craft Failed/Cancelled outcomes.
+    fn make_dialog(call_id: &str, followups: &[(&str, &str, bool)]) -> SipDialog {
+        let t0 = base_ts();
+        let raw_invite = build_sip(
+            "INVITE sip:1002@example.com SIP/2.0",
+            &[
+                "From: \"Alice\" <sip:1001@example.com>;tag=t1",
+                "To: <sip:1002@example.com>",
+                &format!("Call-ID: {call_id}"),
+                "CSeq: 1 INVITE",
+                "Content-Length: 0",
+            ],
+            b"",
+        );
+        let invite = parse_sip(
+            &raw_invite,
+            t0,
+            localhost(),
+            localhost(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("parse invite");
+        let mut dialog = SipDialog::new(&invite).expect("create dialog");
+
+        for (i, (start, cseq, with_tag)) in followups.iter().enumerate() {
+            let to = if *with_tag {
+                "To: <sip:1002@example.com>;tag=t2"
+            } else {
+                "To: <sip:1002@example.com>"
+            };
+            let raw = build_sip(
+                start,
+                &[
+                    "From: \"Alice\" <sip:1001@example.com>;tag=t1",
+                    to,
+                    &format!("Call-ID: {call_id}"),
+                    cseq,
+                    "Content-Length: 0",
+                ],
+                b"",
+            );
+            let msg = parse_sip(
+                &raw,
+                t0 + TimeDelta::seconds(1 + i as i64),
+                localhost(),
+                localhost(),
+                5060,
+                5060,
+                TransportProto::Udp,
+            )
+            .expect("parse followup");
+            crate::sip::dialog::update_state(&mut dialog, &msg);
+            dialog.messages.push(msg);
+        }
+        dialog
+    }
+
+    #[test]
+    fn report_has_code_column_header() {
+        let dialog = make_completed_dialog();
+        let report = print_dialog_report(&[&dialog], &[]);
+        assert!(
+            report.contains("Code"),
+            "report should have a Code column header: {report}"
+        );
+    }
+
+    #[test]
+    fn completed_dialog_shows_final_code_200() {
+        // A real answered+ended call: INVITE -> 200 (INVITE) -> BYE.
+        let dialog = make_dialog(
+            "done@example.com",
+            &[
+                ("SIP/2.0 200 OK", "CSeq: 1 INVITE", true),
+                ("BYE sip:1002@example.com SIP/2.0", "CSeq: 2 BYE", true),
+            ],
+        );
+        assert_eq!(dialog.state(), &DialogState::Completed);
+        let report = print_dialog_report(&[&dialog], &[]);
+        assert!(
+            report.contains("200"),
+            "completed dialog should show final code 200: {report}"
+        );
+    }
+
+    #[test]
+    fn failed_dialog_shows_response_code() {
+        // INVITE rejected with 486 Busy Here -> State Failed, Code 486.
+        let dialog = make_dialog(
+            "busy@example.com",
+            &[("SIP/2.0 486 Busy Here", "CSeq: 1 INVITE", true)],
+        );
+        let report = print_dialog_report(&[&dialog], &[]);
+        assert!(report.contains("Failed"), "should be Failed: {report}");
+        assert!(
+            report.contains("486"),
+            "failed dialog should show its 486 code, not just 'Failed': {report}"
+        );
+    }
+
+    #[test]
+    fn cancelled_dialog_shows_487() {
+        // INVITE cancelled before answer -> State Cancelled, Code 487.
+        let dialog = make_dialog(
+            "cxl@example.com",
+            &[
+                (
+                    "CANCEL sip:1002@example.com SIP/2.0",
+                    "CSeq: 1 CANCEL",
+                    false,
+                ),
+                ("SIP/2.0 487 Request Terminated", "CSeq: 1 INVITE", true),
+            ],
+        );
+        let report = print_dialog_report(&[&dialog], &[]);
+        assert!(
+            report.contains("Cancelled"),
+            "should be Cancelled: {report}"
+        );
+        assert!(
+            report.contains("487"),
+            "cancelled dialog should show its 487 code: {report}"
+        );
+    }
+
+    #[test]
+    fn auth_challenged_call_reports_final_200_not_407() {
+        // INVITE -> 407 (challenge) -> authed INVITE -> 200 -> BYE. The 407 is an
+        // intermediate auth step; the call's outcome is 200, not 407.
+        let dialog = make_dialog(
+            "auth@example.com",
+            &[
+                (
+                    "SIP/2.0 407 Proxy Authentication Required",
+                    "CSeq: 1 INVITE",
+                    true,
+                ),
+                ("SIP/2.0 200 OK", "CSeq: 2 INVITE", true),
+                ("BYE sip:1002@example.com SIP/2.0", "CSeq: 3 BYE", true),
+            ],
+        );
+        assert_eq!(
+            dialog.final_status_code(),
+            Some(200),
+            "an auth-challenged call that then succeeds reports 200, not the 407 challenge"
+        );
+        let report = print_dialog_report(&[&dialog], &[]);
+        assert!(
+            !report.contains("407"),
+            "report must not surface the intermediate 407 as the outcome: {report}"
+        );
+    }
+
+    #[test]
+    fn unauthenticated_call_still_reports_the_challenge() {
+        // 407 with no authenticated retry: the challenge IS the outcome.
+        let dialog = make_dialog(
+            "noauth@example.com",
+            &[(
+                "SIP/2.0 407 Proxy Authentication Required",
+                "CSeq: 1 INVITE",
+                true,
+            )],
+        );
+        assert_eq!(dialog.final_status_code(), Some(407));
+    }
+
+    #[test]
+    fn in_progress_dialog_has_no_final_code() {
+        // INVITE + 180 Ringing only — no final response yet -> Code "-".
+        let dialog = make_dialog(
+            "ring@example.com",
+            &[("SIP/2.0 180 Ringing", "CSeq: 1 INVITE", true)],
+        );
+        assert_eq!(
+            dialog.final_status_code(),
+            None,
+            "a ringing dialog has no final status code yet"
         );
     }
 

--- a/src/sip/dialog.rs
+++ b/src/sip/dialog.rs
@@ -142,6 +142,41 @@ impl SipDialog {
         &self.state
     }
 
+    /// The final SIP response code of the call's INVITE transaction — the code
+    /// that determined the outcome behind the [`DialogState`] word: 200 for an
+    /// answered call (`InCall`/`Completed`), the 4xx/5xx/6xx for a `Failed` one
+    /// (486 busy vs 503 unavailable vs 404 …), 487 for `Cancelled`. Returns
+    /// `None` while the call is still in progress (no final response yet), so a
+    /// `Ringing`/`Trying` dialog shows no code.
+    ///
+    /// Considers final (`>= 200`) responses carrying a CSeq method of `INVITE`
+    /// (responses to CANCEL/BYE — their own CSeq — are excluded, so a cancelled
+    /// call reports 487, not the 200 that acknowledged its CANCEL). Auth
+    /// challenges (401/407) are *intermediate* — a call challenged then answered
+    /// reports its real outcome (200), not the 407 — so they are ignored unless
+    /// the call was *only* ever challenged (never authenticated), in which case
+    /// the challenge is the outcome.
+    pub fn final_status_code(&self) -> Option<u16> {
+        let invite_finals: Vec<u16> = self
+            .messages
+            .iter()
+            .filter(|m| !m.is_request)
+            .filter(|m| {
+                m.cseq()
+                    .map(|(_, method)| method == "INVITE")
+                    .unwrap_or(false)
+            })
+            .filter_map(|m| m.status_code)
+            .filter(|&code| code >= 200)
+            .collect();
+        invite_finals
+            .iter()
+            .copied()
+            .filter(|&code| code != 401 && code != 407)
+            .max()
+            .or_else(|| invite_finals.iter().copied().max())
+    }
+
     /// Create a new dialog from the first message in a conversation.
     ///
     /// Initializes the dialog state based on the message's method:

--- a/tests/cli/out/report.trycmd
+++ b/tests/cli/out/report.trycmd
@@ -1,7 +1,7 @@
 ```
 $ sipnab -N -I tests/fixtures/sip_call.pcap --report --no-cli-print
-Call-ID                          From           To             State        Duration   Msgs   PDD      Tags            
-------------------------------------------------------------------------------------------------------------------
-test-call-1@10.0.0.1             1001           1002           Completed    1m 0s      7      0.5s     -               
+Call-ID                          From           To             State        Code   Duration   Msgs   PDD      Tags            
+-------------------------------------------------------------------------------------------------------------------------
+test-call-1@10.0.0.1             1001           1002           Completed    200    1m 0s      7      0.5s     -               
 
 ```

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2081" data-suffix="">2081</span>
+        <span class="arch-stat" data-count="2088" data-suffix="">2088</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
## v0.4.5

### Added
- `--report` dialog table gains a **`Code`** column: the terminating SIP response behind each dialog's `State` (`Completed 200`, `Failed 486`, `Cancelled 487`, `-` while in progress), via `SipDialog::final_status_code()`. The precise outcome (486 busy vs 503 unavailable vs 408 timeout) is now visible, not just the generic state word.

### Fixed
- Auth-challenged calls reported the challenge as their outcome. An INVITE challenged with **407/401** then answered now reports **200** (the challenge is intermediate); a call only ever challenged, with no authenticated retry, still reports the 401/407.

### Release
- Version 0.4.4 → 0.4.5; CHANGELOG + homepage test count (2088) updated.
- Unit-tested in `dialog_report.rs` (completed/failed/cancelled/ringing + auth flows) + the `report.trycmd` golden. Found while building cross-checked dialog tests in the siptest harness.