### PR TITLE
sipgrep parity: column-save, parse-size cap, reassembly toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **TUI**: the F10 column selector now saves the current column layout with
+  `s`, writing `[display] visible_columns` into your sipnabrc so it persists
+  across runs (previously the layout had to be hand-edited into the config).
+- **Capture**: `-S` / `--limitlen <BYTES>` (sipgrep `-S`) — parse only the
+  first N bytes of each packet, independent of the capture snaplen and the
+  display truncation.
+- **Capture**: `--no-reassembly` — disable IP-fragment and TCP-segment
+  reassembly (inverse of sipgrep `-a`); every packet is parsed standalone.
+
 ## [0.5.8] - 2026-07-16
 
 ### Added

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -14,6 +14,8 @@ CLI flags always override config file values (see [config-reference.md](config-r
 | `-B`, `--buffer` | `<MIB>` | `2` | Kernel capture buffer size in MiB |
 | `--buffer-budget` | `<MIB>` | `64` | Memory budget for the in-flight capture→processing queue. The queue grows under load up to this budget (capped, never OOM) and shrinks when idle; overrides `[capture] buffer_budget_mb` |
 | `--snaplen` | `<BYTES>` | `65535` | Snapshot length for packet capture (bytes) |
+| `-S`, `--limitlen` | `<BYTES>` | -- | Parse only the first N bytes of each packet (sipgrep `-S`). Caps what the SIP parser and matchers inspect, independent of `--snaplen` (capture length) and `--payload-limit` (display truncation) |
+| `--no-reassembly` | -- | off | Disable IP-fragment and TCP-segment reassembly; every packet is parsed standalone (inverse of sipgrep `-a`). Useful for pure single-packet UDP scanning |
 | `--portrange` | `<RANGE>` | `5060-5061` | SIP port range to capture |
 | `--multi-device` | -- | off | Capture on all available interfaces |
 | `--no-rtp` | -- | off | Disable RTP capture and analysis |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -268,6 +268,7 @@ browse your own files.
 | Up / k | Move selection up |
 | Down / j | Move selection down |
 | Space | Toggle column visibility |
+| s | Save the current layout to `[display] visible_columns` in your sipnabrc (persists across runs) |
 | Enter / Esc | Close selector |
 
 ## Timestamp Modes

--- a/src/app/batch.rs
+++ b/src/app/batch.rs
@@ -139,6 +139,8 @@ pub fn run_cores_file(
         no_dialog: cli.no_dialog,
         no_rtp,
         xcid_headers: config.sip.xcid_headers.clone().unwrap_or_default(),
+        reassembly: !cli.no_reassembly,
+        parse_limit: cli.limitlen,
     };
     match crate::parallel::run_offline_parallel_file(
         std::path::Path::new(input),
@@ -195,6 +197,8 @@ pub fn run(
             no_dialog: cli.no_dialog,
             no_rtp,
             xcid_headers: config.sip.xcid_headers.clone().unwrap_or_default(),
+            reassembly: !cli.no_reassembly,
+            parse_limit: cli.limitlen,
         };
         let result = crate::parallel::run_offline_parallel(rx, pcfg);
         let _ = handle.thread.join();
@@ -293,7 +297,9 @@ impl BatchRunner {
         // (when --api is set) reads from the SAME store the packet loop writes
         // to, eliminating the prior mirror-and-double-parse pattern. In the
         // common single-writer batch case the locks are uncontested.
-        let processor = capture::PacketProcessor::with_max_sessions(cli.max_reassembly as usize);
+        let processor = capture::PacketProcessor::with_max_sessions(cli.max_reassembly as usize)
+            .with_reassembly(!cli.no_reassembly)
+            .with_parse_limit(cli.limitlen);
         let dialog_store: Arc<RwLock<DialogStore>> = Arc::new(RwLock::new(
             DialogStore::new(cli.limit as usize, cli.rotate_enabled())
                 .with_xcid_headers(config.sip.xcid_headers.clone().unwrap_or_default()),

--- a/src/app/tui_mode.rs
+++ b/src/app/tui_mode.rs
@@ -116,7 +116,9 @@ pub fn run_tui_mode(
         .name("tui-processor".to_string())
         .spawn(move || {
             let mut processor =
-                capture::PacketProcessor::with_max_sessions(cli_clone.max_reassembly as usize);
+                capture::PacketProcessor::with_max_sessions(cli_clone.max_reassembly as usize)
+                    .with_reassembly(!cli_clone.no_reassembly)
+                    .with_parse_limit(cli_clone.limitlen);
             let mut rtp_heuristic = rtp::heuristic::RtpHeuristic::new();
 
             // SRTP/DTLS-SRTP media-decryption state for the live pipeline.

--- a/src/capture/hep.rs
+++ b/src/capture/hep.rs
@@ -1248,6 +1248,27 @@ mod tests {
     }
 
     #[test]
+    fn hep_auth_chunk_handles_special_bytes() {
+        // An auth key with backslashes / colons / slashes must round-trip
+        // verbatim in the 0x000e chunk (no escaping or truncation).
+        let ts = Utc.timestamp_opt(1700000000, 0).single().unwrap();
+        let key = "k3y\\with:special/chars";
+        let pkt = build_hep_v3(&v4_endpoint(), ts, HepProtocol::Sip, 7, Some(key), b"X");
+        assert_eq!(
+            find_hep_chunk(&pkt, 0x0000, 0x000e).as_deref(),
+            Some(key.as_bytes())
+        );
+    }
+
+    #[test]
+    fn hep_custom_capture_id_round_trips() {
+        // A non-default capture/agent id is emitted and parses back.
+        let ts = Utc.timestamp_opt(1700000000, 0).single().unwrap();
+        let pkt = build_hep_v3(&v4_endpoint(), ts, HepProtocol::Sip, 4242, None, b"X");
+        assert_eq!(parse_hep(&pkt).unwrap().capture_id, Some(4242));
+    }
+
+    #[test]
     fn hep_no_auth_chunk_when_key_absent() {
         let ts = Utc.timestamp_opt(1700000000, 0).single().unwrap();
         let pkt = build_hep_v3(&v4_endpoint(), ts, HepProtocol::Sip, 1, None, b"INVITE");

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -75,6 +75,13 @@ pub struct PacketProcessor {
     tcp_sip_leftover:
         std::collections::HashMap<(std::net::SocketAddr, std::net::SocketAddr), Vec<u8>>,
     max_sessions: usize,
+    /// When `false` (`--no-reassembly`), IP fragments and TCP segments pass
+    /// through as individual packets instead of being reassembled/reframed.
+    reassembly: bool,
+    /// When `Some(n)` (`-S`/`--limitlen`), each emitted packet's payload is
+    /// truncated to `n` bytes before upper-layer parsing — the sipgrep `-S`
+    /// "look at only the first N bytes" cap, independent of the capture snaplen.
+    parse_limit: Option<usize>,
 }
 
 /// Default reassembly session cap (matches the reassemblers' default).
@@ -93,7 +100,25 @@ impl PacketProcessor {
             tcp_reassembler: TcpReassembler::new(),
             tcp_sip_leftover: std::collections::HashMap::new(),
             max_sessions: DEFAULT_MAX_SESSIONS,
+            reassembly: true,
+            parse_limit: None,
         }
+    }
+
+    /// Builder: enable or disable IP-fragment / TCP-segment reassembly
+    /// (`--no-reassembly` sets this `false`). Default `true`.
+    #[must_use]
+    pub fn with_reassembly(mut self, on: bool) -> Self {
+        self.reassembly = on;
+        self
+    }
+
+    /// Builder: cap the bytes of each emitted packet handed to the parser
+    /// (`-S`/`--limitlen`). Default `None` (no cap).
+    #[must_use]
+    pub fn with_parse_limit(mut self, limit: Option<usize>) -> Self {
+        self.parse_limit = limit;
+        self
     }
 
     /// Create a new packet processor with a custom maximum reassembly session count.
@@ -109,6 +134,8 @@ impl PacketProcessor {
             ),
             tcp_sip_leftover: std::collections::HashMap::new(),
             max_sessions,
+            reassembly: true,
+            parse_limit: None,
         }
     }
 
@@ -118,7 +145,21 @@ impl PacketProcessor {
     /// - **Zero:** packet is non-IP, a buffered fragment, or a buffered TCP segment.
     /// - **One:** typical UDP packet or a completed fragment/TCP flush.
     /// - **Multiple:** TCP reassembly may flush several accumulated segments.
+    ///
+    /// Applies the `-S`/`--limitlen` parse cap to every emitted packet.
     pub fn process(&mut self, packet: &Packet) -> ParsedPackets {
+        let mut out = self.process_inner(packet);
+        if let Some(limit) = self.parse_limit {
+            for p in out.iter_mut() {
+                if p.payload.len() > limit {
+                    p.payload = p.payload.slice(..limit);
+                }
+            }
+        }
+        out
+    }
+
+    fn process_inner(&mut self, packet: &Packet) -> ParsedPackets {
         let parsed = match parse_packet(packet) {
             Ok(p) => p,
             Err(e) => {
@@ -126,6 +167,12 @@ impl PacketProcessor {
                 return SmallVec::new();
             }
         };
+
+        // Reassembly disabled (`--no-reassembly`): every packet stands alone —
+        // IP fragments and TCP segments are neither reassembled nor reframed.
+        if !self.reassembly {
+            return smallvec![parsed];
+        }
 
         // Check if this is an IP fragment that needs reassembly
         let is_fragment =
@@ -612,6 +659,43 @@ mod tests {
     }
 
     #[test]
+    fn no_reassembly_passes_tcp_segment_through_unframed() {
+        // Two SIP messages packed in one TCP segment: with reassembly OFF
+        // (sipgrep -a inverse) the raw segment emerges as a single packet,
+        // not reframed into individual messages.
+        let mut payload = opts("a");
+        payload.extend(opts("b"));
+        let pkt = tcp_frame(&payload, 1000, true, false);
+
+        let mut proc = PacketProcessor::new().with_reassembly(false);
+        let out = proc.process(&pkt);
+        assert_eq!(
+            out.len(),
+            1,
+            "no reassembly emits the raw segment as one packet"
+        );
+        assert_eq!(
+            &out[0].payload[..],
+            &payload[..],
+            "bytes pass through intact"
+        );
+    }
+
+    #[test]
+    fn reassembly_on_by_default_reframes_tcp() {
+        // Contrast: the default processor DOES reframe the same segment.
+        let mut payload = opts("a");
+        payload.extend(opts("b"));
+        let mut proc = PacketProcessor::new();
+        let out = proc.process(&tcp_frame(&payload, 1000, true, false));
+        assert_eq!(
+            out.len(),
+            2,
+            "default reassembly reframes into two messages"
+        );
+    }
+
+    #[test]
     fn process_passes_non_sip_tcp_through_unframed() {
         // TLS-over-TCP (and other binary payloads) must NOT be SIP-framed — they
         // pass through whole so downstream TLS decryption still sees them.
@@ -705,6 +789,42 @@ mod tests {
             assert_eq!(out.len(), 1);
             assert_eq!(out[0].transport, parse::TransportProto::Udp);
             assert_eq!(out[0].dst_port, 5060);
+        }
+
+        #[test]
+        fn parse_limit_truncates_payload() {
+            // `-S`/`--limitlen`: only the first N bytes of each message are
+            // handed downstream, independent of capture snaplen.
+            let mut proc = PacketProcessor::new().with_parse_limit(Some(10));
+            let sip = b"REGISTER sip:x SIP/2.0\r\nCall-ID: hidden-after-limit\r\n\r\n";
+            let out = proc.process(&packet(eth_ipv4_udp(5060, 5060, sip)));
+            assert_eq!(out.len(), 1);
+            assert_eq!(
+                out[0].payload.len(),
+                10,
+                "payload capped to the parse limit"
+            );
+            assert_eq!(&out[0].payload[..], &sip[..10]);
+        }
+
+        #[test]
+        fn parse_limit_none_keeps_full_payload() {
+            let mut proc = PacketProcessor::new();
+            let sip = b"REGISTER sip:x SIP/2.0\r\n\r\n";
+            let out = proc.process(&packet(eth_ipv4_udp(5060, 5060, sip)));
+            assert_eq!(out[0].payload.len(), sip.len(), "no limit → full payload");
+        }
+
+        #[test]
+        fn parse_limit_larger_than_payload_is_noop() {
+            let mut proc = PacketProcessor::new().with_parse_limit(Some(100_000));
+            let sip = b"REGISTER sip:x SIP/2.0\r\n\r\n";
+            let out = proc.process(&packet(eth_ipv4_udp(5060, 5060, sip)));
+            assert_eq!(
+                out[0].payload.len(),
+                sip.len(),
+                "limit beyond payload is a no-op"
+            );
         }
 
         #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,6 +145,23 @@ pub struct Cli {
     #[arg(help_heading = "Capture", long, value_name = "BYTES")]
     pub snaplen: Option<u32>,
 
+    /// Parse only the first N bytes of each packet (sipgrep -S). Caps what the
+    /// SIP parser and matchers inspect, independent of the capture snaplen
+    /// (`--snaplen`) and the display truncation (`--payload-limit`).
+    #[arg(
+        help_heading = "Capture",
+        short = 'S',
+        long = "limitlen",
+        value_name = "BYTES"
+    )]
+    pub limitlen: Option<usize>,
+
+    /// Disable IP-fragment and TCP-segment reassembly; every packet is parsed
+    /// standalone. The inverse of sipgrep's `-a`. Useful for pure single-packet
+    /// UDP scanning where reassembly is only overhead.
+    #[arg(help_heading = "Capture", long = "no-reassembly")]
+    pub no_reassembly: bool,
+
     /// SIP port range to capture [default: 5060-5061]. An Option (not a
     /// clap default) so an explicit `--portrange 5060-5061` still overrides
     /// a config-file range.
@@ -1227,6 +1244,20 @@ mod tests {
             cli.bpf_filter,
             vec!["host", "10.0.0.1", "and", "port", "5060"]
         );
+    }
+
+    #[test]
+    fn limitlen_and_no_reassembly_flags_parse() {
+        // Short form.
+        let cli = Cli::parse_from_args(["sipnab", "-S", "512", "--no-reassembly"]);
+        assert_eq!(cli.limitlen, Some(512));
+        assert!(cli.no_reassembly);
+        // Long form (`--limitlen`).
+        let long = Cli::parse_from_args(["sipnab", "--limitlen", "256"]);
+        assert_eq!(long.limitlen, Some(256));
+        let d = Cli::parse_from_args(["sipnab"]);
+        assert_eq!(d.limitlen, None);
+        assert!(!d.no_reassembly);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -737,6 +737,51 @@ pub fn upsert_manual_mappings(
     Ok(doc.to_string())
 }
 
+/// Surgically set `[display] visible_columns` in a sipnabrc document.
+///
+/// Parses `existing` (may be empty), writes `columns` (ordered column labels)
+/// as `[display] visible_columns`, and returns the new document text with all
+/// comments, key ordering, and other sections preserved. The previous value is
+/// fully replaced.
+pub fn upsert_display_columns(existing: &str, columns: &[String]) -> Result<String, crate::Error> {
+    use toml_edit::{Array, DocumentMut, Item, Table, value};
+
+    let mut doc = existing
+        .parse::<DocumentMut>()
+        .map_err(|e| crate::Error::ConfigInvalid(format!("sipnabrc is not valid TOML: {e}")))?;
+
+    if doc.get("display").is_none() {
+        doc["display"] = Item::Table(Table::new());
+    }
+    let display = doc["display"]
+        .as_table_mut()
+        .ok_or_else(|| crate::Error::ConfigInvalid("[display] is not a table".into()))?;
+
+    let mut arr = Array::new();
+    for c in columns {
+        arr.push(c.as_str());
+    }
+    display["visible_columns"] = value(arr);
+
+    Ok(doc.to_string())
+}
+
+/// Write the current visible column layout into `[display] visible_columns` of
+/// the sipnabrc at `path`, preserving the rest of the file (see
+/// [`upsert_display_columns`]). Creates the file and parent directory if needed.
+pub fn write_display_columns_file(path: &Path, columns: &[String]) -> Result<(), crate::Error> {
+    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    let updated = upsert_display_columns(&existing, columns)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            crate::Error::ConfigInvalid(format!("create {}: {e}", parent.display()))
+        })?;
+    }
+    std::fs::write(path, updated)
+        .map_err(|e| crate::Error::ConfigInvalid(format!("write {}: {e}", path.display())))?;
+    Ok(())
+}
+
 /// Return the default config file search paths (items 3-5).
 fn default_config_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
@@ -856,6 +901,84 @@ enabled = true
     #[test]
     fn upsert_manual_rejects_invalid_toml() {
         assert!(upsert_manual_mappings("this is = = not toml", &[]).is_err());
+    }
+
+    // ── display column persistence (F10 save) ────────────────────────
+
+    #[test]
+    fn upsert_display_columns_preserves_other_sections() {
+        let existing = "# my config\n[capture]\nsnaplen = 1500\n";
+        let cols = vec!["#".to_string(), "Method".to_string(), "From".to_string()];
+        let out = upsert_display_columns(existing, &cols).expect("valid toml");
+        // Unrelated section + comment survive.
+        assert!(out.contains("# my config"));
+        assert!(out.contains("snaplen = 1500"));
+        // Round-trips into the typed config.
+        let cfg: Config = toml::from_str(&out).unwrap();
+        assert_eq!(
+            cfg.display.visible_columns.as_deref(),
+            Some(cols.as_slice())
+        );
+        assert_eq!(cfg.capture.snaplen, Some(1500));
+    }
+
+    #[test]
+    fn upsert_display_columns_replaces_existing() {
+        let existing = "[display]\nvisible_columns = [\"#\", \"State\"]\n";
+        let cols = vec!["Method".to_string(), "Duration".to_string()];
+        let out = upsert_display_columns(existing, &cols).unwrap();
+        let cfg: Config = toml::from_str(&out).unwrap();
+        assert_eq!(
+            cfg.display.visible_columns.as_deref(),
+            Some(cols.as_slice())
+        );
+        assert!(
+            !out.contains("State"),
+            "stale columns must be replaced:\n{out}"
+        );
+    }
+
+    #[test]
+    fn upsert_display_columns_rejects_invalid_toml() {
+        assert!(upsert_display_columns("this is = = not toml", &[]).is_err());
+    }
+
+    #[test]
+    fn upsert_display_columns_empty_writes_empty_array() {
+        // Hiding every column persists as an empty list, not a missing key.
+        let out = upsert_display_columns("", &[]).unwrap();
+        let cfg: Config = toml::from_str(&out).unwrap();
+        assert_eq!(cfg.display.visible_columns.as_deref(), Some([].as_slice()));
+    }
+
+    #[test]
+    fn write_display_columns_file_creates_dirs_and_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested/sipnab.toml");
+        let cols = vec![
+            "#".to_string(),
+            "Method".to_string(),
+            "Duration".to_string(),
+        ];
+        write_display_columns_file(&path, &cols).unwrap();
+        let cfg = Config::load(Some(path.to_str().unwrap()), false)
+            .unwrap()
+            .config;
+        assert_eq!(
+            cfg.display.visible_columns.as_deref(),
+            Some(cols.as_slice())
+        );
+
+        // A second write replaces the set.
+        let cols2 = vec!["From".to_string(), "To".to_string()];
+        write_display_columns_file(&path, &cols2).unwrap();
+        let cfg = Config::load(Some(path.to_str().unwrap()), false)
+            .unwrap()
+            .config;
+        assert_eq!(
+            cfg.display.visible_columns.as_deref(),
+            Some(cols2.as_slice())
+        );
     }
 
     #[test]

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -68,6 +68,10 @@ pub struct ParallelConfig {
     /// Correlation header names for B2BUA leg matching (sngrep `sip.xcid`).
     /// Empty falls back to the `DialogStore` default (`["X-Call-ID"]`).
     pub xcid_headers: Vec<String>,
+    /// Reassemble IP fragments / TCP segments (`--no-reassembly` sets false).
+    pub reassembly: bool,
+    /// Cap on parsed bytes per packet (`-S`/`--limitlen`).
+    pub parse_limit: Option<usize>,
 }
 
 /// Merged reconstruction output of all workers.
@@ -157,7 +161,9 @@ pub fn run_offline_parallel(rx: PacketRx, cfg: ParallelConfig) -> ReconResult {
         .map(|wrx| {
             let cfg = cfg.clone();
             thread::spawn(move || {
-                let mut processor = PacketProcessor::with_max_sessions(cfg.max_reassembly);
+                let mut processor = PacketProcessor::with_max_sessions(cfg.max_reassembly)
+                    .with_reassembly(cfg.reassembly)
+                    .with_parse_limit(cfg.parse_limit);
                 let mut ds = DialogStore::new(cfg.max_dialogs, cfg.rotate)
                     .with_xcid_headers(cfg.xcid_headers.clone());
                 let mut ss = StreamStore::new(cfg.max_streams);
@@ -258,7 +264,9 @@ pub fn run_offline_parallel_file(
         .map(|wrx| {
             let cfg = cfg.clone();
             thread::spawn(move || {
-                let mut processor = PacketProcessor::with_max_sessions(cfg.max_reassembly);
+                let mut processor = PacketProcessor::with_max_sessions(cfg.max_reassembly)
+                    .with_reassembly(cfg.reassembly)
+                    .with_parse_limit(cfg.parse_limit);
                 let mut ds = DialogStore::new(cfg.max_dialogs, cfg.rotate)
                     .with_xcid_headers(cfg.xcid_headers.clone());
                 let mut ss = StreamStore::new(cfg.max_streams);
@@ -493,6 +501,8 @@ mod tests {
             no_dialog: false,
             no_rtp: false,
             xcid_headers: Vec::new(),
+            reassembly: true,
+            parse_limit: None,
         }
     }
 

--- a/src/sip/matcher.rs
+++ b/src/sip/matcher.rs
@@ -625,6 +625,26 @@ mod tests {
     }
 
     #[test]
+    fn match_expr_invalid_regex_via_flag_errors() {
+        // A malformed `-e` pattern must fail to build the matcher (not panic or
+        // silently match nothing).
+        let cli = Cli::parse_from_args(["sipnab", "-e", "[unterminated"]);
+        let result = SipMatcher::new(&cli, cli.match_expr.as_deref());
+        assert!(
+            result.is_err(),
+            "-e with invalid regex must return an error"
+        );
+    }
+
+    #[test]
+    fn match_expr_oversized_via_flag_errors() {
+        // A >1 MB `-e` pattern trips the ReDoS size guard.
+        let huge = "a".repeat(2_000_000);
+        let cli = Cli::parse_from_args(["sipnab", "-e", &huge]);
+        assert!(SipMatcher::new(&cli, cli.match_expr.as_deref()).is_err());
+    }
+
+    #[test]
     fn match_expr_honors_ignore_case_and_invert() {
         // -i makes the expression case-insensitive; -v inverts the result.
         let cli = Cli::parse_from_args(["sipnab", "-i", "-v", "-e", "register"]);

--- a/src/tui/call_list.rs
+++ b/src/tui/call_list.rs
@@ -294,6 +294,18 @@ impl CallListState {
         }
     }
 
+    /// The labels of the currently-visible columns, in [`COLUMN_LABELS`] order.
+    /// Inverse of [`apply_visible_columns`](Self::apply_visible_columns); used to
+    /// persist the column layout to `[display] visible_columns`.
+    pub fn visible_column_names(&self) -> Vec<String> {
+        COLUMN_LABELS
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| self.visible_columns[*i])
+            .map(|(_, &label)| label.to_string())
+            .collect()
+    }
+
     /// Clear the multi-selected rows list.
     pub fn clear_selections(&mut self) {
         self.selected_rows.clear();
@@ -857,7 +869,7 @@ pub fn render_column_selector(
     theme: &super::Theme,
 ) {
     let popup_width: u16 = 38;
-    let popup_height: u16 = (ALL_COLUMNS.len() as u16) + 5; // columns + borders + footer
+    let popup_height: u16 = (ALL_COLUMNS.len() as u16) + 6; // columns + borders + 2-line footer
     let w = popup_width.min(area.width);
     let h = popup_height.min(area.height);
     let x = area.x + (area.width.saturating_sub(w)) / 2;
@@ -897,6 +909,10 @@ pub fn render_column_selector(
     lines.push(ratatui::text::Line::from(""));
     lines.push(ratatui::text::Line::from(Span::styled(
         "  Space: toggle  Enter: apply",
+        Style::default().fg(theme.muted),
+    )));
+    lines.push(ratatui::text::Line::from(Span::styled(
+        "  s: save layout to config",
         Style::default().fg(theme.muted),
     )));
 
@@ -1389,5 +1405,46 @@ mod tests {
         assert_eq!(state_display_str(&DialogState::InCall), "InCall");
         assert_eq!(state_display_str(&DialogState::Failed), "FAILED");
         assert_eq!(state_display_str(&DialogState::Completed), "Completed");
+    }
+
+    #[test]
+    fn visible_column_names_default_is_all() {
+        let state = CallListState::new();
+        assert_eq!(state.visible_column_names(), COLUMN_LABELS.to_vec());
+    }
+
+    #[test]
+    fn visible_column_names_subset_in_order() {
+        let mut state = CallListState::new();
+        // Hide "Method" (idx 1) and "Date" (idx 8); the rest stay in order.
+        state.visible_columns[1] = false;
+        state.visible_columns[8] = false;
+        let names = state.visible_column_names();
+        assert!(!names.contains(&"Method".to_string()));
+        assert!(!names.contains(&"Date".to_string()));
+        assert_eq!(names.first().map(String::as_str), Some("#"));
+        assert_eq!(names.last().map(String::as_str), Some("Duration"));
+        assert_eq!(names.len(), 9);
+    }
+
+    #[test]
+    fn visible_column_names_none_visible_is_empty() {
+        let mut state = CallListState::new();
+        state.visible_columns = [false; 11];
+        assert!(state.visible_column_names().is_empty());
+    }
+
+    #[test]
+    fn visible_column_names_round_trips_through_apply() {
+        // Names produced by the getter re-apply to the same visibility set —
+        // the exact contract the save→reload path relies on.
+        let mut state = CallListState::new();
+        state.visible_columns[2] = false; // hide "From"
+        state.visible_columns[5] = false; // hide "Destination"
+        let names = state.visible_column_names();
+
+        let mut reloaded = CallListState::new();
+        reloaded.apply_visible_columns(&names);
+        assert_eq!(reloaded.visible_columns, state.visible_columns);
     }
 }

--- a/src/tui/controllers/call_list.rs
+++ b/src/tui/controllers/call_list.rs
@@ -231,10 +231,27 @@ pub(in crate::tui) fn handle_column_selector_key(app: &mut App, key: KeyEvent) {
         KeyCode::Up | KeyCode::Char('k') => app.call_list.column_selector_up(),
         KeyCode::Down | KeyCode::Char('j') => app.call_list.column_selector_down(),
         KeyCode::Char(' ') => app.call_list.toggle_column_visibility(),
+        KeyCode::Char('s') => save_columns(app),
         KeyCode::Enter | KeyCode::Esc => {
             app.call_list.column_selector_open = false;
         }
         _ => {}
+    }
+}
+
+/// Persist the current column layout to `[display] visible_columns` in the
+/// user's sipnabrc, then close the selector. Reports the outcome on the status
+/// line. A no-op (with an error message) when no config path is available.
+pub(in crate::tui) fn save_columns(app: &mut App) {
+    app.call_list.column_selector_open = false;
+    let cols = app.call_list.visible_column_names();
+    let Some(path) = app.column_config_path.clone() else {
+        app.status_error = Some("Cannot save columns: no config path".to_string());
+        return;
+    };
+    match crate::config::write_display_columns_file(&path, &cols) {
+        Ok(()) => app.status_error = Some(format!("Saved columns to {}", path.display())),
+        Err(e) => app.status_error = Some(format!("Save columns failed: {e}")),
     }
 }
 
@@ -318,6 +335,61 @@ pub(in crate::tui) fn clear_matching(app: &mut App) {
 mod tests {
     use super::*;
     use crate::tui::controllers::test_support::*;
+
+    #[test]
+    fn save_columns_without_config_path_reports_error() {
+        // Default test App has no column_config_path → save is a safe no-op
+        // that surfaces an error rather than writing anywhere.
+        let mut app = App::new_test();
+        app.call_list.column_selector_open = true;
+        handle_call_list_key(&mut app, key(KeyCode::Char('s')));
+        assert!(!app.call_list.column_selector_open, "selector should close");
+        assert!(
+            app.status_error
+                .as_deref()
+                .unwrap_or("")
+                .contains("no config path"),
+            "got: {:?}",
+            app.status_error
+        );
+    }
+
+    #[test]
+    fn save_columns_writes_visible_layout_to_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sub/sipnab.toml");
+        let mut app = App::new_test();
+        app.set_column_config_path(Some(path.clone()));
+
+        // Hide the first column ("#") via the selector, then save with `s`.
+        app.call_list.column_selector_open = true;
+        app.call_list.column_selector_cursor = 0;
+        handle_call_list_key(&mut app, key(KeyCode::Char(' '))); // toggle "#" off
+        handle_call_list_key(&mut app, key(KeyCode::Char('s'))); // save
+
+        assert!(!app.call_list.column_selector_open);
+        assert!(
+            app.status_error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Saved columns")
+        );
+
+        // The written config reloads with "#" hidden and the other 10 present.
+        let cfg = crate::config::Config::load(Some(path.to_str().unwrap()), false)
+            .unwrap()
+            .config;
+        let cols = cfg
+            .display
+            .visible_columns
+            .expect("visible_columns written");
+        assert_eq!(cols.len(), 10);
+        assert!(
+            !cols.iter().any(|c| c == "#"),
+            "hidden column must be absent"
+        );
+        assert!(cols.iter().any(|c| c == "Method"));
+    }
 
     #[test]
     fn call_list_u_cycles_from_to_mode() {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -161,6 +161,9 @@ pub struct App {
     /// When `Some`, `N`-dialog edits are also written into this sipnabrc's
     /// `[names.manual]` table (opt-in via `[names] persist_to_config`).
     names_config_path: Option<PathBuf>,
+    /// Where the F10 column selector's `s` (save) action writes
+    /// `[display] visible_columns`. `None` in tests / when no home dir exists.
+    column_config_path: Option<PathBuf>,
     /// "Name Address" popup state.
     name_dialog: NameDialogState,
     sdp_display_mode: SdpDisplayMode,
@@ -245,6 +248,7 @@ impl App {
             resolver: Arc::new(NameResolver::new()),
             names_save_path: None,
             names_config_path: None,
+            column_config_path: None,
             name_dialog: NameDialogState::default(),
             header_form: header_form::HeaderFormMode::default(),
             sdp_display_mode: SdpDisplayMode::default(),
@@ -887,6 +891,8 @@ pub fn run_tui_with_pause(
     app.set_name_mode(name_setup.mode);
     app.set_names_save_path(name_setup.save_path);
     app.set_names_config_path(name_setup.config_path);
+    // The F10 column selector's `s` saves into the user's sipnabrc.
+    app.set_column_config_path(crate::config::default_user_config_path());
 
     // Dead rebinds (duplicates, or shadowed by a view's built-in key) used
     // to fail silently; warn on stderr and in the status line at startup.

--- a/src/tui/test_api.rs
+++ b/src/tui/test_api.rs
@@ -200,6 +200,12 @@ impl App {
         self.names_config_path = path;
     }
 
+    /// Where the F10 column selector's save (`s`) action writes
+    /// `[display] visible_columns`.
+    pub fn set_column_config_path(&mut self, path: Option<PathBuf>) {
+        self.column_config_path = path;
+    }
+
     /// Count dialogs visible after applying the active filter.
     pub fn visible_dialog_count(&self) -> usize {
         filtered_dialog_count(self)

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_column_selector_popup.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_column_selector_popup.snap
@@ -1,16 +1,14 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 791
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
  Match Expression:     BPF Filter:
  Display Filter:
-  # ▲   Metho From To   Source    Destinatio State     Msgs Date   PDD    Durati
-> [ ]1  INVIT 1001 10┌ Columns ───────────────────────────┐ +0.000 1000ms 1m2s
-  [ ]2  INVIT 1003 10│> [x] #                             │ +5.000        1.0s
-  [ ]3  INVIT 1005 10│  [x] Method                        │ +5.000        2.0s
-                     │  [x] From                          │
+  # ▲   Metho From To┌ Columns ───────────────────────────┐ Date   PDD    Durati
+> [ ]1  INVIT 1001 10│> [x] #                             │ +0.000 1000ms 1m2s
+  [ ]2  INVIT 1003 10│  [x] Method                        │ +5.000        1.0s
+  [ ]3  INVIT 1005 10│  [x] From                          │ +5.000        2.0s
                      │  [x] To                            │
                      │  [x] Source                        │
                      │  [x] Destination                   │
@@ -21,6 +19,7 @@ expression: output
                      │  [x] Duration                      │
                      │                                    │
                      │  Space: toggle  Enter: apply       │
+                     │  s: save layout to config          │
                      │                                    │
                      └────────────────────────────────────┘
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -155,7 +155,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2470 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2491 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -226,7 +226,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2470" data-suffix="">2470</span>
+        <span class="arch-stat" data-count="2491" data-suffix="">2491</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
The final three sngrep/sipgrep parity gaps (#6/#7/#8 from the re-audit), plus failure-scenario test backfill for the already-shipped features.

## #6 — TUI column-layout persistence
The F10 column selector now saves the current layout with `s`, writing `[display] visible_columns` into your sipnabrc so it persists across runs (previously hand-edit only). Mirrors the `[names] persist_to_config` write-back pattern.

## #7 — `-S` / `--limitlen <BYTES>` (sipgrep `-S`)
Parse only the first N bytes of each packet — caps what the SIP parser and matchers inspect, independent of `--snaplen` (capture length) and `--payload-limit` (display truncation).

## #8 — `--no-reassembly` (inverse of sipgrep `-a`)
Disable IP-fragment and TCP-segment reassembly; every packet is parsed standalone.

Both capture flags thread through the batch, TUI, and `--cores` paths via `PacketProcessor` builders and `ParallelConfig`.

## Tests — success + failure/boundary for every feature
- Config `upsert_display_columns`/`write_display_columns_file`: preserves other sections, replaces existing, **invalid-TOML errors**, empty, round-trip.
- `visible_column_names`: default / subset-in-order / **none-visible empty** / round-trips through apply.
- Controller save: writes to a temp config (success) / **no-config-path error**.
- `PacketProcessor`: parse-limit truncate / no-limit full / **oversize no-op**; reassembly **off-passthrough vs on-reframe**; CLI parse (short + long).
- Backfill for shipped features: **`-e` invalid/oversized regex errors**; **adversarial HEP auth-key bytes** + custom capture-id round-trip.

**Real-binary e2e**: `-S 5` starves the parser to 0 messages (vs 11 by default); `--no-reassembly` accepted, correctly no-ops on UDP. Docs, keybindings, CHANGELOG, and the column-selector snapshot updated. Targets the next release.