### PR TITLE
Release v0.4.9: adversarial-hardening fixes (SNB-0009..0013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-06-23
+
+Hardening release driven by an adversarial review of the `siptest` harness: new
+fixtures and a field-level cross-check surfaced five real defects, each fixed
+tests-first (red → green) with adversarial-input coverage.
+
+### Added
+- **`--json` now emits `contact` and the raw `sdp` body** (SNB-0009). `contact`
+  carries the `Contact` header; `sdp` is the raw body, emitted only for
+  `Content-Type: application/sdp` with a valid-UTF-8 body. Lets consumers
+  cross-check the routing target and the negotiated media (connection / `m=` /
+  `a=rtpmap`) that dynamic-PT decode relies on. `schema_version` stays 1
+  (optional fields); schema and `docs/output-formats.md` updated.
+- **Extension-enumeration detection** (SNB-0010). The scanner detector now tracks
+  the set of distinct target extensions (To user, falling back to R-URI) probed
+  by a single source within the window and raises `detection=enumeration` when it
+  exceeds a threshold — catching a **UA-randomized, INVITE-based, or low-and-slow**
+  sweep that signature (`ua_pattern`) and pure-rate detection both miss. INVITE is
+  now also counted toward the rate signal. Bounded per source.
+- **Deterministic parser-robustness test** (`tests/fuzz_corpus_replay.rs`): a
+  stable-toolchain no-panic gate driving `parse_sip`/`parse_sdp`/
+  `parse_rtp_header`/`parse_rtcp` with an adversarial seed set and a fixed
+  mutation sweep, complementing the nightly `cargo fuzz` targets.
+
+### Fixed
+- **IP-fragmented SIP is now reassembled and decoded** (SNB-0011). After IP
+  fragment reassembly the buffer is the full IP payload (transport header + data);
+  the transport header was never re-parsed, so ports stayed `0` and the SIP
+  parser saw the UDP header before the start line — dropping the message entirely
+  (e.g. a >MTU INVITE with a large SDP on a real NIC). Added
+  `parse::reparse_transport`, which recovers the ports/transport and strips the
+  header before SIP parsing.
+- **Out-of-order TCP: a gap-filling segment now completes a stalled push**
+  (SNB-0012). When the final segment (carrying PSH) arrived before an earlier
+  one, the push could not drain (gap) and the later gap-filling segment had no
+  PSH, so the now-contiguous data was buffered forever and never decoded. The
+  reassembler now remembers a pending push and flushes once the gap fills.
+- **stdio MCP server exits on client disconnect** (SNB-0013). `--mcp` over stdio
+  spun until SIGINT and ignored stdin EOF, leaking the process after a client
+  disconnected. The wait loop now also breaks when the stdio serve thread
+  finishes (HTTP transport, which only ends on a signal, is unaffected).
+
 ## [0.4.8] - 2026-06-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,7 +3755,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [package]
 name = "sipnab"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Norm Brandinger"]

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -40,6 +40,12 @@ message, requests included, so re-requests within a dialog (e.g. two REGISTERs
 with `CSeq` 1 and 2) stay distinguishable. It is omitted only when the `CSeq`
 header is absent or unparseable.
 
+`contact` is the `Contact` header value when present (routing-critical, omitted
+otherwise). `sdp` is the raw SDP body, emitted **only** when `Content-Type` is
+`application/sdp` and the body is valid UTF-8 — it lets a consumer verify the
+negotiated media (connection / `m=` / `a=rtpmap`) that dynamic-PT decode depends
+on; omitted for non-SDP or non-UTF-8 bodies.
+
 Responses carry `status_code` and `reason` instead of `method`, plus
 `response_context` (`"<num> <method>"`, what the response answers) — now
 redundant with `cseq` and retained only for backward compatibility.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3,13 +3,19 @@
 version = 4
 
 [[package]]
-name = "aes"
-version = "0.8.4"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
+ "cpubits",
  "cpufeatures",
 ]
 
@@ -112,6 +118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,11 +137,11 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -161,9 +173,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
  "cipher",
 ]
@@ -200,11 +212,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -255,18 +267,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -295,6 +328,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "derive-into-owned"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +356,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "const-oid",
+ "crypto-common 0.1.7",
 ]
 
 [[package]]
@@ -346,6 +409,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,18 +430,34 @@ dependencies = [
 
 [[package]]
 name = "etherparse"
-version = "0.16.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d8a704b617484e9d867a0423cd45f7577f008c4068e2e33378f8d3860a6d73"
+checksum = "e8b5355e41024c070dd6c1a9b3340e5026a71a4222fb6c64606f21c9f6b502c1"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "generic-array"
@@ -416,6 +505,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,12 +549,12 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding",
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -520,6 +618,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -546,6 +647,18 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -578,19 +691,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
+name = "miniz_oxide"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -603,12 +719,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -662,7 +815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2eecc2ddc671ec563b5b39f846556aade68a65d1afb14d8fe6b30b0457d75"
 dependencies = [
  "bitflags 1.3.2",
- "errno",
+ "errno 0.2.8",
  "libc",
  "libloading",
  "pkg-config",
@@ -682,10 +835,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -706,6 +889,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -731,6 +923,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -782,6 +1003,39 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno 0.3.14",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -876,11 +1130,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -899,8 +1153,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "sipnab"
-version = "0.4.1"
+version = "0.4.8"
 dependencies = [
  "aes",
  "anyhow",
@@ -912,6 +1182,7 @@ dependencies = [
  "crossbeam-channel",
  "env_logger",
  "etherparse",
+ "flate2",
  "indexmap",
  "libc",
  "log",
@@ -922,11 +1193,14 @@ dependencies = [
  "pcap-file",
  "regex",
  "ring",
+ "rsa",
  "rustls",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -947,6 +1221,22 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "strsim"
@@ -980,6 +1270,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1033,44 +1336,55 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1133,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1435,9 +1749,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -1447,6 +1761,26 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zeroize"

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -424,12 +424,22 @@ impl PacketProcessor {
         if is_fragment {
             return match self.fragment_reassembler.insert(&parsed) {
                 Some(reassembled) => {
-                    // Re-parse the reassembled datagram to get transport headers.
-                    // The reassembled data is the IP payload (transport header + data),
-                    // so we need to create a synthetic packet for re-parsing.
-                    // For now, emit the parsed packet with the reassembled payload.
+                    // The reassembled buffer is the full IP payload (transport
+                    // header + data). Re-parse the transport header so the ports
+                    // and offset are recovered — the fragments themselves carried
+                    // no usable transport header, so without this the payload
+                    // still begins with the UDP/TCP header and SIP parsing fails.
                     let mut completed = parsed;
-                    completed.payload = reassembled.into();
+                    if let Some((sp, dp, tp, hdr)) =
+                        parse::reparse_transport(completed.ip_protocol, &reassembled)
+                    {
+                        completed.src_port = sp;
+                        completed.dst_port = dp;
+                        completed.transport = tp;
+                        completed.payload = bytes::Bytes::copy_from_slice(&reassembled[hdr..]);
+                    } else {
+                        completed.payload = reassembled.into();
+                    }
                     completed.fragment_offset = Some(0);
                     completed.more_fragments = false;
                     vec![completed]

--- a/src/capture/parse.rs
+++ b/src/capture/parse.rs
@@ -161,6 +161,46 @@ fn slice_of(data: &bytes::Bytes, child: &[u8]) -> bytes::Bytes {
     }
 }
 
+/// Re-parse the transport header from a reassembled IP payload.
+///
+/// After IP-fragment reassembly the buffer is the full IP payload — i.e. the
+/// transport header (UDP/TCP) followed by the application data. The original
+/// fragment carried no usable transport header (non-first fragments have none,
+/// and the first fragment's UDP length covers the whole datagram), so the ports
+/// and the header length must be recovered here before the SIP/RTP parser sees
+/// the payload. Returns `(src_port, dst_port, transport, header_len)` or `None`
+/// for a truncated buffer or an unhandled protocol.
+pub(crate) fn reparse_transport(
+    ip_protocol: u8,
+    payload: &[u8],
+) -> Option<(u16, u16, TransportProto, usize)> {
+    match ip_protocol {
+        17 => {
+            // UDP: src(2) dst(2) len(2) cksum(2) = 8-byte fixed header.
+            if payload.len() < 8 {
+                return None;
+            }
+            let sp = u16::from_be_bytes([payload[0], payload[1]]);
+            let dp = u16::from_be_bytes([payload[2], payload[3]]);
+            Some((sp, dp, TransportProto::Udp, 8))
+        }
+        6 => {
+            // TCP: data offset (high nibble of byte 12) in 32-bit words.
+            if payload.len() < 20 {
+                return None;
+            }
+            let sp = u16::from_be_bytes([payload[0], payload[1]]);
+            let dp = u16::from_be_bytes([payload[2], payload[3]]);
+            let data_off = ((payload[12] >> 4) as usize) * 4;
+            if data_off < 20 || payload.len() < data_off {
+                return None;
+            }
+            Some((sp, dp, TransportProto::Tcp, data_off))
+        }
+        _ => None,
+    }
+}
+
 /// Parse a raw captured [`Packet`] into a [`ParsedPacket`].
 ///
 /// Walks through link-layer, network, and transport headers based on
@@ -504,6 +544,42 @@ fn extract_parsed_packet(
 mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    #[test]
+    fn reparse_transport_udp_recovers_ports_and_strips_header() {
+        // After IP reassembly the buffer is the IP payload = UDP header + body.
+        // reparse must recover the ports and the offset past the 8-byte header.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&5060u16.to_be_bytes()); // src port
+        buf.extend_from_slice(&5062u16.to_be_bytes()); // dst port
+        buf.extend_from_slice(&0u16.to_be_bytes()); // len (ignored)
+        buf.extend_from_slice(&0u16.to_be_bytes()); // cksum
+        buf.extend_from_slice(b"OPTIONS sip:x SIP/2.0\r\n");
+        let (sp, dp, tp, hdr) = reparse_transport(17, &buf).expect("udp reparse");
+        assert_eq!((sp, dp), (5060, 5062));
+        assert_eq!(tp, TransportProto::Udp);
+        assert_eq!(&buf[hdr..hdr + 7], b"OPTIONS");
+    }
+
+    #[test]
+    fn reparse_transport_tcp_uses_data_offset() {
+        let mut buf = vec![0u8; 20];
+        buf[0..2].copy_from_slice(&5060u16.to_be_bytes());
+        buf[2..4].copy_from_slice(&40000u16.to_be_bytes());
+        buf[12] = 5 << 4; // data offset = 5 words = 20 bytes, no options
+        buf.extend_from_slice(b"INVITE");
+        let (sp, dp, tp, hdr) = reparse_transport(6, &buf).expect("tcp reparse");
+        assert_eq!((sp, dp), (5060, 40000));
+        assert_eq!(tp, TransportProto::Tcp);
+        assert_eq!(hdr, 20);
+    }
+
+    #[test]
+    fn reparse_transport_rejects_truncated_and_unknown() {
+        assert!(reparse_transport(17, &[0, 0, 0]).is_none()); // < 8 bytes
+        assert!(reparse_transport(6, &[0u8; 10]).is_none()); // < 20 bytes
+        assert!(reparse_transport(132, &[0u8; 40]).is_none()); // SCTP: not handled
+    }
 
     /// Build a minimal Ethernet + IPv4 + UDP packet.
     fn build_eth_ipv4_udp(

--- a/src/capture/reassembly.rs
+++ b/src/capture/reassembly.rs
@@ -272,6 +272,10 @@ struct TcpStream {
     initialized: bool,
     /// Whether a SYN was seen (meaning expected_seq is authoritative).
     syn_seen: bool,
+    /// A PSH was seen but its data could not yet be drained (a missing earlier
+    /// segment left a gap). Stays set until the gap fills and the data flushes,
+    /// so an out-of-order push completes instead of being buffered forever.
+    pending_flush: bool,
 }
 
 /// Reassembles TCP segments into ordered byte streams.
@@ -357,6 +361,7 @@ impl TcpReassembler {
                 buffered_bytes: 0,
                 initialized: false,
                 syn_seen: false,
+                pending_flush: false,
             });
 
         stream.last_seen = Instant::now();
@@ -394,6 +399,12 @@ impl TcpReassembler {
             stream.buffered_bytes += parsed.payload.len();
             stream.buffer.insert(seq, parsed.payload.clone());
         }
+        // A PSH requests delivery of the data up to here; record it while we hold
+        // the borrow. It may not be drainable yet (a gap before it) — the flush
+        // below retries it once a later out-of-order segment fills the gap.
+        if flags.psh {
+            stream.pending_flush = true;
+        }
 
         let mut results = Vec::new();
 
@@ -422,11 +433,18 @@ impl TcpReassembler {
             return results;
         }
 
-        // PSH: flush in-order data
-        if flags.psh {
+        // Flush if a push is pending — now, or one that earlier stalled on a
+        // missing segment that this (out-of-order) segment has just filled.
+        if self.streams.get(&key).is_some_and(|s| s.pending_flush) {
             let flushed = self.drain_in_order(&key);
             if !flushed.is_empty() {
                 results.push(flushed);
+            }
+            // Once the contiguous data is delivered, the push is satisfied.
+            if let Some(s) = self.streams.get_mut(&key)
+                && s.buffer.is_empty()
+            {
+                s.pending_flush = false;
             }
         }
 
@@ -601,6 +619,36 @@ mod tests {
             rst: false,
             psh: false,
         }
+    }
+
+    #[test]
+    fn tcp_psh_on_final_segment_arriving_first_flushes_when_gap_fills() {
+        // Real-world out-of-order: the FINAL segment (carrying PSH) arrives
+        // first; the earlier segment (no PSH) arrives last and fills the gap.
+        // The push stalled on the gap, so when the gap fills the now-contiguous
+        // data MUST be flushed — previously it was buffered forever (decoded 0).
+        let mut r = TcpReassembler::new();
+        // SYN establishes the sequence base (data starts at seq 100), so a later
+        // seg at 105 has a real gap rather than redefining the stream start.
+        let mut syn = default_tcp_flags();
+        syn.syn = true;
+        assert!(
+            r.insert(&make_tcp_segment(5060, 5061, 99, syn, b""))
+                .is_empty()
+        );
+        let mut psh = default_tcp_flags();
+        psh.psh = true;
+        // seg2 = bytes [105..110) with PSH, arrives first
+        let seg2 = make_tcp_segment(5060, 5061, 105, psh, b"world");
+        assert!(r.insert(&seg2).is_empty(), "gap before it → nothing yet");
+        // seg1 = bytes [100..105), NO PSH, arrives last and fills the gap
+        let seg1 = make_tcp_segment(5060, 5061, 100, default_tcp_flags(), b"hello");
+        let result = r.insert(&seg1);
+        assert_eq!(
+            result,
+            vec![b"helloworld".to_vec()],
+            "filling the gap must complete the stalled push"
+        );
     }
 
     /// At large caps, eviction is batched (cap/100 at a time): the old

--- a/src/main.rs
+++ b/src/main.rs
@@ -1788,6 +1788,16 @@ fn run_batch_mode(
             tracing::info!("MCP server active — press Ctrl-C to stop");
         }
         while !signals::shutdown_requested() {
+            // A stdio MCP client owns the lifetime: when it closes stdin the
+            // serve thread finishes, and there is no client left to serve — so
+            // exit instead of spinning forever (otherwise the process leaks
+            // until SIGINT). HTTP's serve thread only finishes on a signal, so
+            // this is a no-op there.
+            #[cfg(feature = "mcp")]
+            if _mcp_thread.as_ref().is_some_and(|h| h.is_finished()) {
+                tracing::info!("MCP client disconnected — shutting down");
+                break;
+            }
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
         #[cfg(feature = "api")]

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -37,8 +37,16 @@ struct MessageJson<'a> {
     from: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     to: Option<&'a str>,
+    /// `Contact` header (routing-critical, cross-checked by the field digest).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    contact: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     ua: Option<&'a str>,
+    /// Raw SDP body, emitted only when `Content-Type` is `application/sdp` and
+    /// the body is valid UTF-8 — so the cross-check can verify the negotiated
+    /// media (connection/media/rtpmap) the dynamic-PT decode relies on.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sdp: Option<&'a str>,
     /// Parsed `CSeq` (number + method) on **every** message — requests included,
     /// so re-requests within a dialog stay distinguishable (SNB-0002). Omitted
     /// only when the `CSeq` header is absent or unparseable.
@@ -176,6 +184,18 @@ pub fn message_to_json(msg: &SipMessage) -> String {
         None
     };
 
+    // Emit the raw SDP body only for application/sdp + valid UTF-8 (a non-UTF-8
+    // body is left to the malformed path, not surfaced as a comparable sdp).
+    let sdp = if msg
+        .content_type()
+        .map(|ct| ct.contains("application/sdp"))
+        .unwrap_or(false)
+    {
+        std::str::from_utf8(&msg.body).ok()
+    } else {
+        None
+    };
+
     let json = MessageJson {
         schema_version: 1,
         timestamp: msg.timestamp.to_rfc3339(),
@@ -191,7 +211,9 @@ pub fn message_to_json(msg: &SipMessage) -> String {
         call_id: msg.call_id(),
         from: msg.from_header(),
         to: msg.to_header(),
+        contact: msg.contact(),
         ua: msg.user_agent(),
+        sdp,
         cseq,
         response_context,
         malformed: msg.malformations(),
@@ -448,6 +470,124 @@ mod tests {
         assert_eq!(parsed["status_code"], 200);
         assert_eq!(parsed["is_request"], false);
         assert!(parsed["response_context"].is_string());
+    }
+
+    #[test]
+    fn message_to_json_includes_contact_and_sdp() {
+        // Field-digest cross-check (item 1): sipnab must EMIT Contact + the SDP
+        // body so the comparator can verify them against tshark — without these
+        // a dropped/mangled rtpmap or a corrupt Contact is invisible.
+        let body = b"v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\nm=audio 6000 RTP/AVP 8 96\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:96 telephone-event/8000\r\n";
+        let cl = format!("Content-Length: {}", body.len());
+        let raw = build_sip(
+            "INVITE sip:bob@example.com SIP/2.0",
+            &[
+                "From: \"Alice\" <sip:1001@example.com>;tag=t1",
+                "To: <sip:1002@example.com>",
+                "Contact: <sip:1001@127.0.0.1:5062>",
+                "Call-ID: sdp-test@example.com",
+                "CSeq: 1 INVITE",
+                "Content-Type: application/sdp",
+                &cl,
+            ],
+            body,
+        );
+        let msg = parse_sip(
+            &raw,
+            ts(),
+            localhost(),
+            localhost(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("should parse");
+        let parsed = parsed_json(&msg);
+        assert_eq!(parsed["contact"], "<sip:1001@127.0.0.1:5062>");
+        let sdp = parsed["sdp"].as_str().expect("sdp body present");
+        assert!(
+            sdp.contains("m=audio 6000 RTP/AVP 8 96"),
+            "sdp body emitted: {sdp}"
+        );
+        assert!(
+            sdp.contains("a=rtpmap:96 telephone-event/8000"),
+            "rtpmap present: {sdp}"
+        );
+    }
+
+    #[test]
+    fn message_to_json_omits_contact_and_sdp_when_absent() {
+        let parsed = parsed_json(&make_invite()); // no Contact, empty body
+        assert!(parsed.get("contact").is_none(), "no Contact header => omit");
+        assert!(parsed.get("sdp").is_none(), "no SDP body => omit");
+    }
+
+    #[test]
+    fn message_to_json_sdp_omitted_for_non_sdp_body() {
+        let body = b"plain text body";
+        let cl = format!("Content-Length: {}", body.len());
+        let raw = build_sip(
+            "MESSAGE sip:bob@example.com SIP/2.0",
+            &[
+                "From: <sip:a@h>;tag=t1",
+                "To: <sip:b@h>",
+                "Call-ID: txt@h",
+                "CSeq: 1 MESSAGE",
+                "Content-Type: text/plain",
+                &cl,
+            ],
+            body,
+        );
+        let msg = parse_sip(
+            &raw,
+            ts(),
+            localhost(),
+            localhost(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("should parse");
+        assert!(
+            parsed_json(&msg).get("sdp").is_none(),
+            "a non-application/sdp body must not be emitted as sdp"
+        );
+    }
+
+    #[test]
+    fn message_to_json_sdp_preserves_adversarial_bytes() {
+        // backslash + embedded quote in the SDP must round-trip through JSON
+        // string escaping intact (not corrupt the line or get dropped).
+        let body = b"v=0\r\nc=IN IP4 127.0.0.1\r\nm=audio 6000 RTP/AVP 8\r\na=label:a\\b\"c\r\n";
+        let cl = format!("Content-Length: {}", body.len());
+        let raw = build_sip(
+            "INVITE sip:bob@example.com SIP/2.0",
+            &[
+                "From: <sip:a@h>;tag=t1",
+                "To: <sip:b@h>",
+                "Call-ID: adv@h",
+                "CSeq: 1 INVITE",
+                "Content-Type: application/sdp",
+                &cl,
+            ],
+            body,
+        );
+        let msg = parse_sip(
+            &raw,
+            ts(),
+            localhost(),
+            localhost(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("should parse");
+        let parsed = parsed_json(&msg); // must still be valid JSON
+        let sdp = parsed["sdp"].as_str().expect("sdp present");
+        assert!(
+            sdp.contains("a=label:a\\b\"c"),
+            "adversarial bytes preserved: {sdp:?}"
+        );
     }
 
     /// Parse a REGISTER request carrying exactly `headers`.

--- a/src/security/scanner_detect.rs
+++ b/src/security/scanner_detect.rs
@@ -3,10 +3,12 @@
 //! Detects SIP scanning activity through two methods:
 //! - **User-Agent pattern matching** against known scanner signatures
 //!   (friendly-scanner, sipvicious, etc.) and user-defined patterns.
-//! - **Behavioral analysis** detecting high-rate REGISTER/OPTIONS probing
-//!   from a single source without valid authentication.
+//! - **Behavioral analysis** detecting high-rate REGISTER/OPTIONS/INVITE probing
+//!   from a single source, and **extension enumeration** — many *distinct*
+//!   target users from one source — which catches a UA-randomized, INVITE-based,
+//!   or low-and-slow sweep that signature/rate detection alone would miss.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::time::Instant;
 
@@ -29,6 +31,17 @@ const KNOWN_SCANNER_PATTERNS: &[&str] = &[
 /// that triggers a behavioral detection alert.
 const BEHAVIORAL_THRESHOLD: u32 = 10;
 
+/// Number of DISTINCT target extensions probed by one source within the window
+/// that triggers an enumeration alert. Lower than the rate threshold because
+/// hitting many *different* users is a far more specific recon signal than
+/// volume alone (svwar's signature) — and it catches a UA-randomized, INVITE-
+/// based, or low-and-slow sweep that the rate counter misses.
+const ENUMERATION_THRESHOLD: usize = 5;
+
+/// Cap on tracked distinct targets per source (bounds memory under a flood that
+/// also randomizes the target user-part).
+const MAX_TARGETS_PER_SOURCE: usize = 1024;
+
 /// Behavioral detection window in seconds.
 const BEHAVIORAL_WINDOW_SECS: u64 = 5;
 
@@ -37,6 +50,8 @@ struct BehavioralState {
     register_count: u32,
     options_count: u32,
     invite_count: u32,
+    /// Distinct target extensions (To/R-URI user-part) seen this window.
+    targets: HashSet<String>,
     first_seen: Instant,
     last_seen: Instant,
 }
@@ -50,7 +65,8 @@ pub struct ScannerAlert {
     pub ua: String,
     /// SIP method of the triggering message.
     pub method: String,
-    /// How the scanner was detected: `"ua_pattern"` or `"behavioral"`.
+    /// How the scanner was detected: `"ua_pattern"`, `"behavioral"` (rate), or
+    /// `"enumeration"` (many distinct targets from one source).
     pub detection_method: String,
 }
 
@@ -162,6 +178,7 @@ impl ScannerDetector {
                     register_count: 0,
                     options_count: 0,
                     invite_count: 0,
+                    targets: HashSet::new(),
                     first_seen: now,
                     last_seen: now,
                 });
@@ -171,6 +188,7 @@ impl ScannerDetector {
                 state.register_count = 0;
                 state.options_count = 0;
                 state.invite_count = 0;
+                state.targets.clear();
                 state.first_seen = now;
             }
 
@@ -180,9 +198,32 @@ impl ScannerDetector {
                 "INVITE" => state.invite_count += 1,
                 _ => {}
             }
+            // Track distinct probed extensions (To user, falling back to R-URI).
+            if let Some(target) = msg.to_user().or_else(|| {
+                msg.request_uri
+                    .as_deref()
+                    .and_then(crate::sip::message::extract_uri_user)
+            }) && state.targets.len() < MAX_TARGETS_PER_SOURCE
+            {
+                state.targets.insert(target);
+            }
             state.last_seen = now;
 
-            let probe_count = state.register_count + state.options_count;
+            // Enumeration: many DISTINCT targets from one source — catches a
+            // UA-randomized, INVITE-based, or low-and-slow sweep the rate path
+            // misses. Checked first as the more specific (lower-FP) signal.
+            if state.targets.len() > ENUMERATION_THRESHOLD {
+                return Some(ScannerAlert {
+                    src_ip: msg.src_addr,
+                    ua,
+                    method: method.to_string(),
+                    detection_method: "enumeration".to_string(),
+                });
+            }
+
+            // Rate: high volume of REGISTER/OPTIONS probes (now incl. INVITE) in
+            // the window — a same-target flood the enumeration signal won't see.
+            let probe_count = state.register_count + state.options_count + state.invite_count;
             if probe_count > BEHAVIORAL_THRESHOLD {
                 return Some(ScannerAlert {
                     src_ip: msg.src_addr,
@@ -326,6 +367,103 @@ mod tests {
                 if let Some(a) = alert {
                     assert_eq!(a.detection_method, "behavioral");
                 }
+            }
+        }
+    }
+
+    /// Build a request that enumerates a specific target extension, with an
+    /// arbitrary (attacker-chosen, here randomized-looking) User-Agent — the
+    /// evasion: no known scanner UA, so ua_pattern can never fire.
+    fn enum_request(method: &str, target: &str, ua: &str, src: IpAddr, n: usize) -> SipMessage {
+        let raw = build_sip(
+            &format!("{method} sip:{target}@example.com SIP/2.0"),
+            &[
+                &format!("From: <sip:probe@example.com>;tag=t{n}"),
+                &format!("To: <sip:{target}@example.com>"),
+                &format!("Call-ID: enum-{n}@example.com"),
+                &format!("CSeq: 1 {method}"),
+                &format!("User-Agent: {ua}"),
+                "Content-Length: 0",
+            ],
+            b"",
+        );
+        parse_sip(
+            &raw,
+            ts(),
+            src,
+            localhost(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("should parse")
+    }
+
+    #[test]
+    fn detect_invite_extension_enumeration_with_randomized_ua() {
+        // EVASION: attacker enumerates extensions over INVITE with a different,
+        // innocuous UA each probe. ua_pattern never fires; the old behavioral
+        // path only summed REGISTER+OPTIONS, so INVITE enumeration slipped
+        // through entirely. The distinct-target signal must catch it.
+        let mut det = ScannerDetector::new(&[]);
+        let src = scanner_ip();
+        let uas = [
+            "PolyUA/1",
+            "Acme/2",
+            "Zoip/3",
+            "Xlite/4",
+            "Bria/5",
+            "Linphone/6",
+            "Baresip/7",
+            "Csip/8",
+        ];
+        let mut fired = None;
+        for (i, ua) in uas.iter().enumerate() {
+            let msg = enum_request("INVITE", &format!("ext{i:04}"), ua, src, i);
+            if let Some(a) = det.check(&msg) {
+                fired = Some(a);
+            }
+        }
+        let a = fired.expect("extension enumeration over INVITE must be detected");
+        assert_eq!(a.detection_method, "enumeration");
+    }
+
+    #[test]
+    fn detect_low_and_slow_enumeration_under_rate_threshold() {
+        // EVASION: stay UNDER the rate threshold (only 6 probes), but hit 6
+        // DISTINCT extensions — a rate-only detector misses it; distinct-target
+        // enumeration does not.
+        let mut det = ScannerDetector::new(&[]);
+        let src = scanner_ip();
+        let mut fired = None;
+        for i in 0..6 {
+            let msg = enum_request("OPTIONS", &format!("user{i:04}"), "Normalish/9.0", src, i);
+            if let Some(a) = det.check(&msg) {
+                fired = Some(a);
+            }
+        }
+        assert!(
+            fired.is_some(),
+            "6 distinct extensions from one source is enumeration"
+        );
+        assert_eq!(fired.unwrap().detection_method, "enumeration");
+    }
+
+    #[test]
+    fn normal_call_to_few_targets_not_flagged_as_enumeration() {
+        // FALSE-POSITIVE guard: a normal client placing several requests to the
+        // SAME one or two targets (retransmits / re-INVITE / a couple of calls)
+        // must NOT be flagged as enumeration.
+        let mut det = ScannerDetector::new(&[]);
+        let src = localhost();
+        for i in 0..12 {
+            let target = if i % 2 == 0 { "alice" } else { "bob" };
+            let msg = enum_request("INVITE", target, "Linphone/5.1", src, i);
+            if let Some(a) = det.check(&msg) {
+                assert_ne!(
+                    a.detection_method, "enumeration",
+                    "two distinct targets must not be enumeration (msg {i})"
+                );
             }
         }
     }

--- a/src/sip/message.rs
+++ b/src/sip/message.rs
@@ -263,7 +263,7 @@ fn has_control_bytes(s: &str) -> bool {
 /// Extract the user part from a SIP URI inside a header value.
 ///
 /// Handles both `<sip:user@host>` and bare `sip:user@host` forms (RFC 3261 § 20.20).
-fn extract_uri_user(header_value: &str) -> Option<String> {
+pub(crate) fn extract_uri_user(header_value: &str) -> Option<String> {
     // Try angle-bracket form first: <sip:user@host> or <sips:user@host>
     // Fall back to bare form: sip:user@host or sips:user@host
     let scheme_pos = header_value

--- a/tests/fuzz_corpus_replay.rs
+++ b/tests/fuzz_corpus_replay.rs
@@ -1,0 +1,230 @@
+//! Deterministic, stable-toolchain robustness gate over the wire parsers.
+//!
+//! The `fuzz/` crate holds the real cargo-fuzz (libFuzzer) targets, but they
+//! need a nightly toolchain and run unbounded, so they can't be a `cargo test`
+//! gate. This file is the always-runnable counterpart: it drives the same parser
+//! entry points (`parse_sip` / `parse_sdp` / `parse_rtp_header` / `parse_rtcp`)
+//! with a fixed adversarial seed set AND a deterministic mutation sweep, and
+//! asserts none of them ever **panics** — a privileged parser of hostile traffic
+//! (priority #2: robustness) must reject bad input with `Err`/empty, never
+//! unwind. Returning `Err` is fine; panicking is the failure.
+//!
+//! "Validate the validator": `harness_actually_catches_a_panic` proves the
+//! catch_unwind harness has teeth, so a parser that *did* panic could not slip
+//! through as a false pass.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use sipnab::capture::parse::TransportProto;
+use sipnab::rtp::parser::parse_rtp_header;
+use sipnab::rtp::rtcp::parse_rtcp;
+use sipnab::sip::parser::parse_sip;
+use sipnab::sip::sdp::parse_sdp;
+
+/// Run `f` and return Err(label) if it panicked (panic output is suppressed so
+/// a deliberate self-test panic doesn't spam the log).
+fn ran_without_panic<F: FnOnce()>(label: &str, f: F) -> Result<(), String> {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let res = catch_unwind(AssertUnwindSafe(f));
+    std::panic::set_hook(prev);
+    res.map_err(|_| label.to_string())
+}
+
+fn drive_sip(data: &[u8]) {
+    let _ = parse_sip(
+        data,
+        chrono::Utc::now(),
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        5060,
+        5060,
+        TransportProto::Udp,
+    );
+}
+
+/// A spread of nasty raw inputs that hit boundary/special-char paths the CLAUDE
+/// directive calls out (backslash, NUL, empty, lying lengths, huge counts).
+fn adversarial_seeds() -> Vec<Vec<u8>> {
+    let mut v: Vec<Vec<u8>> = vec![
+        vec![],                   // empty
+        vec![0u8],                // single NUL
+        vec![0u8; 4096],          // all-NUL block
+        vec![0xFFu8; 512],        // invalid UTF-8 block
+        b"\r\n\r\n\r\n".to_vec(), // only line endings
+        b"INVITE".to_vec(),       // truncated request line
+        b"SIP/2.0 200".to_vec(),  // truncated status line
+    ];
+    // Lying Content-Length (declares a body far larger than present).
+    v.push(
+        b"INVITE sip:a@b SIP/2.0\r\nVia: SIP/2.0/UDP h\r\nFrom: <sip:a@b>;tag=1\r\n\
+          To: <sip:c@d>\r\nCall-ID: x@h\r\nCSeq: 1 INVITE\r\nContent-Length: 99999\r\n\r\nshort"
+            .to_vec(),
+    );
+    // Embedded NUL and backslash inside a header value.
+    v.push(b"OPTIONS sip:a@b SIP/2.0\r\nFrom: <sip:a\\b@h>\x00evil;tag=1\r\nCall-ID: n\x00l@h\r\nCSeq: 1 OPTIONS\r\n\r\n".to_vec());
+    // Header with no colon, then a giant single line.
+    v.push(b"REGISTER sip:a SIP/2.0\r\nthisHasNoColon\r\n\r\n".to_vec());
+    v.push({
+        let mut s = b"INVITE sip:a@b SIP/2.0\r\nX-Long: ".to_vec();
+        s.extend(std::iter::repeat_n(b'A', 100_000));
+        s.extend_from_slice(b"\r\n\r\n");
+        s
+    });
+    // Thousands of headers (allocation / loop bounds).
+    v.push({
+        let mut s = b"INVITE sip:a@b SIP/2.0\r\n".to_vec();
+        for _ in 0..5000 {
+            s.extend_from_slice(b"X: y\r\n");
+        }
+        s.extend_from_slice(b"\r\n");
+        s
+    });
+    // A plausible SDP-bearing INVITE with a malformed SDP body.
+    v.push(b"INVITE sip:a@b SIP/2.0\r\nCall-ID: s@h\r\nCSeq: 1 INVITE\r\nContent-Type: application/sdp\r\nContent-Length: 9\r\n\r\nm=audio x".to_vec());
+    v
+}
+
+/// SDP-specific adversarial bodies.
+fn sdp_seeds() -> Vec<Vec<u8>> {
+    vec![
+        vec![],
+        vec![0u8; 256],
+        b"v=0".to_vec(),
+        b"=\r\n=\r\n=".to_vec(), // lines that are just '='
+        b"m=audio 99999999999999999999 RTP/AVP 8".to_vec(), // overflow-y port
+        b"a=rtpmap:notanumber FOO/abc".to_vec(), // non-numeric pt/clock
+        b"c=IN IP4 \r\nm=audio -1 RTP/AVP 0 8 9 96 97 98 99 100 101 102".to_vec(),
+        b"a=rtpmap:96 \x00\x00\x00/8000".to_vec(), // NUL in codec
+        {
+            let mut s = b"v=0\r\n".to_vec();
+            for i in 0..10_000 {
+                s.extend_from_slice(format!("a=rtpmap:{} X/8000\r\n", i % 128).as_bytes());
+            }
+            s
+        },
+    ]
+}
+
+/// A tiny deterministic xorshift PRNG so the mutation sweep is reproducible
+/// (no Math.random / wall-clock seeding — same bytes every CI run).
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn byte(&mut self) -> u8 {
+        (self.next() & 0xff) as u8
+    }
+}
+
+/// Mutate a seed by flipping/overwriting/truncating bytes — deterministic.
+fn mutate(seed: &[u8], rng: &mut Rng) -> Vec<u8> {
+    let mut out = seed.to_vec();
+    if out.is_empty() {
+        out.push(rng.byte());
+    }
+    let ops = 1 + (rng.next() % 6);
+    for _ in 0..ops {
+        match rng.next() % 4 {
+            0 if !out.is_empty() => {
+                let i = (rng.next() as usize) % out.len();
+                out[i] = rng.byte();
+            }
+            1 => out.push(rng.byte()),
+            2 if out.len() > 1 => {
+                let i = (rng.next() as usize) % out.len();
+                out.truncate(i);
+            }
+            _ => out.insert((rng.next() as usize) % (out.len() + 1), rng.byte()),
+        }
+    }
+    out
+}
+
+#[test]
+fn harness_actually_catches_a_panic() {
+    // validate the validator: a panicking closure MUST be reported as a failure.
+    assert!(ran_without_panic("boom", || panic!("deliberate")).is_err());
+    // and a clean closure must pass.
+    assert!(ran_without_panic("ok", || {}).is_ok());
+}
+
+#[test]
+fn parsers_never_panic_on_adversarial_seeds() {
+    let mut failures = Vec::new();
+    for (i, seed) in adversarial_seeds().iter().enumerate() {
+        let s = seed.clone();
+        if let Err(l) = ran_without_panic(&format!("sip seed #{i}"), move || drive_sip(&s)) {
+            failures.push(l);
+        }
+        let s = seed.clone();
+        if let Err(l) = ran_without_panic(&format!("rtp seed #{i}"), move || {
+            let _ = parse_rtp_header(&s);
+        }) {
+            failures.push(l);
+        }
+        let s = seed.clone();
+        if let Err(l) = ran_without_panic(&format!("rtcp seed #{i}"), move || {
+            let _ = parse_rtcp(&s);
+        }) {
+            failures.push(l);
+        }
+    }
+    for (i, seed) in sdp_seeds().iter().enumerate() {
+        let s = seed.clone();
+        if let Err(l) = ran_without_panic(&format!("sdp seed #{i}"), move || {
+            let _ = parse_sdp(&s);
+        }) {
+            failures.push(l);
+        }
+    }
+    assert!(failures.is_empty(), "parsers panicked on: {failures:?}");
+}
+
+#[test]
+fn parsers_never_panic_on_mutation_sweep() {
+    // ~20k deterministic mutations across all four parsers from the seed set.
+    let mut rng = Rng(0x9E3779B97F4A7C15);
+    let seeds: Vec<Vec<u8>> = adversarial_seeds().into_iter().chain(sdp_seeds()).collect();
+    let mut failures = Vec::new();
+    for round in 0..5000u32 {
+        let base = &seeds[(round as usize) % seeds.len()];
+        let m = mutate(base, &mut rng);
+        let s = m.clone();
+        if let Err(l) = ran_without_panic(&format!("sip mut #{round}"), move || drive_sip(&s)) {
+            failures.push(l);
+        }
+        let s = m.clone();
+        if let Err(l) = ran_without_panic(&format!("sdp mut #{round}"), move || {
+            let _ = parse_sdp(&s);
+        }) {
+            failures.push(l);
+        }
+        let s = m.clone();
+        if let Err(l) = ran_without_panic(&format!("rtp mut #{round}"), move || {
+            let _ = parse_rtp_header(&s);
+        }) {
+            failures.push(l);
+        }
+        let s = m.clone();
+        if let Err(l) = ran_without_panic(&format!("rtcp mut #{round}"), move || {
+            let _ = parse_rtcp(&s);
+        }) {
+            failures.push(l);
+        }
+        if !failures.is_empty() {
+            break; // fail fast with the first crashing input class
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "mutation sweep crashed on: {failures:?}"
+    );
+}

--- a/tests/schemas/message.schema.json
+++ b/tests/schemas/message.schema.json
@@ -30,7 +30,9 @@
     "call_id": { "type": "string" },
     "from": { "type": "string" },
     "to": { "type": "string" },
+    "contact": { "type": "string" },
     "ua": { "type": "string" },
+    "sdp": { "type": "string" },
     "cseq": {
       "type": "object",
       "additionalProperties": false,

--- a/website/config.toml
+++ b/website/config.toml
@@ -22,7 +22,7 @@ enabled = true
 theme = "ayu-dark"
 
 [extra]
-version = "0.4.8"
+version = "0.4.9"
 github_url = "https://github.com/NormB/sipnab"
 author = "Norm Brandinger"
 linkedin_url = "https://www.linkedin.com/in/nbrandinger"

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2115" data-suffix="">2115</span>
+        <span class="arch-stat" data-count="2129" data-suffix="">2129</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Hardening release driven by an adversarial review of the **siptest** harness. New
fixtures + a field-level cross-check surfaced **five real defects**, each fixed
tests-first (red → green) with adversarial-input coverage. Full suite green
(2129 tests), clippy/fmt clean.

## Added
- **`--json` emits `contact` + raw `sdp`** (SNB-0009) — lets consumers verify the
  routing target and negotiated media (connection / `m=` / `a=rtpmap`).
  `schema_version` stays 1; schema + `docs/output-formats.md` updated.
- **Extension-enumeration detection** (SNB-0010) — distinct-target tracking raises
  `detection=enumeration`, catching **UA-randomized / INVITE-based / low-and-slow**
  sweeps that signature (`ua_pattern`) and pure-rate detection both miss.
- **Deterministic parser no-panic gate** (`tests/fuzz_corpus_replay.rs`) over
  `parse_sip`/`parse_sdp`/`parse_rtp_header`/`parse_rtcp`, complementing the
  nightly `cargo fuzz` targets.

## Fixed
- **IP-fragmented SIP was dropped** (SNB-0011) — the reassembled datagram's
  transport header is now re-parsed (`parse::reparse_transport`), recovering the
  ports/payload (e.g. a >MTU INVITE with a large SDP).
- **Out-of-order TCP gap-fill** (SNB-0012) — a later segment that fills a gap now
  completes a stalled PSH instead of buffering forever.
- **stdio MCP process leak** (SNB-0013) — `--mcp` now exits on client disconnect
  (stdin EOF) instead of spinning until SIGINT.

All defects were found by new siptest coverage: field-digest cross-check, IPv6 /
fragmentation / out-of-order fixtures, a UA-randomized enumeration adversary, and
a real `--mcp` stdio JSON-RPC correctness + injection test.