### PR TITLE
fix(capture): frame every SIP message in a coalesced TCP segment (SNB-0008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **TCP: every SIP message in a coalesced segment is now decoded** (SNB-0008).
+  Over TCP, message boundaries are delimited by `Content-Length`, not packet
+  boundaries, so one segment can carry several complete messages. The reassembly
+  consumer previously wrapped each flush as a single message and parsed only the
+  first, silently dropping the rest — the classic sngrep (#466) weakness. The TCP
+  branch of `PacketProcessor::process` now frames the reassembled stream
+  message-by-message (`frame_tcp_sip`: scan to `\r\n\r\n`/`\n\n`, read
+  `Content-Length` incl. compact `l`, `message_end = headers_end + CL`), emitting
+  one packet per complete message. A trailing incomplete message is held as
+  bounded per-stream leftover (`tcp_sip_leftover`) and prepended to the next
+  flush, so a body split across segments completes cleanly instead of being
+  false-flagged malformed; on FIN/RST the held partial is surfaced (truncated)
+  rather than dropped. Framing is gated by `sip::is_sip_message`, so
+  TLS/WebSocket/binary TCP still passes through whole.
+
 ## [0.4.7] - 2026-06-22
 
 ### Fixed

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -359,7 +359,21 @@ pub fn start_multi_capture(
 pub struct PacketProcessor {
     fragment_reassembler: FragmentReassembler,
     tcp_reassembler: TcpReassembler,
+    /// Per-direction leftover bytes of an incomplete trailing SIP message held
+    /// across TCP flushes (SNB-0008). Keyed by (src, dst); bounded by
+    /// `max_sessions`.
+    tcp_sip_leftover:
+        std::collections::HashMap<(std::net::SocketAddr, std::net::SocketAddr), Vec<u8>>,
+    max_sessions: usize,
 }
+
+/// Default reassembly session cap (matches the reassemblers' default).
+const DEFAULT_MAX_SESSIONS: usize = 10_000;
+
+/// Upper bound on a single held partial SIP message (bytes). A larger remainder
+/// is flushed rather than buffered, so a peer can't pin memory with an
+/// unterminated message.
+const MAX_TCP_LEFTOVER: usize = 65_536;
 
 impl PacketProcessor {
     /// Create a new packet processor with default reassembly limits.
@@ -367,6 +381,8 @@ impl PacketProcessor {
         Self {
             fragment_reassembler: FragmentReassembler::new(),
             tcp_reassembler: TcpReassembler::new(),
+            tcp_sip_leftover: std::collections::HashMap::new(),
+            max_sessions: DEFAULT_MAX_SESSIONS,
         }
     }
 
@@ -381,6 +397,8 @@ impl PacketProcessor {
                 max_sessions,
                 std::time::Duration::from_secs(30),
             ),
+            tcp_sip_leftover: std::collections::HashMap::new(),
+            max_sessions,
         }
     }
 
@@ -420,20 +438,80 @@ impl PacketProcessor {
             };
         }
 
-        // TCP: feed into reassembler
+        // TCP: feed into reassembler, then frame the reassembled byte stream
+        // into individual SIP messages (SNB-0008 — one segment can carry many).
         if parsed.transport == parse::TransportProto::Tcp {
             let flushed = self.tcp_reassembler.insert(&parsed);
+            let src = std::net::SocketAddr::new(parsed.src_addr, parsed.src_port);
+            let dst = std::net::SocketAddr::new(parsed.dst_addr, parsed.dst_port);
+            let key = (src, dst);
+            // `false` here means the connection ended on this packet (FIN/RST):
+            // a held partial will never complete, so flush it as a truncated tail.
+            let stream_open = self.tcp_reassembler.contains(src, dst);
+
             if flushed.is_empty() {
+                // Connection ended (FIN/RST) with a partial message still held:
+                // surface it as a truncated tail so it is flagged malformed
+                // downstream rather than silently dropped.
+                if !stream_open
+                    && let Some(rem) = self.tcp_sip_leftover.remove(&key)
+                    && !rem.is_empty()
+                {
+                    let mut p = parsed.clone();
+                    p.payload = bytes::Bytes::from(rem);
+                    return vec![p];
+                }
                 return Vec::new();
             }
-            return flushed
+
+            // Prepend any partial message held from a previous flush.
+            let mut buf = self.tcp_sip_leftover.remove(&key).unwrap_or_default();
+            for chunk in &flushed {
+                buf.extend_from_slice(chunk);
+            }
+
+            // Only SIP-over-TCP is Content-Length framed. TLS, WebSocket, and any
+            // other binary TCP payload must pass through whole (downstream
+            // try_tls_decrypt / websocket unwrap handle them) — framing them as
+            // SIP would swallow them.
+            if !crate::sip::is_sip_message(&buf) {
+                let mut p = parsed.clone();
+                p.payload = bytes::Bytes::from(buf);
+                return vec![p];
+            }
+
+            let (ranges, consumed) = frame_tcp_sip(&buf);
+
+            let mut out: Vec<ParsedPacket> = ranges
                 .into_iter()
-                .map(|payload| {
+                .map(|r| {
                     let mut p = parsed.clone();
-                    p.payload = payload.into();
+                    p.payload = bytes::Bytes::copy_from_slice(&buf[r]);
                     p
                 })
                 .collect();
+
+            let remainder = &buf[consumed..];
+            if !remainder.is_empty() {
+                if stream_open && remainder.len() <= MAX_TCP_LEFTOVER {
+                    // More bytes may arrive — hold the partial for the next flush.
+                    if !self.tcp_sip_leftover.contains_key(&key)
+                        && self.tcp_sip_leftover.len() >= self.max_sessions
+                        && let Some(victim) = self.tcp_sip_leftover.keys().next().copied()
+                    {
+                        self.tcp_sip_leftover.remove(&victim);
+                    }
+                    self.tcp_sip_leftover.insert(key, remainder.to_vec());
+                } else {
+                    // Connection ended (or the partial is oversized): surface the
+                    // truncated tail so a downstream parser can flag it malformed
+                    // rather than silently dropping it.
+                    let mut p = parsed.clone();
+                    p.payload = bytes::Bytes::copy_from_slice(remainder);
+                    out.push(p);
+                }
+            }
+            return out;
         }
 
         // UDP (and other non-TCP, non-fragment): ready immediately
@@ -447,6 +525,10 @@ impl PacketProcessor {
     pub fn sweep(&mut self) {
         self.fragment_reassembler.sweep();
         self.tcp_reassembler.sweep();
+        // Drop held SIP partials whose TCP stream was swept (timed out without a
+        // FIN), so an idle half-message can't leak.
+        self.tcp_sip_leftover
+            .retain(|(src, dst), _| self.tcp_reassembler.contains(*src, *dst));
     }
 }
 
@@ -454,6 +536,76 @@ impl Default for PacketProcessor {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Frame a reassembled TCP byte stream into individual SIP messages.
+///
+/// Over TCP, SIP message boundaries are delimited by `Content-Length`, not by
+/// packet boundaries — a single TCP segment can carry several complete messages
+/// (and a flush can end mid-message). This walks `data` message by message:
+/// for each, it finds the end of headers (`\r\n\r\n`, or `\n\n`), reads
+/// `Content-Length` (absent ⇒ 0; compact form `l` honored), and the message
+/// spans up to `header_end + content_length`. The body is taken verbatim by
+/// length, so a blank line *inside* a body never splits a message.
+///
+/// Returns the byte ranges of the complete messages plus `consumed` — the index
+/// where the first incomplete (held-back) message begins. `data[consumed..]`
+/// should be retained and prepended to the next flush of the same stream.
+fn frame_tcp_sip(data: &[u8]) -> (Vec<std::ops::Range<usize>>, usize) {
+    let mut ranges = Vec::new();
+    let mut pos = 0;
+    while pos < data.len() {
+        let rest = &data[pos..];
+        let Some(body_start) = find_header_end(rest) else {
+            break; // headers not yet complete — hold the remainder
+        };
+        let content_length = parse_content_length(&rest[..body_start]);
+        let msg_end = match body_start.checked_add(content_length) {
+            Some(e) => e,
+            None => break, // absurd Content-Length overflow — hold
+        };
+        if rest.len() < msg_end {
+            break; // body not fully arrived — hold the remainder
+        }
+        ranges.push(pos..pos + msg_end);
+        pos += msg_end;
+    }
+    (ranges, pos)
+}
+
+/// Find the end of the SIP header section, returning the index just past the
+/// blank-line separator (i.e. where the body starts). Accepts CRLFCRLF and the
+/// lenient LFLF form. `None` if no complete header terminator is present yet.
+fn find_header_end(data: &[u8]) -> Option<usize> {
+    let crlf = data
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|i| i + 4);
+    let lf = data.windows(2).position(|w| w == b"\n\n").map(|i| i + 2);
+    match (crlf, lf) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+/// Parse `Content-Length` (or its compact form `l`) from a SIP header block.
+/// Returns 0 when absent or unparseable (the framer then treats the message as
+/// bodyless; a downstream parser still flags any real mismatch).
+fn parse_content_length(headers: &[u8]) -> usize {
+    for line in headers.split(|&b| b == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let Some(colon) = line.iter().position(|&b| b == b':') else {
+            continue;
+        };
+        let name = std::str::from_utf8(&line[..colon]).unwrap_or("").trim();
+        if name.eq_ignore_ascii_case("content-length") || name.eq_ignore_ascii_case("l") {
+            let val = std::str::from_utf8(&line[colon + 1..]).unwrap_or("").trim();
+            return val.parse::<usize>().unwrap_or(0);
+        }
+    }
+    0
 }
 
 /// Parse a duration string like "30s", "5m", "1h" into a [`Duration`].
@@ -508,6 +660,268 @@ mod tests {
         assert!(parse_duration("").is_err());
         assert!(parse_duration("abc").is_err());
         assert!(parse_duration("5x").is_err());
+    }
+
+    // ── TCP SIP framing (SNB-0008) ──────────────────────────────────
+    // Over TCP one segment may carry several SIP messages; the framer must
+    // split them all (not just the first), hold an incomplete tail, and never
+    // split on a blank line inside a body.
+
+    fn opts(cid: &str) -> Vec<u8> {
+        format!(
+            "OPTIONS sip:h SIP/2.0\r\nVia: SIP/2.0/TCP h;branch={cid}\r\n\
+             Call-ID: {cid}\r\nCSeq: 1 OPTIONS\r\nContent-Length: 0\r\n\r\n"
+        )
+        .into_bytes()
+    }
+
+    fn frame_strs(data: &[u8]) -> (Vec<String>, usize) {
+        let (ranges, consumed) = frame_tcp_sip(data);
+        (
+            ranges
+                .iter()
+                .map(|r| String::from_utf8_lossy(&data[r.clone()]).into_owned())
+                .collect(),
+            consumed,
+        )
+    }
+
+    #[test]
+    fn frame_three_complete_messages_in_one_buffer() {
+        let mut buf = opts("a");
+        buf.extend(opts("b"));
+        buf.extend(opts("c"));
+        let total = buf.len();
+        let (msgs, consumed) = frame_strs(&buf);
+        assert_eq!(msgs.len(), 3, "all three messages must be framed");
+        assert!(msgs[0].contains("Call-ID: a"));
+        assert!(msgs[1].contains("Call-ID: b"));
+        assert!(msgs[2].contains("Call-ID: c"));
+        assert_eq!(consumed, total, "fully consumed, nothing held");
+    }
+
+    #[test]
+    fn frame_holds_incomplete_trailing_headers() {
+        let mut buf = opts("a");
+        buf.extend(opts("b"));
+        let consumed_expected = buf.len();
+        buf.extend_from_slice(b"OPTIONS sip:h SIP/2.0\r\nCall-ID: partial\r\n"); // no \r\n\r\n
+        let (msgs, consumed) = frame_strs(&buf);
+        assert_eq!(msgs.len(), 2, "two complete; the partial third is held");
+        assert_eq!(consumed, consumed_expected, "held bytes start after msg 2");
+    }
+
+    #[test]
+    fn frame_holds_message_with_unfinished_body() {
+        // Headers complete, Content-Length declares 10 but no body bytes yet.
+        let mut buf = opts("a");
+        let after_a = buf.len();
+        buf.extend_from_slice(b"INVITE sip:h SIP/2.0\r\nCall-ID: b\r\nContent-Length: 10\r\n\r\n");
+        let (msgs, consumed) = frame_strs(&buf);
+        assert_eq!(msgs.len(), 1, "only the bodyless OPTIONS is complete");
+        assert_eq!(
+            consumed, after_a,
+            "the CL:10 message is held until its body"
+        );
+    }
+
+    #[test]
+    fn frame_body_with_embedded_blank_line_not_split() {
+        // A body that itself contains \r\n\r\n must be taken by Content-Length,
+        // not split at the blank line.
+        let body = "v=0\r\n\r\no=x"; // 10 bytes, contains a blank line
+        let msg = format!(
+            "INVITE sip:h SIP/2.0\r\nCall-ID: b\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        )
+        .into_bytes();
+        let mut buf = msg.clone();
+        buf.extend(opts("tail"));
+        let (msgs, consumed) = frame_strs(&buf);
+        assert_eq!(
+            msgs.len(),
+            2,
+            "the INVITE (with blank-line body) + the OPTIONS"
+        );
+        assert!(
+            msgs[0].ends_with("o=x"),
+            "body taken whole by Content-Length"
+        );
+        assert_eq!(consumed, buf.len());
+    }
+
+    #[test]
+    fn frame_compact_content_length_header() {
+        let body = "abcd";
+        let msg = format!("MESSAGE sip:h SIP/2.0\r\nCall-ID: m\r\nl: 4\r\n\r\n{body}").into_bytes();
+        let (msgs, consumed) = frame_strs(&msg);
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].ends_with("abcd"), "compact 'l' header honored");
+        assert_eq!(consumed, msg.len());
+    }
+
+    #[test]
+    fn frame_lenient_lf_only_separator() {
+        let msg = b"OPTIONS sip:h SIP/2.0\nCall-ID: x\nContent-Length: 0\n\n";
+        let (msgs, consumed) = frame_strs(msg);
+        assert_eq!(msgs.len(), 1, "LFLF terminator accepted");
+        assert_eq!(consumed, msg.len());
+    }
+
+    #[test]
+    fn frame_adversarial_bodies() {
+        // Body with backslashes, embedded NUL, and special chars — taken whole.
+        let body = b"a\\b\x00c\r\nd";
+        let mut msg = format!(
+            "MESSAGE sip:h SIP/2.0\r\nCall-ID: z\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        )
+        .into_bytes();
+        msg.extend_from_slice(body);
+        let after = msg.len();
+        msg.extend(opts("next"));
+        let (ranges, consumed) = frame_tcp_sip(&msg);
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0], 0..after, "NUL/backslash body framed by length");
+        assert_eq!(consumed, msg.len());
+    }
+
+    #[test]
+    fn frame_empty_and_garbage() {
+        // Empty input: nothing framed, nothing consumed.
+        assert_eq!(frame_tcp_sip(b""), (vec![], 0));
+        // Garbage without a header terminator: held entirely (consumed 0).
+        let (ranges, consumed) = frame_tcp_sip(b"not a sip message at all");
+        assert!(ranges.is_empty());
+        assert_eq!(consumed, 0);
+    }
+
+    /// Build an EN10MB frame (Ethernet+IPv4+TCP) carrying `payload`, so a raw
+    /// `Packet` can be pushed through `PacketProcessor::process` end to end.
+    fn tcp_frame(payload: &[u8], seq: u32, psh: bool, fin: bool) -> Packet {
+        let mut tcp = Vec::new();
+        tcp.extend_from_slice(&[0x14, 0x6e]); // src port 5230
+        tcp.extend_from_slice(&[0x13, 0xc4]); // dst port 5060
+        tcp.extend_from_slice(&seq.to_be_bytes());
+        tcp.extend_from_slice(&[0, 0, 0, 0]); // ack
+        let flags = 0x10 | if psh { 0x08 } else { 0 } | if fin { 0x01 } else { 0 };
+        tcp.extend_from_slice(&[0x50, flags]); // data offset 5 words + flags
+        tcp.extend_from_slice(&[0xff, 0xff, 0, 0, 0, 0]); // window, csum(0), urg
+        tcp.extend_from_slice(payload);
+
+        let total_len = (20 + tcp.len()) as u16;
+        let mut ip = vec![0x45, 0x00];
+        ip.extend_from_slice(&total_len.to_be_bytes());
+        ip.extend_from_slice(&[0, 0, 0x40, 0, 64, 6, 0, 0]); // id, flags, ttl, proto=6, csum0
+        ip.extend_from_slice(&[127, 0, 0, 1]); // src
+        ip.extend_from_slice(&[127, 0, 0, 2]); // dst
+        ip.extend_from_slice(&tcp);
+
+        let mut eth = vec![0u8; 12];
+        eth.extend_from_slice(&[0x08, 0x00]); // IPv4
+        eth.extend_from_slice(&ip);
+
+        let len = eth.len();
+        Packet::new(
+            chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            eth,
+            len,
+            len,
+            None,
+            1, // DLT_EN10MB
+        )
+    }
+
+    #[test]
+    fn process_splits_multiple_sip_messages_in_one_tcp_segment() {
+        // SNB-0008 regression: three SIP messages packed into one TCP segment
+        // must all emerge from process(), not just the first.
+        let mut payload = opts("a");
+        payload.extend(opts("b"));
+        payload.extend(opts("c"));
+        let pkt = tcp_frame(&payload, 1000, true, false);
+
+        let mut proc = PacketProcessor::new();
+        let out = proc.process(&pkt);
+        assert_eq!(out.len(), 3, "every message in the segment is emitted");
+        let ids: Vec<String> = out
+            .iter()
+            .map(|p| String::from_utf8_lossy(&p.payload).into_owned())
+            .collect();
+        assert!(ids[0].contains("Call-ID: a"));
+        assert!(ids[1].contains("Call-ID: b"));
+        assert!(ids[2].contains("Call-ID: c"));
+        assert!(
+            out.iter()
+                .all(|p| p.transport == parse::TransportProto::Tcp)
+        );
+    }
+
+    #[test]
+    fn process_surfaces_truncated_tail_on_fin() {
+        // A message whose body never completes before the connection closes is
+        // held while the stream is open, then emitted (truncated) on FIN so a
+        // downstream parser can flag it malformed — never silently dropped.
+        let mut proc = PacketProcessor::new();
+        let head = b"INVITE sip:h SIP/2.0\r\nCall-ID: trunc\r\nContent-Length: 60\r\n\r\n";
+        let out1 = proc.process(&tcp_frame(head, 1, true, false));
+        assert_eq!(
+            out1.len(),
+            0,
+            "incomplete body held while the stream is open"
+        );
+        // FIN with no new data: the held partial must be surfaced.
+        let out2 = proc.process(&tcp_frame(b"", 1 + head.len() as u32, false, true));
+        assert_eq!(out2.len(), 1, "truncated tail emitted on FIN, not dropped");
+        assert!(String::from_utf8_lossy(&out2[0].payload).contains("Call-ID: trunc"));
+    }
+
+    #[test]
+    fn process_passes_non_sip_tcp_through_unframed() {
+        // TLS-over-TCP (and other binary payloads) must NOT be SIP-framed — they
+        // pass through whole so downstream TLS decryption still sees them.
+        let mut proc = PacketProcessor::new();
+        // A TLS ClientHello-ish record: type 0x16, version 0x0301, then bytes
+        // that happen to include a CRLFCRLF, to prove framing is not applied.
+        let tls = b"\x16\x03\x01\x00\x20payload\r\n\r\nmore-tls-bytes-here";
+        let out = proc.process(&tcp_frame(tls, 1, true, false));
+        assert_eq!(
+            out.len(),
+            1,
+            "non-SIP TCP payload emerges as a single packet"
+        );
+        assert_eq!(&out[0].payload[..], &tls[..], "bytes pass through intact");
+    }
+
+    #[test]
+    fn process_holds_partial_across_segments_then_completes() {
+        // A message body split across two TCP segments must be held, not
+        // emitted as a (false) malformed message, then completed on arrival.
+        let mut proc = PacketProcessor::new();
+        let head = b"MESSAGE sip:h SIP/2.0\r\nCall-ID: split\r\nContent-Length: 5\r\n\r\nab";
+        let out1 = proc.process(&tcp_frame(head, 1, true, false));
+        assert_eq!(
+            out1.len(),
+            0,
+            "incomplete body is held, nothing emitted yet"
+        );
+        let out2 = proc.process(&tcp_frame(b"cde", 1 + head.len() as u32, true, false));
+        assert_eq!(
+            out2.len(),
+            1,
+            "the completed message is emitted once the body arrives"
+        );
+        assert!(String::from_utf8_lossy(&out2[0].payload).ends_with("abcde"));
+    }
+
+    #[test]
+    fn frame_content_length_whitespace_and_zeros() {
+        // Leading zeros and surrounding spaces in the CL value parse fine.
+        let msg = b"OPTIONS sip:h SIP/2.0\r\nCall-ID: w\r\nContent-Length:  007\r\n\r\n\
+                    1234567";
+        let (ranges, consumed) = frame_tcp_sip(msg);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(consumed, msg.len(), "CL ' 007' == 7 body bytes consumed");
     }
 
     #[cfg(feature = "native")]

--- a/src/capture/reassembly.rs
+++ b/src/capture/reassembly.rs
@@ -485,6 +485,14 @@ impl TcpReassembler {
         }
     }
 
+    /// Whether a stream for this (src, dst) direction is still tracked. A stream
+    /// is dropped on FIN/RST/timeout, so a `false` after an `insert` means the
+    /// connection ended on that packet — the SIP framer uses this to decide
+    /// whether to hold a partial message or flush it as a truncated tail.
+    pub fn contains(&self, src: SocketAddr, dst: SocketAddr) -> bool {
+        self.streams.contains_key(&TcpStreamKey { src, dst })
+    }
+
     /// Number of tracked TCP streams (for diagnostics).
     pub fn len(&self) -> usize {
         self.streams.len()

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2102" data-suffix="">2102</span>
+        <span class="arch-stat" data-count="2115" data-suffix="">2115</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
## Problem (SNB-0008)

Over TCP, SIP message boundaries are delimited by `Content-Length`, not packet
boundaries, so one TCP segment can legitimately carry several complete messages.
The TCP branch of `PacketProcessor::process` wrapped each `TcpReassembler` flush
as a **single** `ParsedPacket`, and the downstream parser read only the first
message — silently dropping the rest. This is the classic sngrep
([irontec/sngrep#466](https://github.com/irontec/sngrep/issues/466)) weakness
sipnab is meant to beat. Found by the siptest `0020-tcp-dialog` adversarial
framing driver (three `OPTIONS` packed in one segment → only the first decoded;
tshark, on an independent capture of the same bytes, saw all three).

## Fix

Content-Length-aware framing over the reassembled stream:

- **`frame_tcp_sip()`** splits the buffer message-by-message: scan to the header
  terminator (`\r\n\r\n`, or lenient `\n\n`), read `Content-Length` (incl.
  compact `l`), `message_end = headers_end + content_length`; emit one
  `ParsedPacket` per complete message. The body is taken verbatim by length, so a
  blank line *inside* a body never splits a message.
- A trailing **incomplete** message is held as bounded per-stream leftover
  (`tcp_sip_leftover`, capped by `MAX_TCP_LEFTOVER` and `max_sessions`) and
  prepended to the next flush — so a body split across segments completes cleanly
  instead of being false-flagged malformed. On FIN/RST the held partial is
  surfaced truncated rather than dropped; `sweep()` drops partials whose stream
  timed out.
- Framing is gated by **`sip::is_sip_message`**, so TLS / WebSocket / binary TCP
  payloads still pass through whole to their existing downstream handlers.

## Tests (TDD)

- **9** `frame_tcp_sip` unit tests: multi-message, held partial headers, held
  unfinished body, embedded-blank-line body, compact `l`, LF-only separator,
  adversarial bodies (backslash / embedded NUL / special chars),
  empty/garbage, whitespace + leading-zero `Content-Length`.
- **3** `process()`-level integration tests: 3-in-one-segment split,
  partial-held-then-completed across two segments, non-SIP (TLS) passthrough.
- Full suite: `cargo test --features full` → 2115 passing (homepage count bumped
  2102 → 2115).

Verified end-to-end against siptest `0020-tcp-dialog` run.py — the
multi-message differentiator went from `xfail` to a hard assert.