### PR TITLE
test(call-flow): validate ladder arrow direction (request ▶ / response ◀)

### DIFF
--- a/src/tui/call_flow/prepare.rs
+++ b/src/tui/call_flow/prepare.rs
@@ -1558,6 +1558,34 @@ mod tests {
         );
     }
 
+    // ── Arrow direction: response reverses the request's swimlanes ────
+    // The direct-buffer (TUI) renderer draws each arrow from src_col→dst_col, so
+    // direction is decided here. A request is A→B; its response is B→A, so the
+    // response's (src_col, dst_col) must be the request's reversed. This is the
+    // end-to-end guard the UI tests previously lacked.
+    #[test]
+    fn prepare_response_reverses_request_columns() {
+        let theme = Theme::default();
+        let o = opts(&theme);
+        let msgs = vec![
+            invite("cdir", 1, t0()), // request  A→B
+            response("cdir", 200, "OK", 1, "INVITE", t0() + TimeDelta::seconds(1)), // response B→A
+        ];
+        let (parts, prepared) = prepare_messages(&msgs, t0(), None, &o, &HashSet::new());
+        assert_eq!(parts.len(), 2, "two distinct endpoints expected");
+        let reqm = prepared.iter().find(|m| !m.is_response).expect("request");
+        let respm = prepared.iter().find(|m| m.is_response).expect("response");
+        assert_ne!(
+            reqm.src_col, reqm.dst_col,
+            "request must span the two swimlanes"
+        );
+        assert_eq!(
+            (respm.src_col, respm.dst_col),
+            (reqm.dst_col, reqm.src_col),
+            "response columns must be the reverse of the request — i.e. the arrow points the other way"
+        );
+    }
+
     // ── prepare_messages: scaled spacer insertion ─────────────────────
 
     #[test]

--- a/src/tui/call_flow/render.rs
+++ b/src/tui/call_flow/render.rs
@@ -1244,6 +1244,83 @@ mod tests {
         assert_eq!(lines.len(), 1);
     }
 
+    // ── Arrow DIRECTION: requests and responses point opposite ways ────
+    // A request travels A→B (arrowhead ▶ on the right); its response travels
+    // B→A (arrowhead ◀ on the left). Regression guard for the gap where the
+    // ladder direction was never asserted end to end — only the request/response
+    // *src↔dst* swap makes the arrow flip, so this exercises real A→B / B→A
+    // messages, not the glyph helper in isolation.
+    #[test]
+    fn ladder_request_points_right_response_points_left() {
+        let theme = crate::tui::Theme::default();
+        // req() is A→B, resp() is B→A (src/dst swapped), as on a real wire.
+        let msgs = vec![
+            req("INVITE", "1 INVITE", "dir-call", base_ts()),
+            resp(200, "OK", "1 INVITE", "dir-call", base_ts()),
+        ];
+        let lines = format_ladder(&msgs, base_ts(), None, 48, &theme);
+        let text: Vec<String> = lines.iter().map(line_to_string).collect();
+        let invite = text
+            .iter()
+            .find(|l| l.contains("INVITE"))
+            .expect("INVITE row");
+        let ok = text.iter().find(|l| l.contains("200")).expect("200 OK row");
+
+        // Request: rightward only.
+        assert!(
+            invite.contains('\u{25B6}') && !invite.contains('\u{25C0}'),
+            "request must point right (▶), got: {invite:?}"
+        );
+        // Response: leftward only — the bug the perf.pcap capture *looked* like
+        // (it was actually one-directional synthetic data; here the response is
+        // genuinely B→A and must reverse).
+        assert!(
+            ok.contains('\u{25C0}') && !ok.contains('\u{25B6}'),
+            "response must point left (◀), got: {ok:?}"
+        );
+    }
+
+    // Faithful rendering: when a (malformed/synthetic) response carries the SAME
+    // src→dst as the request — e.g. a one-directional load corpus — the arrow
+    // follows the actual packet addresses (forward), it is NOT force-flipped by
+    // status code. This documents that arrow direction is wire-driven.
+    #[test]
+    fn ladder_arrow_follows_actual_src_dst_not_status() {
+        let theme = crate::tui::Theme::default();
+        // Build a 200 OK that (wrongly) travels A→B, like perf.pcap's responses.
+        let raw = build_raw(
+            "SIP/2.0 200 OK",
+            &[
+                "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bKfwd",
+                "From: \"Alice\" <sip:alice@10.0.0.1>;tag=t1",
+                "To: \"Bob\" <sip:bob@10.0.0.2>;tag=t2",
+                "Call-ID: fwd-call",
+                "CSeq: 1 INVITE",
+            ],
+            "",
+        );
+        let fwd_resp = crate::sip::parser::parse_sip(
+            &raw,
+            base_ts(),
+            ip_a(),
+            ip_b(), // A→B, NOT swapped
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("parse");
+        let msgs = vec![req("INVITE", "1 INVITE", "fwd-call", base_ts()), fwd_resp];
+        let lines = format_ladder(&msgs, base_ts(), None, 48, &theme);
+        let text: Vec<String> = lines.iter().map(line_to_string).collect();
+        let ok = text.iter().find(|l| l.contains("200")).expect("200 OK row");
+        // Same src→dst as the request ⇒ same (rightward) direction. Faithful to
+        // the wire, not flipped by the 2xx status.
+        assert!(
+            ok.contains('\u{25B6}') && !ok.contains('\u{25C0}'),
+            "a response that travels A→B on the wire must render forward, got: {ok:?}"
+        );
+    }
+
     #[test]
     fn format_ladder_produces_lines() {
         use crate::sip::parser::parse_sip;

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -244,7 +244,7 @@ sipnab -I capture.pcap --call-report "abc123@host" --markdown</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2158" data-suffix="">2132</span>
+        <span class="arch-stat" data-count="2161" data-suffix="">2132</span>
         <span class="arch-label">Automated tests</span>
       </div>
     </div>


### PR DESCRIPTION
Closes a real UI test-coverage gap: arrow **direction** was never asserted end to end (only the glyph helper in isolation). Three guards:

- `prepare_response_reverses_request_columns` — a response (B→A) gets the request's (src_col,dst_col) reversed (the direct-buffer TUI renderer draws from these).
- `ladder_request_points_right_response_points_left` — `format_ladder` renders ▶ for the request and ◀ for the genuinely-swapped response.
- `ladder_arrow_follows_actual_src_dst_not_status` — a response that travels A→B on the wire renders forward; direction is wire-driven, not forced by status code.

Context: the report capture that looked like responses weren't flipped was a **synthetic one-directional load corpus** (its 401/200 carry the same src→dst as the request), so sipnab faithfully drew them forward — confirmed against the wire and now locked in by these tests. Count 2158→2161.