### PR TITLE
docs: sync documentation with the codebase (32 verified fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ All sngrep keybindings are supported. Press `F1` for the full shortcut reference
 | `tui`      | Interactive terminal UI (ratatui + crossterm)                        | yes     |
 | `audio`    | RTP audio playback in TUI via the lazily-loaded `sipnab-audio` plugin + WAV export | yes     |
 | `tls`      | TLS/DTLS decryption + SRTP key extraction (ring, zeroize, rustls)    | no      |
-| `hep`      | HEP v2/v3 send + receive (Homer Encapsulation Protocol)              | no      |
+| `hep`      | HEP v3 send + HEP v2/v3 receive (Homer Encapsulation Protocol)              | no      |
 | `api`      | REST API + Prometheus metrics endpoint (axum, tokio)                 | no      |
 | `mcp`      | Model Context Protocol server, stdio transport (rmcp)                | no      |
 | `mcp-http` | MCP server over HTTP (Streamable-HTTP). Implies `mcp` + `api`.       | no      |

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -5,8 +5,8 @@ authenticate clients with `Authorization: Bearer <token>`. sipnab supports two
 token kinds, checked with a constant-time comparison:
 
 1. **Static secrets** — `--api-key` / `--mcp-token` (or `--mcp-token-file`,
-   `$SIPNAB_API_SIGNING_KEY`-style env). A fixed shared secret with **no
-   expiry**. Simple, but cannot be expired or revoked without restarting.
+   `$SIPNAB_API_KEY` / `$SIPNAB_MCP_TOKEN` env). A fixed shared secret with
+   **no expiry**. Simple, but cannot be expired or revoked without restarting.
 2. **Signed self-describing tokens** — HMAC-signed tokens that carry their own
    expiry and id, enabling **expiry, rotation, and revocation** without a
    server-side session store. This page documents those.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -141,6 +141,7 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--digest-leak` | -- | off | Detect digest credential leaks in SIP messages |
 | `--alert` | `<CHANNEL>` | -- | Alert channels (repeatable): `syslog`, `json`, `exec` |
 | `--alert-exec` | `<CMD>` | -- | Execute this command when an alert fires |
+| `--alert-json` | -- | off | Emit each security alert as a structured JSON line on stderr (in addition to the human `[ALERT]` line) |
 | `--stir-shaken` | -- | off | Validate STIR/SHAKEN identity headers |
 
 ## Event Execution
@@ -156,7 +157,7 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | Flag | Value | Default | Description |
 |------|-------|---------|-------------|
 | `--metrics` | `<ADDR>` | -- | Prometheus metrics endpoint (e.g., `0.0.0.0:9090`). Feature: `api` |
-| `--metrics-auth` | `<TOKEN>` | -- | Bearer token for metrics endpoint authentication |
+| `--metrics-auth` | `<USER:PASS>` | -- | HTTP Basic auth credentials (`user:pass`) required by the metrics endpoint; requests must send `Authorization: Basic <base64>` |
 | `--api` | `<ADDR>` | -- | REST API endpoint (e.g., `0.0.0.0:8080`). Feature: `api` |
 | `--api-key` | `<KEY>` | -- | API key for REST API authentication. Also reads `$SIPNAB_API_KEY` |
 | `--api-tls-cert` | `<FILE>` | -- | TLS certificate file for API endpoint |
@@ -211,6 +212,7 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | Flag | Value | Default | Description |
 |------|-------|---------|-------------|
 | `--max-reassembly` | `<N>` | `10000` | Maximum concurrent TCP/TLS reassembly sessions |
+| `--cores` | `<N>` | `1` | CPU cores for offline pcap reconstruction (`-I`). 1 = single-threaded; >1 shards by host pair for multi-core throughput (dialog+RTP reconstruction, `--report`/`--json`) |
 
 ## Config
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -57,6 +57,7 @@ Output and TUI display settings.
 | `payload_limit` | integer | -- | Maximum payload bytes to display |
 | `delta_time` | boolean | `false` | Show delta time between messages by default |
 | `from_to` | string | `"default"` | From/To column display: `"default"` (user else host:port), `"host-port"`, `"user"`, `"user-host-port"`. Cycle at runtime with `u`; `--from-to-mode` overrides this |
+| `visible_columns` | array | all columns | Call-list columns to show, by name (case-insensitive): `"#"`, `"Method"`, `"From"`, `"To"`, `"Source"`, `"Destination"`, `"State"`, `"Msgs"`, `"Date"`, `"PDD"`. Adjust at runtime with F10 |
 
 ```toml
 [display]
@@ -114,6 +115,10 @@ Resource limits to prevent unbounded memory growth.
 | `max_streams` | integer | `50000` | Maximum RTP streams |
 | `max_reassembly` | integer | `10000` | Maximum TCP reassembly sessions |
 | `hep_rate_limit` | integer | `50000` | Maximum HEP packets per second |
+| `max_header_line` | integer | `8192` | Maximum bytes in a single SIP header (defense-in-depth) |
+| `max_headers_per_message` | integer | `200` | Maximum SIP headers per message (defense-in-depth) |
+| `max_messages_per_dialog` | integer | `500` | Maximum stored messages per dialog (defense-in-depth) |
+| `max_audio_frames` | integer | `1500` | Maximum RTP payload frames stored per stream for WAV export (~30s at G.711 50pps) |
 
 ```toml
 [limits]

--- a/docs/filter-dsl.md
+++ b/docs/filter-dsl.md
@@ -111,7 +111,7 @@ for the MCP `find_problems` tool. They expand to DSL expressions internally.
 
 | Alias | Dedicated CLI Flag | Expansion |
 |-------|--------------------|-----------|
-| `problems` | `--problems` | `state == 'Failed' OR one_way == true OR rtp.loss > 2.0 OR rtp.jitter > 50.0 OR nat_mismatch == true OR retransmits > 3 OR pdd > 32.0 OR rtp.orphaned == true` |
+| `problems` | `--problems` | `state == 'Failed' OR one_way == true OR rtp.loss > 2.0 OR rtp.jitter > 50.0 OR nat_mismatch == true OR retransmits > 3 OR pdd > 32.0 OR rtp.orphaned == true OR codec_asymmetry == true OR ptime_asymmetry == true OR payload_asymmetry == true OR duration_asymmetry == true OR late_media == true` |
 | `slow-setup` | `--slow-setup` | `pdd > 3.0` |
 | `short-calls` | `--short-calls` | `duration < 5.0 AND state == 'Completed'` |
 | `one-way` | `--one-way` | `one_way == true` |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -77,6 +77,7 @@ Keys marked with **(configurable)** can be remapped via the `[keybindings]` conf
 | [ | Scroll detail panel up |
 | ] | Scroll detail panel down |
 | e | Expand/collapse the selected fold header (retransmissions, auth retries) |
+| f | Filter the ladder to the selected message's transaction (toggle) |
 | m | Set mark at current message |
 | M | Clear mark |
 | E | Export Mermaid sequence diagram to clipboard |

--- a/docs/mcp-overview.md
+++ b/docs/mcp-overview.md
@@ -105,7 +105,7 @@ troubleshooting.
 - **Localhost-default.** HTTP transport binds `127.0.0.1:8731` unless
   explicitly overridden.
 - **Bearer auth on non-loopback.** Tokens compared in constant time
-  via the existing `output::api::constant_time_eq` helper, sharing
+  via the shared `crypto::constant_time_eq` helper (through `auth::TokenVerifier`), sharing
   the same code path as the REST API.
 - **No prompt-injection cooperation.** Tool descriptions never
   instruct the LLM to "trust" or "act on" returned content; they
@@ -128,7 +128,7 @@ SIPNAB_LOG level you reproduced it under.
 ```toml
 mcp       # stdio transport (rmcp dep, ~3 MB binary cost)
 mcp-http  # HTTP transport (mcp + api; rmcp/transport-streamable-http-server)
-full      # default + tui + tls + hep + api + audio + mcp + mcp-http
+full      # native + tui + tls + hep + api + audio + mcp + mcp-http
 ```
 
 The default build does not include `mcp` — operators who'll never

--- a/man/sipnab.1
+++ b/man/sipnab.1
@@ -1,7 +1,7 @@
 .\" sipnab.1 -- man page for sipnab
 .\" Copyright 2024-2026 Norm Brandinger
 .\" License: GPL-3.0-only
-.TH SIPNAB 1 "2026-04-09" "sipnab 0.1.0" "User Commands"
+.TH SIPNAB 1 "2026-07-02" "sipnab 0.4.18" "User Commands"
 .SH NAME
 sipnab \- SIP & RTP capture, analysis, and security tool
 .SH SYNOPSIS

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -4,7 +4,7 @@ weight = 7
 description = "REST API endpoints, Prometheus metrics, and HEP protocol integration."
 +++
 
-sipnab includes an optional REST API and Prometheus metrics endpoint, enabled with the `api` feature flag. The API runs in an isolated child process with no access to capture file descriptors or key material.
+sipnab includes an optional REST API and Prometheus metrics endpoint, enabled with the `api` feature flag. The API runs as a thread inside the sipnab process, reading the same in-memory dialog/stream stores as the capture pipeline (read-only — it never mutates capture state).
 
 > **Looking for AI-agent access?** sipnab also exposes the same dialog / RTP / diagnostic data as a Model Context Protocol server. See [MCP Server](@/docs/mcp.md) -- the MCP path uses the same in-memory stores as this REST API, so a running sipnab instance can serve both surfaces simultaneously.
 
@@ -60,17 +60,22 @@ The REST API requires a bearer token passed via the `--api-key` flag or the `$SI
 curl -H "Authorization: Bearer your-secret-key" http://127.0.0.1:8080/v1/dialogs
 ```
 
-The metrics endpoint optionally requires a bearer token via `--metrics-auth`.
+The REST API's `/metrics` endpoint is guarded by the same Bearer token as
+every other endpoint. The *standalone* metrics server (`--metrics <ADDR>`)
+is separate: it uses HTTP Basic auth via `--metrics-auth <user:pass>`.
 
 All endpoints except `/health` require authentication when an API key is configured. Missing or invalid keys return `401 Unauthorized`. Key comparison uses constant-time comparison to prevent timing side-channel attacks.
 
 ## API TLS
 
-Secure the API endpoint with TLS:
+Direct TLS termination on the API endpoint is **not yet implemented** —
+supplying `--api-tls-cert`/`--api-tls-key` makes sipnab refuse to start
+with an explanatory error. Terminate TLS in a reverse proxy (nginx,
+Caddy, HAProxy) in front of a loopback-bound API instead:
 
 ```bash
-sipnab -d eth0 --api 0.0.0.0:8443 --api-key "secret" \
-  --api-tls-cert /etc/sipnab/cert.pem --api-tls-key /etc/sipnab/key.pem
+sipnab -d eth0 --api 127.0.0.1:8080 --api-key "secret"
+# then proxy https://host/ -> http://127.0.0.1:8080 in your reverse proxy
 ```
 
 ## Connection Limits
@@ -306,8 +311,6 @@ console.log(`State: ${dialog.state}`);
       "mode": "sendrecv"
     }
   ],
-  "refer_to": null,
-  "siprec_metadata": null,
   "diagnosis": {
     "one_way_audio": false,
     "nat_mismatch": false,
@@ -338,8 +341,6 @@ console.log(`State: ${dialog.state}`);
 
 **Additional dialog fields:**
 
-- **`refer_to`** -- Present when a REFER transfer is detected. Contains the `Refer-To` URI extracted from the REFER request. The dialog state transitions to `Transferring` while the transfer is in progress.
-- **`siprec_metadata`** -- Present when SIPREC recording metadata is detected. Parsed from `multipart/mixed` message bodies per RFC 7866. Contains the recording session XML metadata (participant info, session identifiers, media streams).
 - **`stir_shaken`** -- When `--stir-shaken` validation is enabled, the `diagnosis.hints` array includes STIR/SHAKEN results. Tokens with an `iat` (issued-at) timestamp older than 60 seconds are rejected as `Expired` per RFC 8224 Section 12.
 
 Returns `404` if the Call-ID is not found.
@@ -634,7 +635,7 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
 
 ### GET /metrics
 
-Prometheus-compatible metrics endpoint. Returns metrics in the OpenMetrics text format.
+Prometheus-compatible metrics endpoint. Returns metrics in the Prometheus text exposition format (`text/plain; version=0.0.4`).
 
 **curl:**
 
@@ -698,14 +699,14 @@ Metric names emitted by `src/output/prometheus.rs`:
 | `sipnab_messages_total{method}` | counter | SIP messages by method (`INVITE`, `REGISTER`, …). |
 | `sipnab_rtp_streams_active` | gauge | RTP streams currently in the `Established` state. |
 | `sipnab_rtp_streams_total{status}` | counter | RTP streams by status (`established`, `orphaned`). |
-| `sipnab_capture_packets_total` | counter | Total packets captured. |
-| `sipnab_reassembly_timeouts_total` | counter | TCP/IP reassembly sessions that timed out. |
+| `sipnab_capture_queue_depth_packets` | gauge | Packets currently queued between the capture reader and the processing thread (standalone `--metrics` server). |
+| `sipnab_capture_backpressure_blocks_total` | counter | Times the capture reader blocked on a full queue (standalone `--metrics` server). |
 | `sipnab_pdd_seconds` | histogram | Post-dial delay distribution (buckets at 0.5/1/2/3/5/10s). Emits `sipnab_pdd_seconds_bucket{le}`, `_count`, `_sum`. |
 | `sipnab_mos` | histogram | RTP MOS distribution (buckets at 1/2/2.5/3/3.5/4/4.5). |
 | `sipnab_jitter_ms` | histogram | RTP jitter distribution (buckets at 5/10/20/50/100/200ms). |
 | `sipnab_loss_percent` | histogram | RTP packet-loss distribution (buckets at 0.1/0.5/1/2/5/10%). |
 
-The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane in v0.3.x — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
+The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane in v0.3.x — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
 
 ## Client Examples
 
@@ -737,9 +738,8 @@ curl -fsS "$API/v1/dialogs?from=alice&limit=20" $H | jq
 # Get one dialog with full SIP messages
 curl -fsS "$API/v1/dialogs/abc123@host" $H | jq
 
-# Get a Markdown call report
-curl -fsS "$API/v1/dialogs/abc123@host/report" $H \
-     -H 'Accept: text/markdown'
+# Get a call report (JSON — this endpoint is JSON-only)
+curl -fsS "$API/v1/dialogs/abc123@host/report" $H | jq
 
 # Non-orphaned streams (orphaned=false)
 curl -fsS "$API/v1/streams?orphaned=false" $H | jq
@@ -1418,7 +1418,7 @@ sipnab -d eth0 -H 10.0.0.50:9060
 
 ## Security Model
 
-- The API child process is isolated: no capture fd, no key material
+- The API thread only reads dialog/stream metadata: no capture fd access, no key material exposure
 - All network listeners bind to localhost by default
 - Rate limiting on all listener endpoints (100 RPS per source IP)
 - Bearer token authentication (required for API, optional for metrics)
@@ -1426,7 +1426,7 @@ sipnab -d eth0 -H 10.0.0.50:9060
 - TLS available for API endpoint
 - Connection limits prevent resource exhaustion
 
-> **Warning:** The API child process is isolated from the capture process. It has no access to capture file descriptors, TLS key material, or raw packet data. The API can only read dialog/stream metadata.
+> **Note:** The API runs as a thread in the sipnab process, sharing the in-memory dialog/stream stores read-only. It never touches capture file descriptors or TLS key material, and exposes only dialog/stream metadata — but it is not a separate OS process; treat the API bind address and key accordingly.
 
 ## Event Execution
 

--- a/website/content/docs/cli.md
+++ b/website/content/docs/cli.md
@@ -123,6 +123,7 @@ sipnab -N -I capture.pcap --json \
 | `--split` | `<CONDITION>` | -- | Split output files (e.g., `filesize:50` for 50 MiB chunks) |
 | `--replay` | -- | off | Replay packets from a pcap file at original timing |
 | `--pcapng` | -- | off | Use pcapng format for output files |
+| `--strip-secrets` | `<OUTPUT>` | -- | With `-I <input>`, write a copy of the input pcapng to `<OUTPUT>` with all Decryption Secrets Blocks removed (the `editcap --discard-all-secrets` analog), then exit. The input is never modified; the output is written atomically |
 | `<BPF_FILTER>...` | positional | -- | BPF display filter expression (trailing positional args) |
 
 ## Mode
@@ -184,12 +185,21 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | `--fail2ban` | -- | off | Output in fail2ban-compatible format for SIP security events. Requires `-N` |
 | `--group-by` | `<FIELD>` | -- | Group output by field (e.g., `call-id`, `from`, `method`) |
 
+## Name Resolution
+
+| Flag | Value | Default | Description |
+|------|-------|---------|-------------|
+| `--resolve` | -- | off | Start with name resolution enabled (manual mappings + hosts file) |
+| `--reverse-dns` | -- | off | Also resolve via reverse DNS (PTR); implies `--resolve` |
+| `--names` | `<FILE>` | -- | Preload an `/etc/hosts`-format mapping file (repeatable) |
+
 ## Dialog
 
 | Flag | Value | Default | Description |
 |------|-------|---------|-------------|
 | `-l`, `--limit` | `<N>` | `100000` | Maximum number of dialogs to track simultaneously |
-| `-R`, `--rotate` | -- | off | Rotate dialog storage when limit is reached (discard oldest) |
+| `-R`, `--rotate` | -- | **on** | Evict the oldest dialog at `--limit` capacity (LRU). On by default; the flag is kept for back-compat |
+| `--no-rotate` | -- | off | Disable rotation: drop *new* dialogs at capacity instead of evicting the oldest |
 | `--dialog-track` | `<METHOD>` | -- | Dialog tracking method: `call-id` or `branch` |
 | `--no-dialog` | -- | off | Disable dialog tracking entirely (message-only mode) |
 | `--tag` | `<TAG>` | -- | Filter dialogs by tag value |
@@ -214,6 +224,7 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | `--digest-leak` | -- | off | Detect digest credential leaks in SIP messages |
 | `--alert` | `<CHANNEL>` | -- | Alert channels (repeatable): `syslog`, `json`, `exec` |
 | `--alert-exec` | `<CMD>` | -- | Execute this command when an alert fires |
+| `--alert-json` | -- | off | Emit each security alert as a structured JSON line on stderr (in addition to the human `[ALERT]` line) |
 | `--stir-shaken` | -- | off | Validate STIR/SHAKEN identity headers |
 
 ## Event Execution
@@ -229,12 +240,16 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | Flag | Value | Default | Description |
 |------|-------|---------|-------------|
 | `--metrics` | `<ADDR>` | -- | Prometheus metrics endpoint (e.g., `0.0.0.0:9090`). Feature: `api` |
-| `--metrics-auth` | `<TOKEN>` | -- | Bearer token for metrics endpoint authentication |
+| `--metrics-auth` | `<USER:PASS>` | -- | HTTP Basic auth credentials (`user:pass`) required by the metrics endpoint; requests must send `Authorization: Basic <base64>` |
 | `--api` | `<ADDR>` | -- | REST API endpoint (e.g., `0.0.0.0:8080`). Feature: `api` |
 | `--api-key` | `<KEY>` | -- | API key for REST API authentication. Also reads `$SIPNAB_API_KEY` |
 | `--api-tls-cert` | `<FILE>` | -- | TLS certificate file for API endpoint |
 | `--api-tls-key` | `<FILE>` | -- | TLS private key file for API endpoint |
 | `--api-max-conn` | `<N>` | `100` | Maximum concurrent API connections |
+| `--api-signing-key` | `<HEX>` | -- | HMAC signing key (hex) for revocable API tokens |
+| `--api-signing-key-file` | `<FILE>` | -- | Read the API HMAC signing key from a file |
+| `--api-revoked-file` | `<FILE>` | -- | File listing revoked API token IDs (one per line) |
+| `--api-token-ttl` | `<SECS>` | -- | Lifetime for minted API tokens |
 | `-L`, `--hep-listen` | `<ADDR>` | -- | Listen for HEP (Homer Encapsulation Protocol) packets. Feature: `hep` |
 | `-H`, `--hep-send` | `<ADDR>` | -- | Send captured packets via HEP to a remote collector. Feature: `hep` |
 | `-E`, `--hep-parse` | -- | off | Parse incoming HEP packets (enable HEP decoding). Feature: `hep` |
@@ -255,6 +270,12 @@ it. See [MCP Server](@/docs/mcp.md) for the full guide.
 | `--mcp-token` | `<TOKEN>` | -- | Bearer token for HTTP MCP. Required for non-loopback binds. Also reads `$SIPNAB_MCP_TOKEN` |
 | `--mcp-token-file` | `<FILE>` | -- | Read MCP bearer token from a file (preferred over env in systemd units) |
 | `--mcp-allowed-host` | `<HOST>` | -- | Additional Host header values the HTTP MCP server will accept (repeatable). rmcp's DNS-rebind protection defaults to allowing only `localhost`, `127.0.0.1`, and `::1`; add the public hostname or bind IP clients actually use. `*` disables host checking entirely (not recommended; pair the resulting open binding with a network-level allowlist) |
+| `--mcp-signing-key` | `<HEX>` | -- | HMAC signing key (hex) for revocable MCP tokens |
+| `--mcp-signing-key-file` | `<FILE>` | -- | Read the MCP HMAC signing key from a file |
+| `--mcp-revoked-file` | `<FILE>` | -- | File listing revoked MCP token IDs (one per line) |
+| `--mcp-token-ttl` | `<SECS>` | -- | Lifetime for minted MCP tokens |
+| `--mint-token` | -- | off | Mint a signed bearer token (using the API/MCP signing key) and exit |
+| `--token-id` | `<ID>` | -- | Token ID to embed when minting with `--mint-token` |
 
 ## TLS / Decryption
 
@@ -265,7 +286,7 @@ it. See [MCP Server](@/docs/mcp.md) for the full guide.
 | `--keylog-watch` | -- | off | Watch key log file for new entries (live decryption). Feature: `tls` |
 | `--dtls-keylog` | `<FILE>` | -- | DTLS key log file for SRTP key extraction. Feature: `tls` |
 | `--srtp-keys` | `<FILE>` | -- | SRTP master keys file for RTP decryption. Feature: `tls` |
-| `--pcap-export-mode` | `<MODE>` | `decrypted` | Pcap export mode for encrypted traffic: `decrypted` (plaintext payloads, no DSB), `raw` (original encrypted bytes, no DSB), `wired` (original encrypted bytes + Decryption Secrets Block so Wireshark can decrypt) |
+| `--pcap-export-mode` | `<MODE>` | `decrypted` | Pcap export mode for encrypted traffic: `decrypted` (plaintext payloads, no DSB), `raw` (original encrypted bytes, no DSB), `encrypted+dsb` (original encrypted bytes + Decryption Secrets Block so Wireshark can decrypt) |
 | `--allow-coredump` | -- | off | Allow core dumps (do not call `prctl` to disable them) |
 
 ## Privilege
@@ -275,12 +296,14 @@ it. See [MCP Server](@/docs/mcp.md) for the full guide.
 | `--user` | `<USER>` | -- | Drop privileges to this user after opening capture devices |
 | `--no-priv-drop` | -- | off | Do not drop privileges after opening capture devices |
 | `--chroot` | `<DIR>` | -- | Chroot to this directory after initialization |
+| `--setup-caps` | -- | off | Grant the binary `CAP_NET_RAW`/`CAP_NET_ADMIN` via setcap (one-time, needs sudo) and exit |
 
 ## Resource Limits
 
 | Flag | Value | Default | Description |
 |------|-------|---------|-------------|
 | `--max-reassembly` | `<N>` | `10000` | Maximum concurrent TCP/TLS reassembly sessions |
+| `--cores` | `<N>` | `1` | CPU cores for offline pcap reconstruction (`-I`). 1 = single-threaded; >1 shards by host pair for multi-core throughput (dialog+RTP reconstruction, `--report`/`--json`) |
 
 ## Config
 

--- a/website/content/docs/config.md
+++ b/website/content/docs/config.md
@@ -154,6 +154,31 @@ no_priv_drop = false
 chroot = "/var/lib/sipnab"
 ```
 
+### \[names\]
+
+Address name-resolution settings (display `host:port` instead of `ip:port`).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Start with name resolution on (offline sources) |
+| `reverse_dns` | boolean | `false` | Also use reverse DNS (PTR) lookups |
+| `hosts_file` | string | -- | `/etc/hosts`-format file of IP → name mappings to preload |
+| `persist_to_config` | boolean | `false` | When set, in-TUI `N` edits are also written into the `[names.manual]` table below, preserving the rest of this file |
+| `manual` | table | -- | Inline `"IP" = "name"` mappings, loaded at startup (highest-priority manual layer) |
+
+```toml
+[names]
+enabled = true
+reverse_dns = false
+hosts_file = "/etc/sipnab/hosts"
+persist_to_config = true
+
+# Inline mappings (also written here when persist_to_config = true):
+[names.manual]
+"10.0.0.1" = "sbc-edge"
+"2001:db8::1" = "core6"
+```
+
 ### \[theme\]
 
 TUI color theme with 11 semantic color slots. See the [Theme Guide](@/docs/theme.md) for a full customization guide.

--- a/website/content/docs/keybindings.md
+++ b/website/content/docs/keybindings.md
@@ -269,6 +269,7 @@ Toggle display options without leaving the TUI.
 | \[ | Scroll detail panel up |
 | \] | Scroll detail panel down |
 | e | Expand/collapse the selected fold header (retransmissions, auth retries) |
+| f | Filter the ladder to the selected message's transaction (toggle) |
 | m | Set mark at current message. Places a reference marker on the current message. Navigate to another message to see the **delta** time between the mark and your current position -- useful for measuring delays between specific SIP messages. |
 | M | Clear mark |
 | E | Export Mermaid sequence diagram to clipboard |
@@ -416,7 +417,7 @@ Settings items: Color mode, Timestamp mode, Autoscroll, Raw preview, SDP display
 
 ## Timestamp Modes
 
-Press `t` in the Call List or Call Flow to cycle through three timestamp modes (the mode is shared across both views):
+Press `t` in the Call List or Call Flow to cycle through the timestamp modes (the mode is shared across both views):
 
 1. **Absolute** (default) -- `HH:MM:SS.mmm` wall-clock time
 2. **Delta-prev** -- `+N.NNNs` time since previous entry. Color-coded in call flow:
@@ -425,6 +426,9 @@ Press `t` in the Call List or Call Flow to cycle through three timestamp modes (
    - Red: 1 s - 5 s
    - Bold red: > 5 s
 3. **Delta-first** -- `+N.NNNs` cumulative time from first entry
+4. **Scaled** -- delta-prev timestamps plus time-proportional spacer rows, so
+   quiet gaps are visible in the ladder. The set of visible messages is
+   identical in every mode — only the presentation changes.
 
 <div class="terminal">
 <div class="terminal-bar">

--- a/website/content/docs/output-formats.md
+++ b/website/content/docs/output-formats.md
@@ -33,12 +33,14 @@ Message record (fields with no value are omitted, not null):
   "call_id": "abc123@10.0.0.1",
   "from": "1001",
   "to": "1002",
+  "cseq": { "number": 1, "method": "INVITE" },
   "ua": "FreePBX-16"
 }
 ```
 
-Responses carry `status_code`, `reason`, and `response_context` (what the
-response answers) instead of `method`.
+Every message carries `cseq` (`number` + `method`) when a parseable CSeq
+header is present. Responses carry `status_code`, `reason`, and
+`response_context` (what the response answers) instead of `method`.
 
 `schema_version` increments on breaking field changes — pin your
 consumers to it.


### PR DESCRIPTION
Full docs-vs-code audit (five parallel reviews against clap, config structs, MCP tool registry, REST endpoints, filter DSL, output serializers, TUI help). 32 verified discrepancies fixed.

Highlights:
- **api.md**: the API is an in-process thread, not an "isolated child process" (security framing corrected in 3 places); API TLS documented as unimplemented (reverse-proxy guidance); `--metrics-auth` is Basic `user:pass` for the standalone metrics server only; phantom `refer_to`/`siprec_metadata` fields removed; metrics table corrected (2 dead counters → caveat, 2 real gauges/counters added).
- **CLI docs**: ~15 missing flags added to the website's "complete" reference; `--rotate` default corrected (on); nonexistent `wired` export mode → `encrypted+dsb`; man page version 0.1.0 → 0.4.18.
- **Config docs**: `visible_columns` + four `[limits]` keys added; missing `[names]` section added to the website page.
- **DSL/keybindings/output**: field count 31; full `problems` alias expansion; `f` transaction-filter key documented; four timestamp modes; `cseq` in the JSON example.
- **README**: HEP send is v3-only.

Doc-enforcement tests and the full suite pass (1860 tests).