### PR TITLE
Add -K/--kill-target for targeted scanner kill (sipgrep -K)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Security**: `-K` / `--kill-target <ADDR[:PORT-RANGE]>` — targeted scanner
+  kill (sipgrep `-K`). Sends the kill response to any SIP request whose source
+  matches the given address and an optional port range (e.g.
+  `10.0.0.1:5060-5090`, `[::1]:5060`), regardless of UA/behavioral detection.
+  Repeatable; spawns the kill worker on its own, so `--kill-scanner` is not
+  required. Malformed targets are rejected at startup.
+
 ## [0.5.6] - 2026-07-16
 
 ### Added

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -134,9 +134,10 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 
 | Flag | Value | Default | Description |
 |------|-------|---------|-------------|
-| `--kill-scanner` | -- | off | Detect and report SIP scanning activity |
-| `--kill-ua` | `<PATTERN>` | -- | Detect scanners by User-Agent pattern (regex) |
-| `--kill-response` | `<CODE>` | `200` | SIP response code for scanner kill reports (100-699) |
+| `--kill-scanner` | -- | off | Detect SIP scanning (known UA signatures + behavioral rate/enumeration) and send the kill response back to the scanner (sipgrep `-J`/`-j`) |
+| `--kill-ua` | `<PATTERN>` | -- | Add a custom scanner User-Agent pattern (regex) to `--kill-scanner` detection |
+| `--kill-response` | `<CODE>` | `200` | SIP response code for the kill response (100-699) |
+| `-K`, `--kill-target` | `<ADDR[:PORT-RANGE]>` | -- | Targeted kill (sipgrep `-K`): send the kill response to any SIP request whose source matches ADDR and an optional port range (`10.0.0.1:5060-5090`, `[::1]:5060`), regardless of UA/behavioral detection. Repeatable; spawns the kill worker on its own (no `--kill-scanner` needed) |
 | `--fraud-detect` | -- | off | Enable fraud detection heuristics |
 | `--reg-flood` | -- | off | Detect registration flood attacks |
 | `--digest-leak` | -- | off | Detect digest credential leaks in SIP messages |

--- a/man/sipnab.1
+++ b/man/sipnab.1
@@ -84,7 +84,16 @@ Output as JSON, one object per line.
 Generate a detailed diagnostic report for a specific Call-ID.
 .TP
 .B \-\-kill\-scanner
-Detect and report SIP scanning activity.
+Detect SIP scanning (UA signatures and behavioral heuristics) and send the
+kill response back to the scanner.
+.TP
+.BI \-K " addr[:port-range]"
+Targeted scanner kill: send the kill response to any request whose source
+matches
+.I addr
+and an optional port range (e.g.
+.IR 10.0.0.1:5060\-5090 ).
+Repeatable.
 .TP
 .BI \-l " N"
 Maximum number of dialogs to track (default: 100000).

--- a/src/app/batch.rs
+++ b/src/app/batch.rs
@@ -44,6 +44,9 @@ struct DetectionEngines {
     alerts: Arc<RwLock<AlertEngine>>,
     kill_handle: Option<ScannerKillHandle>,
     kill_response_code: u16,
+    /// Targeted-kill directives (`-K` / `--kill-target`): any SIP request whose
+    /// source matches is killed regardless of UA/behavioral detection.
+    kill_targets: Vec<sec::scanner_kill::KillTarget>,
 }
 
 /// Packet processing counters and state.
@@ -300,6 +303,25 @@ impl BatchRunner {
 
         // 17a. Initialize security detectors
         let kill_scanner_active = cli.kill_scanner || config.security.kill_scanner.unwrap_or(false);
+
+        // Targeted-kill directives (-K). Already validated in Cli::validate();
+        // reparse here and skip (loudly) any that somehow fail so a bad entry
+        // can't take the whole run down mid-capture.
+        let kill_targets: Vec<sec::scanner_kill::KillTarget> = cli
+            .kill_target
+            .iter()
+            .filter_map(|spec| match sec::scanner_kill::KillTarget::parse(spec) {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    tracing::error!("Ignoring invalid --kill-target '{spec}': {e}");
+                    None
+                }
+            })
+            .collect();
+        // The kill worker is needed whenever we may emit a kill response —
+        // detection-driven (--kill-scanner) OR targeted (-K).
+        let kill_worker_active = kill_scanner_active || !kill_targets.is_empty();
+
         let scanner_detector = if kill_scanner_active {
             let custom = cli
                 .kill_ua
@@ -312,7 +334,7 @@ impl BatchRunner {
         };
 
         // 17a-2. Spawn scanner-kill worker thread (D16: process isolation)
-        let scanner_kill_handle: Option<ScannerKillHandle> = if kill_scanner_active {
+        let scanner_kill_handle: Option<ScannerKillHandle> = if kill_worker_active {
             match process_isolation::spawn_scanner_kill_worker(None) {
                 Ok(handle) => Some(handle),
                 Err(e) => {
@@ -381,6 +403,7 @@ impl BatchRunner {
             alerts: alert_engine,
             kill_handle: scanner_kill_handle,
             kill_response_code,
+            kill_targets,
         };
 
         // 17c. Initialize TLS decryptor if --keylog and/or --tls-key is provided
@@ -1069,6 +1092,7 @@ fn process_parsed_packet(
     let alert_engine = &mut engines.alerts;
     let scanner_kill_handle = &engines.kill_handle;
     let kill_response_code = engines.kill_response_code;
+    let kill_targets = &engines.kill_targets;
     let sip_count = &mut counters.sip_count;
     let rtp_count = &mut counters.rtp_count;
     let prev_timestamp = &mut counters.prev_timestamp;
@@ -1187,6 +1211,38 @@ fn process_parsed_packet(
                 }
 
                 // D16: Send kill response via isolated worker thread
+                if let Some(handle) = &scanner_kill_handle
+                    && let Some(response_bytes) =
+                        sec::scanner_kill::build_scanner_response(&sip_msg, kill_response_code)
+                {
+                    let _ = handle.send_kill(KillRequest::SendResponse {
+                        dst_addr: sip_msg.src_addr,
+                        dst_port: sip_msg.src_port,
+                        response_bytes,
+                    });
+                }
+            }
+
+            // Targeted scanner kill (sipgrep -K): kill any request whose source
+            // matches a --kill-target, independent of UA/behavioral detection.
+            if !kill_targets.is_empty()
+                && sip_msg.is_request
+                && kill_targets
+                    .iter()
+                    .any(|t| t.matches(sip_msg.src_addr, sip_msg.src_port))
+            {
+                let method = sip_msg.method.as_ref().map_or("-", |m| m.as_str());
+                let ua = sip_msg.user_agent().unwrap_or("-");
+                alert_engine.write().fire(
+                    "scanner",
+                    sip_msg.src_addr,
+                    &format!("method={method} ua={ua} detection=kill-target"),
+                );
+                if cli.fail2ban {
+                    let event =
+                        output::format_scanner_event(&sip_msg.src_addr.to_string(), ua, method);
+                    println!("{event}");
+                }
                 if let Some(handle) = &scanner_kill_handle
                     && let Some(response_bytes) =
                         sec::scanner_kill::build_scanner_response(&sip_msg, kill_response_code)
@@ -1685,6 +1741,7 @@ mod tests {
             alerts: Arc::new(RwLock::new(AlertEngine::new(Vec::new(), None))),
             kill_handle: None,
             kill_response_code: 0,
+            kill_targets: Vec::new(),
         };
         let mut counters = PacketCounters {
             sip_count: 0,
@@ -1718,6 +1775,110 @@ mod tests {
         (counters.sip_count, counters.rtp_count)
     }
 
+    /// Drive one packet with `--kill-target` directives active and return the
+    /// detail lines of any "scanner" findings the alert engine recorded. Uses
+    /// `kill_handle: None`, so no socket send is attempted — the targeted-kill
+    /// alert still fires before the (absent) worker handoff.
+    fn drive_kill_targets(cli: &Cli, pp: &ParsedPacket, targets: &[&str]) -> Vec<String> {
+        let matcher = SipMatcher::new(cli, None).expect("matcher");
+        let filter_expr: Option<FilterExpr> = None;
+        let output_opts = OutputOptions::default();
+        let mut dialog_store = DialogStore::new(100, false);
+        let mut stream_store = StreamStore::new(100);
+        let mut rtp_heuristic = rtp::heuristic::RtpHeuristic::new();
+        let mut event_exec = EventExecEngine::new(None, None, 0, 0.0);
+
+        let kill_targets = targets
+            .iter()
+            .map(|s| sec::scanner_kill::KillTarget::parse(s).expect("valid target"))
+            .collect();
+        let alerts = Arc::new(RwLock::new(AlertEngine::new(Vec::new(), None)));
+        let mut engines = DetectionEngines {
+            scanner: None,
+            fraud: None,
+            digest: None,
+            reg_flood: None,
+            alerts: Arc::clone(&alerts),
+            kill_handle: None,
+            kill_response_code: 200,
+            kill_targets,
+        };
+        let mut counters = PacketCounters {
+            sip_count: 0,
+            rtp_count: 0,
+            prev_timestamp: None,
+            trailing_remaining: 0,
+            followed_dialogs: std::collections::HashSet::new(),
+        };
+        let ctx = BatchContext {
+            matcher: &matcher,
+            filter_expr: &filter_expr,
+            output_opts: &output_opts,
+            cli,
+            no_rtp: false,
+            after_count: 0,
+            portrange: (5060, 5061),
+        };
+        let mut state = ProcessingState {
+            dialog_store: &mut dialog_store,
+            stream_store: &mut stream_store,
+            rtp_heuristic: &mut rtp_heuristic,
+            event_exec: &mut event_exec,
+            #[cfg(feature = "tls")]
+            srtp: None,
+            #[cfg(feature = "tls")]
+            dtls: None,
+        };
+        process_parsed_packet(pp, &ctx, &mut state, &mut engines, &mut counters);
+
+        alerts
+            .read()
+            .iter_findings(&["scanner"], None, 16)
+            .into_iter()
+            .map(|f| f.detail.clone())
+            .collect()
+    }
+
+    #[test]
+    fn kill_target_matching_request_fires_kill_alert() {
+        // parsed_sip_packet sources from 10.0.0.1; src_port 5075 is inside the
+        // target's 5060-5090 range → the targeted kill must fire.
+        let mut cli = base_cli();
+        cli.no_cli_print = true;
+        let pp = parsed_sip_packet(invite_bytes("kt-hit@example.com"), 5075, 5060);
+        let details = drive_kill_targets(&cli, &pp, &["10.0.0.1:5060-5090"]);
+        assert!(
+            details.iter().any(|d| d.contains("detection=kill-target")),
+            "expected a kill-target alert, got {details:?}"
+        );
+    }
+
+    #[test]
+    fn kill_target_out_of_range_port_does_not_fire() {
+        // src_port 6000 is outside 5060-5090 → no targeted kill.
+        let mut cli = base_cli();
+        cli.no_cli_print = true;
+        let pp = parsed_sip_packet(invite_bytes("kt-miss@example.com"), 6000, 5060);
+        let details = drive_kill_targets(&cli, &pp, &["10.0.0.1:5060-5090"]);
+        assert!(
+            !details.iter().any(|d| d.contains("kill-target")),
+            "should not kill a source outside the port range, got {details:?}"
+        );
+    }
+
+    #[test]
+    fn kill_target_wrong_ip_does_not_fire() {
+        // Target a different IP than the packet's source (10.0.0.1) → no kill.
+        let mut cli = base_cli();
+        cli.no_cli_print = true;
+        let pp = parsed_sip_packet(invite_bytes("kt-ip@example.com"), 5075, 5060);
+        let details = drive_kill_targets(&cli, &pp, &["10.0.0.99:5060-5090"]);
+        assert!(
+            !details.iter().any(|d| d.contains("kill-target")),
+            "should not kill a non-targeted source IP, got {details:?}"
+        );
+    }
+
     /// Drive a packet through `process_parsed_packet` with an active SRTP
     /// context, returning the rtp_count so wiring can be asserted.
     #[cfg(feature = "tls")]
@@ -1742,6 +1903,7 @@ mod tests {
             alerts: Arc::new(RwLock::new(AlertEngine::new(Vec::new(), None))),
             kill_handle: None,
             kill_response_code: 0,
+            kill_targets: Vec::new(),
         };
         let mut counters = PacketCounters {
             sip_count: 0,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -471,6 +471,19 @@ pub struct Cli {
     #[arg(help_heading = "Security", long, value_name = "CODE", default_value = "200", value_parser = clap::value_parser!(u16).range(100..=699))]
     pub kill_response: u16,
 
+    /// Targeted scanner kill (sipgrep -K): send the kill response to any SIP
+    /// request whose source matches ADDR and an optional port range, e.g.
+    /// `10.0.0.1:5060-5090` or `[::1]:5060`, regardless of UA/behavioral
+    /// detection. Repeatable. Spawns the kill worker on its own; `--kill-scanner`
+    /// is not required.
+    #[arg(
+        help_heading = "Security",
+        short = 'K',
+        long = "kill-target",
+        value_name = "ADDR[:PORT-RANGE]"
+    )]
+    pub kill_target: Vec<String>,
+
     /// Enable fraud detection heuristics.
     #[arg(help_heading = "Security", long)]
     pub fraud_detect: bool,
@@ -982,6 +995,13 @@ impl Cli {
             }
         }
 
+        // Fail fast on a malformed --kill-target so a typo can't silently leave
+        // an attacker unblocked.
+        for spec in &self.kill_target {
+            crate::security::scanner_kill::KillTarget::parse(spec)
+                .map_err(|e| crate::Error::CliValidation(format!("--kill-target '{spec}': {e}")))?;
+        }
+
         Ok(())
     }
 
@@ -1181,6 +1201,33 @@ mod tests {
             cli.bpf_filter,
             vec!["host", "10.0.0.1", "and", "port", "5060"]
         );
+    }
+
+    #[test]
+    fn kill_target_repeatable_and_coexists() {
+        let cli = Cli::parse_from_args([
+            "sipnab",
+            "-K",
+            "10.0.0.1:5060-5090",
+            "--kill-target",
+            "192.168.1.5",
+            "host 10.0.0.1",
+        ]);
+        assert_eq!(cli.kill_target, vec!["10.0.0.1:5060-5090", "192.168.1.5"]);
+        assert_eq!(cli.bpf_filter, vec!["host 10.0.0.1"]);
+    }
+
+    #[test]
+    fn validate_rejects_bad_kill_target() {
+        let cli = Cli::parse_from_args(["sipnab", "-K", "not-an-ip"]);
+        let err = cli.validate().unwrap_err();
+        assert!(err.to_string().contains("--kill-target"));
+    }
+
+    #[test]
+    fn validate_accepts_good_kill_targets() {
+        let cli = Cli::parse_from_args(["sipnab", "-K", "10.0.0.1:5060-5090", "-K", "[::1]:5060"]);
+        assert!(cli.validate().is_ok());
     }
 
     #[test]

--- a/src/security/scanner_kill.rs
+++ b/src/security/scanner_kill.rs
@@ -5,7 +5,107 @@
 //! To, Call-ID, CSeq) per RFC 3261 SS8.2.6, keeping the scanner's state
 //! machine satisfied while wasting its resources.
 
+use std::net::IpAddr;
+
 use crate::sip::SipMessage;
+
+/// A targeted-kill directive (sipgrep `-K` / `--kill-target`): an IP address
+/// and an optional inclusive source-port range. A SIP request whose source
+/// matches is killed regardless of UA/behavioral scanner detection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KillTarget {
+    ip: IpAddr,
+    /// Inclusive `(lo, hi)` source-port range; `None` matches any port.
+    ports: Option<(u16, u16)>,
+}
+
+impl KillTarget {
+    /// Parse a `-K` / `--kill-target` spec into a [`KillTarget`].
+    ///
+    /// Accepted forms:
+    /// - `ADDR` — bare IPv4/IPv6, matches any source port (`10.0.0.1`, `::1`).
+    /// - `ADDR:PORT` — a single port (`10.0.0.1:5060`).
+    /// - `ADDR:LO-HI` — an inclusive port range (`10.0.0.1:5060-5090`).
+    ///
+    /// IPv6 with a port MUST be bracketed (`[::1]:5060`) so the address colons
+    /// are unambiguous; a bare IPv6 (no port) needs no brackets.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable message when the address is invalid, the port
+    /// spec is malformed, or a range is inverted (`lo > hi`).
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        if spec.is_empty() {
+            return Err("empty kill-target".to_string());
+        }
+
+        // Bracketed IPv6: `[addr]` or `[addr]:portspec`.
+        if let Some(rest) = spec.strip_prefix('[') {
+            let end = rest
+                .find(']')
+                .ok_or_else(|| format!("unclosed '[' in '{spec}'"))?;
+            let ip: IpAddr = rest[..end]
+                .parse()
+                .map_err(|_| format!("invalid IPv6 address in '{spec}'"))?;
+            let after = &rest[end + 1..];
+            let ports = if after.is_empty() {
+                None
+            } else {
+                let port_spec = after
+                    .strip_prefix(':')
+                    .ok_or_else(|| format!("expected ':port' after ']' in '{spec}'"))?;
+                Some(parse_port_range(port_spec)?)
+            };
+            return Ok(Self { ip, ports });
+        }
+
+        // A bare address (IPv4 or unbracketed IPv6) with no port spec.
+        if let Ok(ip) = spec.parse::<IpAddr>() {
+            return Ok(Self { ip, ports: None });
+        }
+
+        // Otherwise it must be `ADDR:portspec`. Split on the FIRST colon; a
+        // valid IPv4 has none, so anything left containing a colon (an
+        // unbracketed IPv6 + port) fails the address parse below — as intended.
+        let (ip_str, port_spec) = spec
+            .split_once(':')
+            .ok_or_else(|| format!("invalid kill-target '{spec}'"))?;
+        let ip: IpAddr = ip_str
+            .parse()
+            .map_err(|_| format!("invalid address '{ip_str}' in '{spec}'"))?;
+        Ok(Self {
+            ip,
+            ports: Some(parse_port_range(port_spec)?),
+        })
+    }
+
+    /// True if a SIP request from `src_ip:src_port` matches this target.
+    pub fn matches(&self, src_ip: IpAddr, src_port: u16) -> bool {
+        self.ip == src_ip
+            && self
+                .ports
+                .is_none_or(|(lo, hi)| (lo..=hi).contains(&src_port))
+    }
+}
+
+/// Parse a `LO-HI` inclusive range or a single `PORT` into `(lo, hi)`.
+fn parse_port_range(spec: &str) -> Result<(u16, u16), String> {
+    if let Some((lo_str, hi_str)) = spec.split_once('-') {
+        let lo: u16 = lo_str
+            .parse()
+            .map_err(|_| format!("invalid port '{lo_str}'"))?;
+        let hi: u16 = hi_str
+            .parse()
+            .map_err(|_| format!("invalid port '{hi_str}'"))?;
+        if lo > hi {
+            return Err(format!("inverted port range {lo}-{hi}"));
+        }
+        Ok((lo, hi))
+    } else {
+        let p: u16 = spec.parse().map_err(|_| format!("invalid port '{spec}'"))?;
+        Ok((p, p))
+    }
+}
 
 /// Standard SIP reason phrases for common response codes.
 fn reason_phrase(code: u16) -> &'static str {
@@ -282,5 +382,75 @@ mod tests {
         let text = String::from_utf8(resp).expect("valid utf8");
 
         assert!(text.starts_with("SIP/2.0 699 Unknown\r\n"));
+    }
+
+    // ── KillTarget (sipgrep -K targeted kill) ────────────────────────
+
+    fn ip4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+
+    #[test]
+    fn parse_bare_ipv4_matches_any_port() {
+        let t = KillTarget::parse("10.0.0.1").expect("valid");
+        assert!(t.matches(ip4(10, 0, 0, 1), 5060));
+        assert!(t.matches(ip4(10, 0, 0, 1), 1));
+        assert!(t.matches(ip4(10, 0, 0, 1), 65535));
+        assert!(!t.matches(ip4(10, 0, 0, 2), 5060));
+    }
+
+    #[test]
+    fn parse_ipv4_single_port() {
+        let t = KillTarget::parse("10.0.0.1:5060").expect("valid");
+        assert!(t.matches(ip4(10, 0, 0, 1), 5060));
+        assert!(!t.matches(ip4(10, 0, 0, 1), 5061));
+    }
+
+    #[test]
+    fn parse_ipv4_port_range_inclusive() {
+        let t = KillTarget::parse("10.0.0.1:5060-5090").expect("valid");
+        assert!(t.matches(ip4(10, 0, 0, 1), 5060)); // lo boundary
+        assert!(t.matches(ip4(10, 0, 0, 1), 5075));
+        assert!(t.matches(ip4(10, 0, 0, 1), 5090)); // hi boundary
+        assert!(!t.matches(ip4(10, 0, 0, 1), 5059));
+        assert!(!t.matches(ip4(10, 0, 0, 1), 5091));
+        assert!(!t.matches(ip4(10, 0, 0, 2), 5075)); // wrong ip
+    }
+
+    #[test]
+    fn parse_bare_ipv6_and_bracketed_with_port() {
+        let bare = KillTarget::parse("::1").expect("valid bare v6");
+        let v6 = IpAddr::V6(std::net::Ipv6Addr::LOCALHOST);
+        assert!(bare.matches(v6, 12345));
+
+        let bracketed = KillTarget::parse("[::1]:5060-5061").expect("valid bracketed v6");
+        assert!(bracketed.matches(v6, 5060));
+        assert!(bracketed.matches(v6, 5061));
+        assert!(!bracketed.matches(v6, 5062));
+    }
+
+    #[test]
+    fn parse_rejects_invalid_specs() {
+        // Each of these must be a hard error, not a silently-permissive target.
+        for bad in [
+            "",                   // empty
+            "not-an-ip",          // garbage
+            "999.0.0.1",          // bad octet
+            "10.0.0.1:abc",       // non-numeric port
+            "10.0.0.1:",          // empty port spec
+            "10.0.0.1:5060-",     // empty range hi
+            "10.0.0.1:-5090",     // empty range lo
+            "10.0.0.1:5090-5060", // lo > hi
+            "10.0.0.1:70000",     // port out of u16 range
+            "gggg::1:5060",       // not a valid IPv6, and not ADDR:port
+            "[::1",               // unclosed bracket
+            "[::1]:99999",        // bracketed v6 with out-of-range port
+            "10.0.0.1:5060\\",    // trailing backslash junk
+        ] {
+            assert!(
+                KillTarget::parse(bad).is_err(),
+                "expected error for {bad:?}"
+            );
+        }
     }
 }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -155,7 +155,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2446 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2457 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -226,7 +226,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2446" data-suffix="">2446</span>
+        <span class="arch-stat" data-count="2457" data-suffix="">2457</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Completes sipgrep scanner-kill parity. sipnab **already** sends an active SIP kill response — `--kill-scanner` detects scanners (built-in UA signatures like friendly-scanner/sipvicious/sipcli/sipsak **plus** behavioral rate/enumeration heuristics) and fires a crafted response via an isolated worker, and `--kill-ua` adds custom UA patterns. That covers sipgrep `-J` (auto) and `-j` (by-UA).

The missing piece was sipgrep `-K`: killing a **specified address/port range regardless of detection**.

## Change

`-K` / `--kill-target <ADDR[:PORT-RANGE]>` (repeatable): any SIP request whose source matches the address and an optional inclusive port range gets the kill response, independent of UA/behavioral detection.

- Forms: `10.0.0.1`, `10.0.0.1:5060`, `10.0.0.1:5060-5090`, `[::1]:5060` (bare IPv6 needs no brackets; IPv6 + port must be bracketed).
- The kill worker now spawns whenever `--kill-scanner` **or** `-K` is set.
- Malformed targets are rejected at startup via `Cli::validate` (exit 2) so a typo can't silently leave an attacker unblocked.

## Tests
- Unit: `KillTarget::parse` + `matches` — bare v4/v6, single port, ranges, boundaries, and adversarial/invalid specs.
- CLI: `-K` repeatable + BPF coexistence; `validate()` accepts good / rejects bad.
- Batch integration: fires the kill alert on a matching source; **not** on an out-of-range port or a wrong IP.
- Real-binary e2e: `-K 10.33.6.101` fires `detection=kill-target` on a matching pcap source; non-matching address/port-range stay silent; bad `-K` exits 2.

Docs (cli-reference, man page), CHANGELOG updated. Targets the next release.