### PR TITLE
Release v0.4.11: structured --alert-json alert channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.11] - 2026-06-24
+
+### Added
+- **`--alert-json` structured alert channel.** Security alerts could previously
+  only be consumed by scraping the human `[ALERT] <type> src=<ip> <detail>`
+  stderr line, which is brittle to any format change. With `--alert-json`, each
+  fired alert is also emitted as one JSON object per line on **stderr** —
+  `{"ts","alert","src","detail"}` — a stable machine channel. stdout stays
+  reserved for `--json` message output and the stdio MCP wire, so the JSON alert
+  lines go to stderr (safe even mid-MCP-session). `serde_json` escapes
+  attacker-controlled detail, so a crafted UA/Call-ID can't break the line or
+  inject a field.
+
 ## [0.4.10] - 2026-06-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,7 +3755,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [package]
 name = "sipnab"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Norm Brandinger"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -589,6 +589,12 @@ pub struct Cli {
     #[arg(long)]
     pub syslog: bool,
 
+    /// Emit each security alert as a structured JSON line on stderr (in addition
+    /// to the human `[ALERT]` line) — a stable machine channel that survives log
+    /// format changes. stdout stays reserved for `--json` / MCP.
+    #[arg(long)]
+    pub alert_json: bool,
+
     // ── TLS / Decryption ─────────────────────────────────────────────
     /// TLS private key (PEM) for TLS 1.2 RSA-key-exchange decryption. Only
     /// non-PFS RSA handshakes; ECDHE/DHE (forward secrecy) need --keylog.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1253,6 +1253,9 @@ fn run_batch_mode(
     if cli.syslog {
         alert_engine.set_syslog(true);
     }
+    if cli.alert_json {
+        alert_engine.set_json_output(true);
+    }
     let alert_engine = Arc::new(RwLock::new(alert_engine));
 
     let mut engines = DetectionEngines {

--- a/src/security/alerting.rs
+++ b/src/security/alerting.rs
@@ -152,6 +152,8 @@ pub struct AlertEngine {
     exec_cmd: Option<String>,
     /// Whether to send alerts to syslog via `libc::syslog()`.
     syslog_enabled: bool,
+    /// Whether to emit each fired alert as a structured JSON line on stderr.
+    json_output: bool,
     /// Tracked child processes from exec commands (for reaping).
     #[cfg(feature = "native")]
     children: Vec<std::process::Child>,
@@ -179,6 +181,7 @@ impl AlertEngine {
             cooldowns: HashMap::new(),
             exec_cmd: exec_cmd.map(|c| migrate_alert_template(&c)),
             syslog_enabled: false,
+            json_output: false,
             #[cfg(feature = "native")]
             children: Vec::new(),
             findings: std::collections::VecDeque::with_capacity(DEFAULT_FINDINGS_HISTORY),
@@ -230,6 +233,16 @@ impl AlertEngine {
         self.syslog_enabled = enabled;
     }
 
+    /// Enable or disable the structured JSON alert channel.
+    ///
+    /// When enabled, each fired alert is also written as one JSON object per
+    /// line to **stderr** (stdout is reserved for `--json` message output and
+    /// the stdio MCP wire) — a stable machine channel for consumers that
+    /// shouldn't have to scrape the human `[ALERT]` line.
+    pub fn set_json_output(&mut self, enabled: bool) {
+        self.json_output = enabled;
+    }
+
     /// Fire an alert for the given type and source.
     ///
     /// Checks cooldown for the (source, alert_type) pair. If cooled down,
@@ -273,6 +286,8 @@ impl AlertEngine {
         // Sanitize attacker-controlled values for log output (M3)
         let sanitized_detail = sanitize_log_value(detail);
 
+        let fired_at = chrono::Utc::now();
+
         // Phase 8.3 — store the finding in the ring buffer (after cooldown,
         // before any logging/syslog/exec) so deduplicated firings are
         // recorded once each.
@@ -284,7 +299,7 @@ impl AlertEngine {
                 rule_name: alert_type.to_string(),
                 src_ip,
                 detail: sanitized_detail.clone(),
-                timestamp: chrono::Utc::now(),
+                timestamp: fired_at,
             });
         }
 
@@ -296,6 +311,15 @@ impl AlertEngine {
             alert_type, %src_ip, %sanitized_detail,
             "[ALERT] {alert_type} src={src_ip} {sanitized_detail}"
         );
+
+        // Structured machine channel: one JSON object per line on STDERR (the
+        // MCP/`--json` wire is stdout, so stderr is safe even mid-session).
+        if self.json_output {
+            eprintln!(
+                "{}",
+                alert_json_line(alert_type, src_ip, &sanitized_detail, fired_at)
+            );
+        }
 
         // Send to syslog if enabled (native only — requires libc)
         #[cfg(feature = "native")]
@@ -352,6 +376,26 @@ fn migrate_alert_template(template: &str) -> String {
 /// Replaces `\r` and `\n` with spaces to prevent log injection attacks.
 pub fn sanitize_log_value(s: &str) -> String {
     s.replace(['\r', '\n'], " ")
+}
+
+/// Format one alert as a single JSON line for the `--alert-json` machine channel.
+///
+/// Fields: `ts` (RFC 3339), `alert` (type/rule), `src` (source IP), `detail`
+/// (the sanitized detail string). serde_json escapes attacker-controlled values,
+/// so a crafted UA/Call-ID can't break the line or inject fields.
+pub fn alert_json_line(
+    alert_type: &str,
+    src_ip: IpAddr,
+    detail: &str,
+    ts: chrono::DateTime<chrono::Utc>,
+) -> String {
+    serde_json::json!({
+        "ts": ts.to_rfc3339(),
+        "alert": alert_type,
+        "src": src_ip.to_string(),
+        "detail": detail,
+    })
+    .to_string()
 }
 
 // ── Syslog support (native only — requires libc) ────────────────────
@@ -594,5 +638,32 @@ mod tests {
             result, "hello  world",
             "\\r and \\n should each be replaced with a space"
         );
+    }
+
+    #[test]
+    fn alert_json_line_has_expected_fields() {
+        let ts = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 6, 24, 1, 2, 3).unwrap();
+        let line = alert_json_line(
+            "scanner",
+            test_ip(),
+            "method=OPTIONS detection=enumeration",
+            ts,
+        );
+        let v: serde_json::Value = serde_json::from_str(&line).expect("valid JSON line");
+        assert_eq!(v["alert"], "scanner");
+        assert_eq!(v["src"], "10.0.0.1");
+        assert_eq!(v["detail"], "method=OPTIONS detection=enumeration");
+        assert!(v["ts"].as_str().unwrap().starts_with("2026-06-24T01:02:03"));
+    }
+
+    #[test]
+    fn alert_json_line_escapes_adversarial_detail() {
+        // a crafted detail (embedded quote/brace) must stay inside the string,
+        // not break the line or inject a sibling field.
+        let ts = chrono::Utc::now();
+        let line = alert_json_line("scanner", test_ip(), r#"ua="evil","injected":1"#, ts);
+        let v: serde_json::Value = serde_json::from_str(&line).expect("still valid JSON");
+        assert!(v.get("injected").is_none(), "no injected field");
+        assert_eq!(v["detail"], r#"ua="evil","injected":1"#);
     }
 }

--- a/tests/cli_options_test.rs
+++ b/tests/cli_options_test.rs
@@ -774,6 +774,13 @@ fn alert_json_flag() {
 }
 
 #[test]
+fn alert_json_output_flag() {
+    // structured JSON alert channel (--alert-json) is accepted without crashing
+    let (_, _, code) = run_json(&["--alert-json"]);
+    assert_eq!(code, 0);
+}
+
+#[test]
 fn exec_rate_limit_flag() {
     let (_, _, code) = run_json(&["--exec-rate-limit", "5"]);
     assert_eq!(code, 0);

--- a/website/config.toml
+++ b/website/config.toml
@@ -22,7 +22,7 @@ enabled = true
 theme = "ayu-dark"
 
 [extra]
-version = "0.4.10"
+version = "0.4.11"
 github_url = "https://github.com/NormB/sipnab"
 author = "Norm Brandinger"
 linkedin_url = "https://www.linkedin.com/in/nbrandinger"

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -240,7 +240,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label">Adaptive poll (active/idle)</span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2129" data-suffix="">2129</span>
+        <span class="arch-stat" data-count="2132" data-suffix="">2132</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
## Added
- **`--alert-json`** — security alerts are emitted as one structured JSON object
  per line on stderr (`{ts, alert, src, detail}`), a stable machine channel
  instead of scraping the human `[ALERT]` line. stdout stays reserved for
  `--json` / the stdio MCP wire; serde_json escapes attacker-controlled detail
  so a crafted UA/Call-ID can't break the line or inject a field.

TDD: `alert_json_line()` unit tests (fields + adversarial escape) + CLI accept
test. Consumed by siptest's security suite (`sipnab_security_alerts_json`).