### PR TITLE
Release v0.4.10: IPv6 fragment reassembly (SNB-0014)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.10] - 2026-06-23
+
+### Fixed
+- **IPv6-fragmented SIP is now reassembled and decoded** (SNB-0014). The
+  IPv4-fragment fix (SNB-0011, 0.4.9) handled IPv4 only. IPv6 carries
+  fragmentation in a **Fragment extension header**, not the base header, but
+  `parse_packet` hardcoded `ip_id`/`fragment_offset`/`more_fragments` to
+  `None/None/false` for IPv6 — so `PacketProcessor` never routed IPv6 fragments
+  to the reassembler and each fragment was mis-parsed as a whole datagram,
+  silently dropping the message (a large INVITE with SDP over IPv6 decoded to
+  0; tshark saw it). `parse_packet` now walks the IPv6 extension headers and, on
+  a Fragment header, pulls its offset / MF / 32-bit identification so the
+  reassembler keys and reassembles it; `reparse_transport` then recovers the
+  transport header from the reassembled payload. `ParsedPacket.ip_id` widened
+  `u16 → u32` (the IPv6 fragment id is 32-bit; the IPv4 16-bit id casts up).
+
 ## [0.4.9] - 2026-06-23
 
 Hardening release driven by an adversarial review of the `siptest` harness: new

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,7 +3755,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [package]
 name = "sipnab"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Norm Brandinger"]

--- a/src/capture/parse.rs
+++ b/src/capture/parse.rs
@@ -9,7 +9,7 @@ use std::net::IpAddr;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use etherparse::{IpNumber, NetSlice, SlicedPacket, TransportSlice};
+use etherparse::{IpNumber, Ipv6ExtensionSlice, NetSlice, SlicedPacket, TransportSlice};
 
 use super::packet::Packet;
 
@@ -85,8 +85,10 @@ pub struct ParsedPacket {
     pub transport: TransportProto,
     /// Transport-layer payload bytes (e.g., SIP message body, RTP packet).
     pub payload: bytes::Bytes,
-    /// IPv4 identification field for fragment tracking (`None` for IPv6).
-    pub ip_id: Option<u16>,
+    /// IP fragment identification (IPv4 16-bit `Identification`, or the IPv6
+    /// Fragment extension header's 32-bit `Identification`) for reassembly
+    /// keying. `None` when the packet is not fragmented.
+    pub ip_id: Option<u32>,
     /// TCP sequence number (present only for TCP packets).
     pub tcp_seq: Option<u32>,
     /// TCP flags (present only for TCP packets).
@@ -407,7 +409,7 @@ fn extract_parsed_packet(
             (
                 IpAddr::V4(hdr.source_addr()),
                 IpAddr::V4(hdr.destination_addr()),
-                Some(hdr.identification()),
+                Some(u32::from(hdr.identification())),
                 Some(hdr.fragments_offset().value()),
                 hdr.more_fragments(),
                 hdr.protocol().0,
@@ -415,13 +417,31 @@ fn extract_parsed_packet(
         }
         NetSlice::Ipv6(v6) => {
             let hdr = v6.header();
+            // IPv6 fragmentation is carried in a Fragment extension header, not
+            // the base header — pull its offset / MF / 32-bit id so fragments
+            // are reassembled (otherwise each fragment is mis-parsed as a whole
+            // datagram and the SIP message is silently dropped).
+            let (foff, more, id) = {
+                let mut found = (None, false, None);
+                for ext in v6.extensions().clone() {
+                    if let Ipv6ExtensionSlice::Fragment(f) = ext {
+                        found = (
+                            Some(f.fragment_offset().value()),
+                            f.more_fragments(),
+                            Some(f.identification()),
+                        );
+                        break;
+                    }
+                }
+                found
+            };
             (
                 IpAddr::V6(hdr.source_addr()),
                 IpAddr::V6(hdr.destination_addr()),
-                None,
-                None,
-                false,
-                // For IPv6, use the ip_number from the payload (after ext headers)
+                id,
+                foff,
+                more,
+                // the ip_number from the payload (after ext headers)
                 v6.payload().ip_number.0,
             )
         }

--- a/src/capture/reassembly.rs
+++ b/src/capture/reassembly.rs
@@ -33,7 +33,7 @@ const MAX_TCP_BUFFER: usize = 65536;
 struct FragmentKey {
     src: IpAddr,
     dst: IpAddr,
-    ip_id: u16,
+    ip_id: u32,
     protocol: u8,
 }
 
@@ -562,7 +562,7 @@ mod tests {
     fn make_fragment(
         src: IpAddr,
         dst: IpAddr,
-        ip_id: u16,
+        ip_id: u32,
         offset: u16, // in 8-byte units
         more_fragments: bool,
         payload: &[u8],
@@ -660,7 +660,7 @@ mod tests {
         let mut r = FragmentReassembler::with_limits(1000, DEFAULT_TTL);
         let src = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
-        for i in 0..1001u16 {
+        for i in 0..1001u32 {
             // Unique ip_id per fragment → unique reassembly key.
             let f = make_fragment(src, dst, i, 0, true, &[0xAA; 8]);
             r.insert(&f);

--- a/website/config.toml
+++ b/website/config.toml
@@ -22,7 +22,7 @@ enabled = true
 theme = "ayu-dark"
 
 [extra]
-version = "0.4.9"
+version = "0.4.10"
 github_url = "https://github.com/NormB/sipnab"
 author = "Norm Brandinger"
 linkedin_url = "https://www.linkedin.com/in/nbrandinger"


### PR DESCRIPTION
Fixes the IPv6 sibling of the IPv4-fragment bug shipped in 0.4.9.

## Fixed
- **IPv6-fragmented SIP is now reassembled** (SNB-0014). IPv6 carries
  fragmentation in a **Fragment extension header**, not the base header, but
  `parse_packet` hardcoded `ip_id`/`fragment_offset`/`more_fragments` to
  `None/None/false` for IPv6 — so fragments were never reassembled and each was
  mis-parsed as a whole datagram, silently dropping the message (a large INVITE
  with SDP over IPv6 decoded to 0; tshark saw it).
- `parse_packet` now walks the IPv6 extension headers and pulls the Fragment
  header's offset / MF / 32-bit identification; the existing reassembler +
  `reparse_transport` (SNB-0011) complete the job. `ParsedPacket.ip_id` widened
  `u16 → u32` (IPv6 frag id is 32-bit).

Found by a new siptest `ipstack/ipv6-fragmented` fixture (VLAN/QinQ/GRE encap
also added there as regression guards — sipnab already handled those). All
pre-commit/pre-push checks green; 2129 tests pass.