### PR TITLE
Release v0.4.8: TCP multi-message segment framing (SNB-0008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-06-23
+
 ### Fixed
 - **TCP: every SIP message in a coalesced segment is now decoded** (SNB-0008).
   Over TCP, message boundaries are delimited by `Content-Length`, not packet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,7 +3755,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [package]
 name = "sipnab"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Norm Brandinger"]

--- a/website/config.toml
+++ b/website/config.toml
@@ -22,7 +22,7 @@ enabled = true
 theme = "ayu-dark"
 
 [extra]
-version = "0.4.7"
+version = "0.4.8"
 github_url = "https://github.com/NormB/sipnab"
 author = "Norm Brandinger"
 linkedin_url = "https://www.linkedin.com/in/nbrandinger"


### PR DESCRIPTION
Release prep for **v0.4.8**. Bumps `Cargo.toml` + `Cargo.lock`, `website/config.toml`,
and adds the `## [0.4.8]` CHANGELOG section. No code changes beyond the version
bump — the SNB-0008 fix itself already landed in #95.

## Included since v0.4.7

### Fixed
- **TCP: every SIP message in a coalesced segment is now decoded** (SNB-0008,
  #95). Over TCP, message boundaries are delimited by `Content-Length`, not packet
  boundaries, so one segment can carry several complete messages. The reassembly
  consumer decoded only the first per flush and dropped the rest (the classic
  sngrep #466 weakness). `PacketProcessor` now frames the reassembled stream
  message-by-message (`frame_tcp_sip`), holds an incomplete trailing message as
  bounded per-stream leftover until its body arrives, surfaces a truncated partial
  on FIN/RST, and gates framing behind `sip::is_sip_message` so TLS/WebSocket/
  binary TCP still passes through whole.

After merge, tag `v0.4.8` on the merge commit to trigger the release workflow
(artifact build + GitHub release).