### PR TITLE
sipgrep parity: --no-promisc, configurable X-Call-ID headers, HEP send auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Capture**: `-p` / `--no-promisc` — do not put the interface into
+  promiscuous mode (sipgrep `-p`). Promiscuous mode stays on by default for a
+  named device (never for the `any` pseudo-device). Also settable via
+  `[capture] promisc`.
+- **SIP**: `[sip] xcid_headers` — configurable B2BUA leg-correlation header
+  names (sngrep `sip.xcid`). Defaults to `["X-Call-ID"]`; add carrier-specific
+  headers (e.g. `["X-Call-ID", "X-CID"]`) so multi-leg calls correlate.
+- **HEP**: `--hep-auth <KEY>` (Homer authenticate-key `0x000e` chunk, also read
+  from `SIPNAB_HEP_AUTH`) and `--hep-id <ID>` (capture-agent id `0x000c` chunk,
+  default 1) for `--hep-send`. Previously the sender emitted no auth key and a
+  hardcoded capture id of 1.
+
 ## [0.5.7] - 2026-07-16
 
 ### Added

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -17,6 +17,7 @@ CLI flags always override config file values (see [config-reference.md](config-r
 | `--portrange` | `<RANGE>` | `5060-5061` | SIP port range to capture |
 | `--multi-device` | -- | off | Capture on all available interfaces |
 | `--no-rtp` | -- | off | Disable RTP capture and analysis |
+| `-p`, `--no-promisc` | -- | off | Do not put the interface into promiscuous mode (sipgrep `-p`). Promisc is on by default for a named device; the `any` pseudo-device is never promiscuous |
 | `--bpf-file` | `<FILE>` | -- | Read BPF filter from a file |
 | `-n`, `--count` | `<N>` | -- | Stop after capturing N packets |
 | `--duration` | `<DURATION>` | -- | Stop after duration (e.g., `30s`, `5m`, `1h`) |
@@ -181,6 +182,8 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--mcp-allowed-host` | `<HOST>` | -- | Additional `Host` header values the HTTP MCP server will accept (repeatable). rmcp's DNS-rebind protection defaults to `localhost`, `127.0.0.1`, `::1` only — add the public hostname or bind IP when clients connect via that name. Use `*` to disable host checking entirely (pair with a network-level source-IP allowlist). Feature: `mcp-http` |
 | `-L`, `--hep-listen` | `<ADDR>` | -- | Listen for HEP (Homer Encapsulation Protocol) packets. Feature: `hep` |
 | `-H`, `--hep-send` | `<ADDR>` | -- | Send captured packets via HEP to a remote collector. Feature: `hep` |
+| `--hep-id` | `<ID>` | `1` | Capture-agent id (HEP `0x000c` chunk) stamped on packets sent via `--hep-send`. Feature: `hep` |
+| `--hep-auth` | `<KEY>` | -- | Homer authenticate key (HEP `0x000e` chunk) added to packets sent via `--hep-send`. Also read from `SIPNAB_HEP_AUTH` (preferred, keeps the secret out of the process list). Feature: `hep` |
 | `-E`, `--hep-parse` | -- | off | Parse incoming HEP packets (enable HEP decoding). Feature: `hep` |
 | `--hep-allow` | `<ADDR>` | -- | Allowed source addresses for HEP input (repeatable) Feature: `hep` |
 | `--hep-rate-limit` | `<N>` | `50000` | Maximum HEP packets per second Feature: `hep` |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -36,6 +36,7 @@ Packet capture defaults.
 | `buffer` | integer | `2` | Kernel capture buffer size in MiB |
 | `buffer_budget_mb` | integer | `64` | Memory budget for the in-flight capture→processing queue. Grows under load up to this budget (capped, never OOM) and shrinks when idle. `--buffer-budget` overrides it |
 | `no_rtp` | boolean | `false` | Disable RTP capture by default |
+| `promisc` | boolean | `true` | Put a named interface into promiscuous mode (the `any` device is never promiscuous). `--no-promisc` overrides this to `false` |
 
 ```toml
 [capture]
@@ -45,6 +46,7 @@ snaplen = 65535
 buffer = 16
 buffer_budget_mb = 64
 no_rtp = false
+promisc = true
 ```
 
 ### [display]
@@ -82,6 +84,19 @@ Default filter presets applied at startup.
 from = "^1001@"
 to = "^1002@"
 expression = "method == 'INVITE'"
+```
+
+### [sip]
+
+SIP protocol handling.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `xcid_headers` | array | `["X-Call-ID"]` | Header names used to correlate B2BUA call legs (sngrep `sip.xcid`). A dialog whose message carries one of these headers pointing at another dialog's Call-ID is correlated. Add carrier-specific headers here; an empty/unset list keeps the `X-Call-ID` default |
+
+```toml
+[sip]
+xcid_headers = ["X-Call-ID", "X-CID"]
 ```
 
 ### [security]

--- a/src/app/batch.rs
+++ b/src/app/batch.rs
@@ -138,6 +138,7 @@ pub fn run_cores_file(
         portrange,
         no_dialog: cli.no_dialog,
         no_rtp,
+        xcid_headers: config.sip.xcid_headers.clone().unwrap_or_default(),
     };
     match crate::parallel::run_offline_parallel_file(
         std::path::Path::new(input),
@@ -193,6 +194,7 @@ pub fn run(
             portrange,
             no_dialog: cli.no_dialog,
             no_rtp,
+            xcid_headers: config.sip.xcid_headers.clone().unwrap_or_default(),
         };
         let result = crate::parallel::run_offline_parallel(rx, pcfg);
         let _ = handle.thread.join();
@@ -263,9 +265,17 @@ impl BatchRunner {
         #[cfg(feature = "hep")]
         let hep_sender: Option<crate::capture::hep::HepSender> =
             if let Some(ref addr) = cli.hep_send {
-                match crate::capture::hep::HepSender::new(addr, 1) {
+                let capture_id = cli.hep_id.unwrap_or(1);
+                match crate::capture::hep::HepSender::new(addr, capture_id, cli.hep_auth.clone()) {
                     Ok(sender) => {
-                        tracing::info!("HEP sender targeting {addr}");
+                        tracing::info!(
+                            "HEP sender targeting {addr} (capture id {capture_id}{})",
+                            if cli.hep_auth.is_some() {
+                                ", authenticated"
+                            } else {
+                                ""
+                            }
+                        );
                         Some(sender)
                     }
                     Err(e) => {
@@ -284,10 +294,10 @@ impl BatchRunner {
         // to, eliminating the prior mirror-and-double-parse pattern. In the
         // common single-writer batch case the locks are uncontested.
         let processor = capture::PacketProcessor::with_max_sessions(cli.max_reassembly as usize);
-        let dialog_store: Arc<RwLock<DialogStore>> = Arc::new(RwLock::new(DialogStore::new(
-            cli.limit as usize,
-            cli.rotate_enabled(),
-        )));
+        let dialog_store: Arc<RwLock<DialogStore>> = Arc::new(RwLock::new(
+            DialogStore::new(cli.limit as usize, cli.rotate_enabled())
+                .with_xcid_headers(config.sip.xcid_headers.clone().unwrap_or_default()),
+        ));
         let no_rtp = cli.no_rtp || config.capture.no_rtp.unwrap_or(false);
         let stream_store: Arc<RwLock<StreamStore>> = {
             let mut ss = StreamStore::new(cli.max_streams as usize);

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -857,6 +857,14 @@ fn build_capture_config(cli: &Cli, config: &Config) -> CaptureConfig {
             }
         });
 
+    // Promiscuous mode: on by default; `--no-promisc` (or `[capture] promisc`)
+    // turns it off. The CLI flag wins over the config value.
+    let promisc = if cli.no_promisc {
+        false
+    } else {
+        config.capture.promisc.unwrap_or(true)
+    };
+
     CaptureConfig {
         snaplen,
         buffer_mb,
@@ -865,6 +873,7 @@ fn build_capture_config(cli: &Cli, config: &Config) -> CaptureConfig {
         duration,
         replay: cli.replay,
         buffer_budget_mb,
+        promisc,
     }
 }
 
@@ -1039,6 +1048,45 @@ mod tests {
         assert_eq!(cc.count, None);
         assert_eq!(cc.duration, None);
         assert!(!cc.replay);
+    }
+
+    #[test]
+    fn build_capture_config_promisc_default_on() {
+        let cc = build_capture_config(&base_cli(), &Config::default());
+        assert!(cc.promisc, "promiscuous mode should default to on");
+    }
+
+    #[test]
+    fn build_capture_config_no_promisc_flag_disables() {
+        let mut cli = base_cli();
+        cli.no_promisc = true;
+        let cc = build_capture_config(&cli, &Config::default());
+        assert!(!cc.promisc, "--no-promisc should disable promiscuous mode");
+    }
+
+    #[test]
+    fn build_capture_config_promisc_config_fallback() {
+        let mut config = Config::default();
+        config.capture.promisc = Some(false);
+        // CLI leaves --no-promisc unset -> config value wins.
+        let cc = build_capture_config(&base_cli(), &config);
+        assert!(
+            !cc.promisc,
+            "[capture] promisc=false should disable promisc"
+        );
+    }
+
+    #[test]
+    fn build_capture_config_no_promisc_flag_overrides_config() {
+        let mut config = Config::default();
+        config.capture.promisc = Some(true);
+        let mut cli = base_cli();
+        cli.no_promisc = true;
+        let cc = build_capture_config(&cli, &config);
+        assert!(
+            !cc.promisc,
+            "--no-promisc must override [capture] promisc=true"
+        );
     }
 
     #[test]

--- a/src/app/tui_mode.rs
+++ b/src/app/tui_mode.rs
@@ -70,10 +70,10 @@ pub fn run_tui_mode(
 ) {
     let no_rtp = cli.no_rtp || config.capture.no_rtp.unwrap_or(false);
 
-    let dialog_store = Arc::new(RwLock::new(DialogStore::new(
-        cli.limit as usize,
-        cli.rotate_enabled(),
-    )));
+    let dialog_store = Arc::new(RwLock::new(
+        DialogStore::new(cli.limit as usize, cli.rotate_enabled())
+            .with_xcid_headers(config.sip.xcid_headers.clone().unwrap_or_default()),
+    ));
     let stream_store = {
         let mut ss = StreamStore::new(cli.max_streams as usize);
         if let Some(max_frames) = config.limits.max_audio_frames {

--- a/src/capture/hep.rs
+++ b/src/capture/hep.rs
@@ -58,6 +58,9 @@ const CHUNK_TS_USEC: u16 = 0x000a;
 const CHUNK_PROTO_TYPE: u16 = 0x000b;
 /// Chunk type: Capture agent ID (4 bytes, big-endian).
 const CHUNK_CAPTURE_ID: u16 = 0x000c;
+/// Chunk type: Authenticate key / password (variable length) — Homer's
+/// per-capture-agent shared secret.
+const CHUNK_AUTH_KEY: u16 = 0x000e;
 /// Chunk type: Payload — the actual SIP/RTP message (variable length).
 const CHUNK_PAYLOAD: u16 = 0x000f;
 /// Chunk type: Correlation ID — typically the Call-ID (variable length).
@@ -431,6 +434,7 @@ pub fn build_hep_v3(
     timestamp: DateTime<Utc>,
     protocol: HepProtocol,
     capture_id: u32,
+    auth_key: Option<&str>,
     payload: &[u8],
 ) -> Vec<u8> {
     let src_addr = endpoint.src_addr;
@@ -487,6 +491,11 @@ pub fn build_hep_v3(
         CHUNK_CAPTURE_ID,
         &capture_id.to_be_bytes(),
     );
+
+    // Authenticate key (Homer shared secret), when configured.
+    if let Some(key) = auth_key {
+        append_chunk(&mut chunks, 0x0000, CHUNK_AUTH_KEY, key.as_bytes());
+    }
 
     // Payload
     append_chunk(&mut chunks, 0x0000, CHUNK_PAYLOAD, payload);
@@ -892,6 +901,8 @@ pub struct HepSender {
     socket: UdpSocket,
     /// Capture agent ID included in every HEP packet.
     capture_id: u32,
+    /// Optional Homer authenticate key (0x000e chunk) added to every packet.
+    auth_key: Option<String>,
 }
 
 impl HepSender {
@@ -902,13 +913,17 @@ impl HepSender {
     /// # Errors
     ///
     /// Returns an error if the socket cannot be created or connected.
-    pub fn new(dest_addr: &str, capture_id: u32) -> Result<Self> {
+    pub fn new(dest_addr: &str, capture_id: u32, auth_key: Option<String>) -> Result<Self> {
         let socket = UdpSocket::bind("0.0.0.0:0")
             .context("Failed to bind ephemeral UDP socket for HEP sender")?;
         socket
             .connect(dest_addr)
             .with_context(|| format!("Failed to connect HEP sender to '{dest_addr}'"))?;
-        Ok(Self { socket, capture_id })
+        Ok(Self {
+            socket,
+            capture_id,
+            auth_key,
+        })
     }
 
     /// Encapsulate and send a SIP message as a HEP v3 packet.
@@ -932,6 +947,7 @@ impl HepSender {
             msg.timestamp,
             HepProtocol::Sip,
             self.capture_id,
+            self.auth_key.as_deref(),
             &msg.raw,
         );
 
@@ -1168,7 +1184,7 @@ mod tests {
             src_port: 5060,
             dst_port: 5061,
         };
-        let built = build_hep_v3(&endpoint, ts, HepProtocol::Sip, 99, payload);
+        let built = build_hep_v3(&endpoint, ts, HepProtocol::Sip, 99, None, payload);
         let parsed = parse_hep(&built).expect("round-trip parse should succeed");
 
         assert_eq!(parsed.version, 3);
@@ -1184,6 +1200,65 @@ mod tests {
         assert_eq!(parsed.timestamp.timestamp_subsec_micros(), 500_000);
     }
 
+    /// Walk HEP3 chunks and return the data of the first (vendor,type) match.
+    fn find_hep_chunk(pkt: &[u8], vendor: u16, ctype: u16) -> Option<Vec<u8>> {
+        let mut i = HEP3_HEADER_LEN;
+        while i + CHUNK_HEADER_LEN <= pkt.len() {
+            let v = u16::from_be_bytes([pkt[i], pkt[i + 1]]);
+            let t = u16::from_be_bytes([pkt[i + 2], pkt[i + 3]]);
+            let len = u16::from_be_bytes([pkt[i + 4], pkt[i + 5]]) as usize;
+            if len < CHUNK_HEADER_LEN || i + len > pkt.len() {
+                break;
+            }
+            if v == vendor && t == ctype {
+                return Some(pkt[i + CHUNK_HEADER_LEN..i + len].to_vec());
+            }
+            i += len;
+        }
+        None
+    }
+
+    fn v4_endpoint() -> HepEndpoint {
+        HepEndpoint {
+            src_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            dst_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            src_port: 5060,
+            dst_port: 5060,
+        }
+    }
+
+    #[test]
+    fn hep_auth_chunk_emitted_when_key_present() {
+        let ts = Utc.timestamp_opt(1700000000, 0).single().unwrap();
+        let pkt = build_hep_v3(
+            &v4_endpoint(),
+            ts,
+            HepProtocol::Sip,
+            42,
+            Some("s3cr3t"),
+            b"INVITE",
+        );
+        // The 0x000e auth-key chunk carries the key verbatim.
+        assert_eq!(
+            find_hep_chunk(&pkt, 0x0000, 0x000e).as_deref(),
+            Some(b"s3cr3t".as_slice())
+        );
+        // The configured capture/agent id still round-trips.
+        assert_eq!(parse_hep(&pkt).unwrap().capture_id, Some(42));
+    }
+
+    #[test]
+    fn hep_no_auth_chunk_when_key_absent() {
+        let ts = Utc.timestamp_opt(1700000000, 0).single().unwrap();
+        let pkt = build_hep_v3(&v4_endpoint(), ts, HepProtocol::Sip, 1, None, b"INVITE");
+        assert!(
+            find_hep_chunk(&pkt, 0x0000, 0x000e).is_none(),
+            "no auth chunk should be emitted without a key"
+        );
+        // The packet is still a valid HEP3 message.
+        assert!(parse_hep(&pkt).is_ok());
+    }
+
     #[test]
     fn build_and_parse_round_trip_ipv6() {
         let src = IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1));
@@ -1197,7 +1272,7 @@ mod tests {
             src_port: 6000,
             dst_port: 7000,
         };
-        let built = build_hep_v3(&endpoint, ts, HepProtocol::Rtp, 1, payload);
+        let built = build_hep_v3(&endpoint, ts, HepProtocol::Rtp, 1, None, payload);
         let parsed = parse_hep(&built).expect("round-trip parse should succeed");
 
         assert_eq!(parsed.src_addr, src);
@@ -1676,7 +1751,7 @@ mod tests {
             dst_port: 5061,
         };
         let ts = Utc.timestamp_opt(1700000000, 0).single().unwrap();
-        let built = build_hep_v3(&endpoint, ts, HepProtocol::Sip, 7, b"hello");
+        let built = build_hep_v3(&endpoint, ts, HepProtocol::Sip, 7, None, b"hello");
 
         assert_eq!(&built[..4], HEP3_MAGIC);
         let declared = u16::from_be_bytes([built[4], built[5]]) as usize;
@@ -1729,7 +1804,7 @@ mod tests {
         };
         let ts = Utc.timestamp_opt(1234567890, 250_000_000).single().unwrap();
         let payload = &[0x80, 0xc8, 0x00, 0x06]; // RTCP SR header start
-        let built = build_hep_v3(&endpoint, ts, HepProtocol::Rtcp, 1000, payload);
+        let built = build_hep_v3(&endpoint, ts, HepProtocol::Rtcp, 1000, None, payload);
         let parsed = parse_hep(&built).expect("round-trip");
 
         assert_eq!(parsed.protocol, HepProtocol::Rtcp);

--- a/src/capture/live.rs
+++ b/src/capture/live.rs
@@ -104,8 +104,9 @@ pub fn capture_live(
     tx: PacketTx,
     ready_tx: Option<crossbeam_channel::Sender<Result<(), String>>>,
 ) -> Result<()> {
-    // The "any" pseudo-device on Linux does not support promiscuous mode.
-    let use_promisc = device != "any";
+    // Promiscuous mode is opt-out (`--no-promisc` / `config.promisc`). The "any"
+    // pseudo-device on Linux does not support it regardless.
+    let use_promisc = config.promisc && device != "any";
 
     let mut cap = match pcap::Capture::from_device(device)
         .with_context(|| format!("Failed to open device '{device}'"))

--- a/src/capture/native.rs
+++ b/src/capture/native.rs
@@ -61,6 +61,9 @@ pub struct CaptureConfig {
     /// Memory budget (MiB) for the in-flight packet queue between capture and
     /// processing. Converted to a packet-count cap via [`Self::channel_capacity`].
     pub buffer_budget_mb: u32,
+    /// Put a named interface into promiscuous mode. The `"any"` pseudo-device is
+    /// never promiscuous regardless of this flag. Disabled by `--no-promisc`.
+    pub promisc: bool,
 }
 
 impl Default for CaptureConfig {
@@ -73,6 +76,7 @@ impl Default for CaptureConfig {
             duration: None,
             replay: false,
             buffer_budget_mb: 64,
+            promisc: true,
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -162,6 +162,12 @@ pub struct Cli {
     #[arg(help_heading = "Capture", long)]
     pub no_rtp: bool,
 
+    /// Do not put the interface into promiscuous mode (sipgrep -p). By default
+    /// promiscuous mode is enabled for a named device (never for the "any"
+    /// pseudo-device, which does not support it).
+    #[arg(help_heading = "Capture", short = 'p', long = "no-promisc")]
+    pub no_promisc: bool,
+
     /// Read BPF filter from a file.
     #[arg(help_heading = "Capture", long, value_name = "FILE")]
     pub bpf_file: Option<String>,
@@ -718,6 +724,26 @@ pub struct Cli {
     )]
     pub hep_send: Option<String>,
 
+    /// Capture-agent id (HEP 0x000c chunk) stamped on every packet sent via
+    /// `--hep-send`. Distinguishes this agent to the Homer collector. Default 1.
+    #[arg(
+        help_heading = "MCP (Model Context Protocol)",
+        long = "hep-id",
+        value_name = "ID"
+    )]
+    pub hep_id: Option<u32>,
+
+    /// Homer authenticate key (HEP 0x000e chunk) added to every packet sent via
+    /// `--hep-send`. Prefer the env var over the flag so the secret is not
+    /// visible in the process list.
+    #[arg(
+        help_heading = "MCP (Model Context Protocol)",
+        long = "hep-auth",
+        value_name = "KEY",
+        env = "SIPNAB_HEP_AUTH"
+    )]
+    pub hep_auth: Option<String>,
+
     /// Parse incoming HEP packets (enable HEP decoding).
     #[arg(
         help_heading = "MCP (Model Context Protocol)",
@@ -1201,6 +1227,23 @@ mod tests {
             cli.bpf_filter,
             vec!["host", "10.0.0.1", "and", "port", "5060"]
         );
+    }
+
+    #[test]
+    fn hep_id_and_auth_flags_parse() {
+        let cli = Cli::parse_from_args(["sipnab", "--hep-id", "7", "--hep-auth", "secret"]);
+        assert_eq!(cli.hep_id, Some(7));
+        assert_eq!(cli.hep_auth.as_deref(), Some("secret"));
+        let none = Cli::parse_from_args(["sipnab"]);
+        assert_eq!(none.hep_id, None);
+        assert_eq!(none.hep_auth, None);
+    }
+
+    #[test]
+    fn no_promisc_short_and_long_flags() {
+        assert!(Cli::parse_from_args(["sipnab", "-p"]).no_promisc);
+        assert!(Cli::parse_from_args(["sipnab", "--no-promisc"]).no_promisc);
+        assert!(!Cli::parse_from_args(["sipnab"]).no_promisc);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,6 +185,9 @@ pub struct Config {
     /// Filter presets.
     #[serde(default)]
     pub filter: FilterConfig,
+    /// SIP protocol handling (dialog correlation, ...).
+    #[serde(default)]
+    pub sip: SipConfig,
     /// Security detection settings.
     #[serde(default)]
     pub security: SecurityConfig,
@@ -208,6 +211,16 @@ pub struct Config {
     pub crash: CrashConfig,
 }
 
+/// SIP protocol handling configuration.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct SipConfig {
+    /// Header names used for B2BUA leg correlation (sngrep `sip.xcid`).
+    /// Defaults to `["X-Call-ID"]` when unset or empty. Set to add
+    /// carrier-specific headers, e.g. `["X-Call-ID", "X-CID"]`.
+    pub xcid_headers: Option<Vec<String>>,
+}
+
 /// Packet capture configuration.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
@@ -226,6 +239,9 @@ pub struct CaptureConfig {
     pub buffer_budget_mb: Option<u32>,
     /// Disable RTP capture by default.
     pub no_rtp: Option<bool>,
+    /// Put the interface into promiscuous mode (default true). `--no-promisc`
+    /// overrides this to false.
+    pub promisc: Option<bool>,
 }
 
 /// Display configuration.
@@ -1085,6 +1101,22 @@ visible_columns = ["#", "Method", "From", "To", "State"]
         let toml_str = "[display]\ncolor = \"auto\"\n";
         let config: Config = toml::from_str(toml_str).unwrap();
         assert!(config.display.visible_columns.is_none());
+    }
+
+    #[test]
+    fn sip_xcid_headers_parse() {
+        let toml_str = "[sip]\nxcid_headers = [\"X-Call-ID\", \"X-CID\"]\n";
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.sip.xcid_headers.as_deref(),
+            Some(["X-Call-ID".to_string(), "X-CID".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn sip_xcid_headers_absent_is_none() {
+        let config: Config = toml::from_str("[capture]\nsnaplen = 1500\n").unwrap();
+        assert!(config.sip.xcid_headers.is_none());
     }
 
     #[test]

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -65,6 +65,9 @@ pub struct ParallelConfig {
     pub no_dialog: bool,
     /// Skip RTP/RTCP processing (`--no-rtp`).
     pub no_rtp: bool,
+    /// Correlation header names for B2BUA leg matching (sngrep `sip.xcid`).
+    /// Empty falls back to the `DialogStore` default (`["X-Call-ID"]`).
+    pub xcid_headers: Vec<String>,
 }
 
 /// Merged reconstruction output of all workers.
@@ -155,7 +158,8 @@ pub fn run_offline_parallel(rx: PacketRx, cfg: ParallelConfig) -> ReconResult {
             let cfg = cfg.clone();
             thread::spawn(move || {
                 let mut processor = PacketProcessor::with_max_sessions(cfg.max_reassembly);
-                let mut ds = DialogStore::new(cfg.max_dialogs, cfg.rotate);
+                let mut ds = DialogStore::new(cfg.max_dialogs, cfg.rotate)
+                    .with_xcid_headers(cfg.xcid_headers.clone());
                 let mut ss = StreamStore::new(cfg.max_streams);
                 ss.set_audio_capture(false); // batch mode never reads audio buffers
                 let mut heuristic = crate::rtp::heuristic::RtpHeuristic::new();
@@ -197,7 +201,8 @@ pub fn run_offline_parallel(rx: PacketRx, cfg: ParallelConfig) -> ReconResult {
     drop(txs); // signal workers to finish
 
     // Merge thread-local stores into one, then resolve cross-worker associations.
-    let mut ds = DialogStore::new(cfg.max_dialogs, cfg.rotate);
+    let mut ds =
+        DialogStore::new(cfg.max_dialogs, cfg.rotate).with_xcid_headers(cfg.xcid_headers.clone());
     let mut ss = StreamStore::new(cfg.max_streams);
     let (mut sip_count, mut rtp_count, mut total) = (0u64, 0u64, 0u64);
     for w in workers {
@@ -254,7 +259,8 @@ pub fn run_offline_parallel_file(
             let cfg = cfg.clone();
             thread::spawn(move || {
                 let mut processor = PacketProcessor::with_max_sessions(cfg.max_reassembly);
-                let mut ds = DialogStore::new(cfg.max_dialogs, cfg.rotate);
+                let mut ds = DialogStore::new(cfg.max_dialogs, cfg.rotate)
+                    .with_xcid_headers(cfg.xcid_headers.clone());
                 let mut ss = StreamStore::new(cfg.max_streams);
                 ss.set_audio_capture(false);
                 let mut heuristic = crate::rtp::heuristic::RtpHeuristic::new();
@@ -337,7 +343,8 @@ pub fn run_offline_parallel_file(
     }
     drop(txs);
 
-    let mut ds = DialogStore::new(cfg.max_dialogs, cfg.rotate);
+    let mut ds =
+        DialogStore::new(cfg.max_dialogs, cfg.rotate).with_xcid_headers(cfg.xcid_headers.clone());
     let mut ss = StreamStore::new(cfg.max_streams);
     let (mut sip_count, mut rtp_count, mut total) = (0u64, 0u64, 0u64);
     for w in workers {
@@ -485,6 +492,7 @@ mod tests {
             portrange: (1, 65535),
             no_dialog: false,
             no_rtp: false,
+            xcid_headers: Vec::new(),
         }
     }
 

--- a/src/sip/dialog_store.rs
+++ b/src/sip/dialog_store.rs
@@ -100,6 +100,11 @@ pub struct DialogStore {
     idle_messages_evicted: u64,
     /// Mutation counter for cache invalidation — see [`Self::generation`].
     generation: u64,
+    /// Header names used for B2BUA leg correlation (sngrep `sip.xcid`). A
+    /// candidate dialog whose message carries one of these headers pointing at
+    /// another dialog's Call-ID (or vice versa) is correlated at score 100.
+    /// Defaults to `["X-Call-ID"]`.
+    xcid_headers: Vec<String>,
 }
 
 /// A dialog idle longer than this has its stored messages compacted.
@@ -144,7 +149,19 @@ impl DialogStore {
             rotate,
             idle_messages_evicted: 0,
             generation: 0,
+            xcid_headers: vec!["X-Call-ID".to_string()],
         }
+    }
+
+    /// Override the correlation header names (sngrep `sip.xcid`). An empty list
+    /// is ignored so the default `["X-Call-ID"]` is preserved. Builder-style:
+    /// returns `self` for chaining after [`new`](Self::new).
+    #[must_use]
+    pub fn with_xcid_headers(mut self, headers: Vec<String>) -> Self {
+        if !headers.is_empty() {
+            self.xcid_headers = headers;
+        }
+        self
     }
 
     /// Monotonic mutation counter: bumped by every operation that can
@@ -405,11 +422,12 @@ impl DialogStore {
             None => return Vec::new(),
         };
 
-        // Strategy 1 data: X-Call-ID values from the source dialog
+        // Strategy 1 data: correlation-header values from the source dialog,
+        // across every configured xcid header name.
         let x_call_ids: Vec<&str> = dialog
             .messages
             .iter()
-            .filter_map(|m| m.header("X-Call-ID"))
+            .flat_map(|m| self.xcid_headers.iter().filter_map(move |h| m.header(h)))
             .collect();
 
         // Strategy 2 data: Via branches from INVITE messages in the source dialog
@@ -432,12 +450,13 @@ impl DialogStore {
                 continue;
             }
 
-            // Strategy 1: X-Call-ID match (score=100)
+            // Strategy 1: correlation-header match (score=100)
             let xcid_match = x_call_ids.iter().any(|&xid| xid == candidate.call_id)
-                || candidate
-                    .messages
-                    .iter()
-                    .any(|m| m.header("X-Call-ID").is_some_and(|v| v == call_id));
+                || candidate.messages.iter().any(|m| {
+                    self.xcid_headers
+                        .iter()
+                        .any(|h| m.header(h).is_some_and(|v| v == call_id))
+                });
 
             if xcid_match {
                 results.push(CorrelationResult {
@@ -1324,6 +1343,88 @@ mod tests {
             TransportProto::Udp,
         )
         .expect("should parse INVITE with X-Call-ID")
+    }
+
+    /// Build an INVITE carrying an arbitrary correlation header.
+    fn make_invite_with_header(
+        call_id: &str,
+        header_name: &str,
+        header_value: &str,
+        ts: DateTime<Utc>,
+    ) -> SipMessage {
+        let raw = build_sip(
+            "INVITE sip:bob@example.com SIP/2.0",
+            &[
+                "From: <sip:alice@example.com>;tag=t1",
+                "To: <sip:bob@example.com>",
+                &format!("Call-ID: {call_id}"),
+                "CSeq: 1 INVITE",
+                &format!("{header_name}: {header_value}"),
+                "Content-Length: 0",
+            ],
+            b"",
+        );
+        parse_sip(
+            &raw,
+            ts,
+            localhost(),
+            localhost(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("should parse INVITE with custom header")
+    }
+
+    #[test]
+    fn xcid_custom_header_correlates() {
+        // With a custom correlation header configured, a B-leg pointing back via
+        // that header (X-CID here, not X-Call-ID) must correlate.
+        let mut store = DialogStore::new(100, false).with_xcid_headers(vec!["X-CID".to_string()]);
+        let t0 = base_ts();
+        store.process_message(make_invite_msg("a-leg@test", t0));
+        store.process_message(make_invite_with_header(
+            "b-leg@test",
+            "X-CID",
+            "a-leg@test",
+            t0 + TimeDelta::seconds(30),
+        ));
+        let correlated = store.find_correlated("a-leg@test");
+        assert_eq!(correlated.len(), 1);
+        assert_eq!(correlated[0].call_id, "b-leg@test");
+    }
+
+    #[test]
+    fn xcid_header_not_in_configured_list_is_ignored() {
+        // Default list is just ["X-Call-ID"]; a B-leg carrying only X-CID (30s
+        // later, so the timing heuristic can't match) must NOT correlate.
+        let mut store = DialogStore::new(100, false);
+        let t0 = base_ts();
+        store.process_message(make_invite_msg("a-leg@test", t0));
+        store.process_message(make_invite_with_header(
+            "b-leg@test",
+            "X-CID",
+            "a-leg@test",
+            t0 + TimeDelta::seconds(30),
+        ));
+        assert!(
+            store.find_correlated("a-leg@test").is_empty(),
+            "X-CID must not correlate when only X-Call-ID is configured"
+        );
+    }
+
+    #[test]
+    fn with_xcid_headers_empty_keeps_default() {
+        // An empty override must not wipe out the default X-Call-ID correlation.
+        let mut store = DialogStore::new(100, false).with_xcid_headers(vec![]);
+        let t0 = base_ts();
+        store.process_message(make_invite_msg("a-leg@test", t0));
+        store.process_message(make_invite_with_x_call_id(
+            "b-leg@test",
+            "a-leg@test",
+            t0 + TimeDelta::seconds(30),
+        ));
+        assert_eq!(store.find_correlated("a-leg@test").len(), 1);
     }
 
     #[test]

--- a/tests/cli/cmd/dump-config.trycmd
+++ b/tests/cli/cmd/dump-config.trycmd
@@ -9,6 +9,8 @@ sipnab v[..]
 
 [filter]
 
+[sip]
+
 [security]
 
 [limits]

--- a/tests/hep_test.rs
+++ b/tests/hep_test.rs
@@ -45,7 +45,7 @@ fn hep3_sip(payload: &[u8]) -> Vec<u8> {
         src_port: 5060,
         dst_port: 5062,
     };
-    build_hep_v3(&ep, Utc::now(), HepProtocol::Sip, 0, payload)
+    build_hep_v3(&ep, Utc::now(), HepProtocol::Sip, 0, None, payload)
 }
 
 /// A spawned `sipnab --hep-listen` process with line-buffered stdout/stderr.

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -155,7 +155,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2457 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2470 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -226,7 +226,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2457" data-suffix="">2457</span>
+        <span class="arch-stat" data-count="2470" data-suffix="">2470</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Three verified sngrep/sipgrep parity gaps (from the re-audit), batched for one release.

## `-p` / `--no-promisc` (sipgrep `-p`)
Opt out of promiscuous mode. Threaded through `CaptureConfig`; the `any` pseudo-device stays non-promiscuous regardless. Also `[capture] promisc`.

## `[sip] xcid_headers` (sngrep `sip.xcid`)
Configurable B2BUA leg-correlation header names, replacing the hardcoded `"X-Call-ID"` in `DialogStore` correlation. Default stays `["X-Call-ID"]`; add e.g. `["X-Call-ID", "X-CID"]`. Wired through the batch, TUI, and `--cores` paths via a `with_xcid_headers` builder (constructor unchanged).

## `--hep-auth` / `--hep-id` (Homer)
`--hep-auth <KEY>` adds the authenticate-key `0x000e` chunk (also `SIPNAB_HEP_AUTH`, keeping the secret out of `ps`); `--hep-id <ID>` sets the capture-agent `0x000c` chunk. Previously the sender emitted no auth key and a hardcoded capture id of 1.

## Tests
Unit: promisc config matrix + CLI flag; DialogStore custom/default/empty xcid correlation + `[sip]` parse; `build_hep_v3` auth-chunk present/absent + CLI flags. **Real-binary e2e** captured a HEP packet on a loopback listener and verified the `0x000e` auth key (`s3cr3t`) and `0x000c` capture id (`42`). Docs, man page, CHANGELOG, and the dump-config golden updated. Targets the next release.