### PR TITLE
Add sipgrep parity: --proto-number, -x/--quiet-bad-parse

### DIFF
--- a/src/app/batch.rs
+++ b/src/app/batch.rs
@@ -138,6 +138,7 @@ pub fn run_cores_file(
         portrange,
         no_dialog: cli.no_dialog,
         no_rtp,
+        quiet_bad_parse: cli.quiet_bad_parse,
         xcid_headers: config.sip.xcid_headers.clone().unwrap_or_default(),
         reassembly: !cli.no_reassembly,
         parse_limit: cli.limitlen,
@@ -196,6 +197,7 @@ pub fn run(
             portrange,
             no_dialog: cli.no_dialog,
             no_rtp,
+            quiet_bad_parse: cli.quiet_bad_parse,
             xcid_headers: config.sip.xcid_headers.clone().unwrap_or_default(),
             reassembly: !cli.no_reassembly,
             parse_limit: cli.limitlen,
@@ -1137,6 +1139,7 @@ fn process_parsed_packet(
         no_dialog: cli.no_dialog,
         no_rtp,
         sip_portrange: Some(portrange),
+        quiet_bad_parse: cli.quiet_bad_parse,
     };
     #[cfg(feature = "tls")]
     let mut decrypt = crate::pipeline::MediaDecrypt {

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -200,6 +200,7 @@ pub fn plan(cli: &Cli, config: &Config) -> Result<RunPlan, PlanError> {
         delta_time: cli.delta_time || config.display.delta_time.unwrap_or(false),
         payload_limit: cli.payload_limit.or(config.display.payload_limit),
         show_empty: cli.show_empty,
+        show_proto_number: cli.proto_number,
     };
 
     // Event exec engine.

--- a/src/app/tui_mode.rs
+++ b/src/app/tui_mode.rs
@@ -245,6 +245,7 @@ pub fn run_tui_mode(
                             // Live capture: BPF (auto-generated from
                             // --portrange) already filtered; no SIP port gate.
                             sip_portrange: None,
+                            quiet_bad_parse: cli_clone.quiet_bad_parse,
                         },
                         &mut media_decrypt,
                     );

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -162,6 +162,13 @@ pub struct Cli {
     #[arg(help_heading = "Capture", long = "no-reassembly")]
     pub no_reassembly: bool,
 
+    /// Quiet bad-parse packets (sipgrep -x): suppress the per-packet
+    /// diagnostic emitted when a SIP-looking packet fails to parse. The packet
+    /// is dropped either way; this only silences the "SIP parse error" notice
+    /// on a noisy link (visible under -v / debug logging).
+    #[arg(help_heading = "Capture", short = 'x', long = "quiet-bad-parse")]
+    pub quiet_bad_parse: bool,
+
     /// SIP port range to capture [default: 5060-5061]. An Option (not a
     /// clap default) so an explicit `--portrange 5060-5061` still overrides
     /// a config-file range.
@@ -385,6 +392,12 @@ pub struct Cli {
     /// Show messages with empty bodies.
     #[arg(help_heading = "Output", long)]
     pub show_empty: bool,
+
+    /// Annotate the transport tag with the IANA IP protocol number, e.g.
+    /// `UDP(17)` / `TCP(6)` (sipgrep -N). `-N` itself is `--no-tui` here, so
+    /// this flag is long-only. TLS/WS report their TCP carrier's number (6).
+    #[arg(help_heading = "Output", long = "proto-number")]
+    pub proto_number: bool,
 
     /// Flush output after each line (useful for piping).
     #[arg(help_heading = "Output", long)]
@@ -1314,6 +1327,20 @@ mod tests {
 
         let none = Cli::parse_from_args(["sipnab"]);
         assert_eq!(none.match_expr, None);
+    }
+
+    #[test]
+    fn proto_number_flag_parses() {
+        // Long-only: `-N` is already taken by `--no-tui`.
+        assert!(Cli::parse_from_args(["sipnab", "--proto-number"]).proto_number);
+        assert!(!Cli::parse_from_args(["sipnab"]).proto_number);
+    }
+
+    #[test]
+    fn quiet_bad_parse_short_and_long_flags() {
+        assert!(Cli::parse_from_args(["sipnab", "-x"]).quiet_bad_parse);
+        assert!(Cli::parse_from_args(["sipnab", "--quiet-bad-parse"]).quiet_bad_parse);
+        assert!(!Cli::parse_from_args(["sipnab"]).quiet_bad_parse);
     }
 
     #[test]

--- a/src/net.rs
+++ b/src/net.rs
@@ -33,6 +33,19 @@ impl TransportProto {
             Self::Ws => "WS",
         }
     }
+
+    /// IANA IP protocol number of the underlying transport (`sipgrep -N`).
+    ///
+    /// TLS and WebSocket are application framings over TCP, so both report
+    /// TCP's number (6) — the number identifies the IP-layer transport, not
+    /// the SIP framing.
+    pub fn ip_proto_number(self) -> u8 {
+        match self {
+            Self::Udp => 17,
+            Self::Tcp | Self::Tls | Self::Ws => 6,
+            Self::Sctp => 132,
+        }
+    }
 }
 
 impl std::fmt::Display for TransportProto {
@@ -57,5 +70,16 @@ mod tests {
             assert_eq!(proto.as_str(), s);
             assert_eq!(proto.to_string(), s);
         }
+    }
+
+    #[test]
+    fn ip_proto_number_maps_to_iana_transport() {
+        // sipgrep -N prints the IP sub-protocol number. TLS and WS both ride
+        // on TCP, so they report TCP's number (6), never their own tag.
+        assert_eq!(TransportProto::Udp.ip_proto_number(), 17);
+        assert_eq!(TransportProto::Tcp.ip_proto_number(), 6);
+        assert_eq!(TransportProto::Sctp.ip_proto_number(), 132);
+        assert_eq!(TransportProto::Tls.ip_proto_number(), 6);
+        assert_eq!(TransportProto::Ws.ip_proto_number(), 6);
     }
 }

--- a/src/output/cli_print.rs
+++ b/src/output/cli_print.rs
@@ -42,6 +42,9 @@ pub struct OutputOptions {
     pub payload_limit: Option<usize>,
     /// If `true`, show messages even when the body is empty.
     pub show_empty: bool,
+    /// If `true`, annotate the transport tag with the IANA IP protocol number
+    /// (`sipgrep -N`), e.g. `UDP(17)`.
+    pub show_proto_number: bool,
 }
 
 impl Default for OutputOptions {
@@ -51,6 +54,7 @@ impl Default for OutputOptions {
             delta_time: false,
             payload_limit: None,
             show_empty: true,
+            show_proto_number: false,
         }
     }
 }
@@ -151,9 +155,12 @@ pub fn format_sip_message(
         );
     }
 
-    // Transport tag
+    // Transport tag (optionally annotated with the IP proto number, sipgrep -N)
     out.push(' ');
     out.push_str(msg.transport.as_str());
+    if opts.show_proto_number {
+        let _ = write!(out, "({})", msg.transport.ip_proto_number());
+    }
     out.push('\n');
 
     // Payload (optional, with truncation)
@@ -363,6 +370,54 @@ mod tests {
             output.contains("+1.500s"),
             "should show delta time: got {output}"
         );
+    }
+
+    #[test]
+    fn proto_number_appended_to_transport_tag() {
+        let msg = make_invite();
+        let opts = OutputOptions {
+            color: ColorMode::Never,
+            show_proto_number: true,
+            ..Default::default()
+        };
+        let output = format_sip_message(&msg, &opts, None);
+        // UDP transport → IANA number 17, rendered adjacent to the tag.
+        assert!(
+            output.contains("UDP(17)"),
+            "should annotate transport with proto number: got {output}"
+        );
+    }
+
+    #[test]
+    fn proto_number_off_by_default() {
+        let msg = make_invite();
+        let opts = OutputOptions {
+            color: ColorMode::Never,
+            ..Default::default()
+        };
+        let output = format_sip_message(&msg, &opts, None);
+        assert!(
+            output.contains("UDP") && !output.contains("UDP("),
+            "default must show bare transport tag: got {output}"
+        );
+    }
+
+    #[test]
+    fn proto_number_with_color_stays_outside_reset() {
+        // Adversarial: the number must not land inside the ANSI color span
+        // for the method, which would corrupt the escape sequence.
+        let msg = make_invite();
+        let opts = OutputOptions {
+            color: ColorMode::Always,
+            show_proto_number: true,
+            ..Default::default()
+        };
+        let output = format_sip_message(&msg, &opts, None);
+        assert!(output.contains("UDP(17)"), "got {output}");
+        // The transport annotation sits after the method's RESET.
+        let reset_pos = output.find(RESET).expect("reset present");
+        let tag_pos = output.find("UDP(17)").expect("tag present");
+        assert!(tag_pos > reset_pos, "transport tag must follow reset");
     }
 
     #[test]

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -65,6 +65,8 @@ pub struct ParallelConfig {
     pub no_dialog: bool,
     /// Skip RTP/RTCP processing (`--no-rtp`).
     pub no_rtp: bool,
+    /// Suppress the bad-parse diagnostic (`--quiet-bad-parse`, sipgrep `-x`).
+    pub quiet_bad_parse: bool,
     /// Correlation header names for B2BUA leg matching (sngrep `sip.xcid`).
     /// Empty falls back to the `DialogStore` default (`["X-Call-ID"]`).
     pub xcid_headers: Vec<String>,
@@ -110,6 +112,7 @@ fn reconstruct(
         no_dialog: cfg.no_dialog,
         no_rtp: cfg.no_rtp,
         sip_portrange: Some(cfg.portrange),
+        quiet_bad_parse: cfg.quiet_bad_parse,
     };
     let mut decrypt = MediaDecrypt::default();
     match classify_packet(pp, heuristic, &opts, &mut decrypt) {
@@ -500,6 +503,7 @@ mod tests {
             portrange: (1, 65535),
             no_dialog: false,
             no_rtp: false,
+            quiet_bad_parse: false,
             xcid_headers: Vec::new(),
             reassembly: true,
             parse_limit: None,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -107,6 +107,10 @@ pub struct PipelineOptions {
     /// only; RTP uses SDP-negotiated dynamic ports and is never gated).
     /// `None` disables the gate (live capture, where BPF already filtered).
     pub sip_portrange: Option<(u16, u16)>,
+    /// Suppress the per-packet "SIP parse error" diagnostic for SIP-looking
+    /// packets that fail to parse (`--quiet-bad-parse`, sipgrep `-x`). The
+    /// packet is dropped either way; only the notice is silenced.
+    pub quiet_bad_parse: bool,
 }
 
 /// Optional media-decryption state threaded through the live pipeline: the SRTP
@@ -249,7 +253,9 @@ pub fn classify_packet(
                 };
             }
             Err(e) => {
-                tracing::debug!("SIP parse error: {e}");
+                if !opts.quiet_bad_parse {
+                    tracing::debug!("SIP parse error: {e}");
+                }
                 return PacketAction::None;
             }
         }
@@ -367,5 +373,143 @@ pub fn process_packet(
                 stream_store.write().process_rtp(pp, &hdr, pp.timestamp);
             }
         },
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+// The `--quiet-bad-parse` diagnostic gate is verified by capturing tracing
+// output, which needs `tracing-subscriber` (only compiled under `native`).
+#[cfg(all(test, feature = "native"))]
+mod quiet_bad_parse_tests {
+    use super::*;
+    use crate::capture::parse::{ParsedPacket, TransportProto};
+    use chrono::Utc;
+    use parking_lot::Mutex;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+
+    /// A `tracing` writer that accumulates every emitted line into a shared
+    /// buffer so a test can assert on what was (or was not) logged.
+    #[derive(Clone, Default)]
+    struct CaptureBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureBuf {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureBuf {
+        type Writer = CaptureBuf;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Run `f` with a thread-local DEBUG subscriber and return captured output.
+    fn capture_logs(f: impl FnOnce()) -> String {
+        let buf = CaptureBuf::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_ansi(false)
+            .with_writer(buf.clone())
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        let bytes = buf.0.lock().clone();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    fn packet(payload: &[u8]) -> ParsedPacket {
+        ParsedPacket {
+            timestamp: Utc::now(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            dst_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            src_port: 5060,
+            dst_port: 5060,
+            transport: TransportProto::Udp,
+            payload: payload.to_vec().into(),
+            ip_id: None,
+            tcp_seq: None,
+            tcp_flags: None,
+            fragment_offset: None,
+            more_fragments: false,
+            ip_protocol: 17,
+        }
+    }
+
+    /// `is_sip_message()` accepts the `SIP/2.0 ` response prefix, but the
+    /// status token `XYZ` is not numeric, so `parse_sip_bytes()` errors — this
+    /// is exactly the bad-parse path `--quiet-bad-parse` controls.
+    fn malformed_sip() -> ParsedPacket {
+        packet(b"SIP/2.0 XYZ Bad Status\r\n\r\n")
+    }
+
+    fn valid_invite() -> ParsedPacket {
+        packet(
+            b"INVITE sip:bob@example.com SIP/2.0\r\n\
+              Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bKq1\r\n\
+              From: <sip:alice@example.com>;tag=q1\r\n\
+              To: <sip:bob@example.com>\r\n\
+              Call-ID: quiet-parse@test\r\n\
+              CSeq: 1 INVITE\r\n\
+              Content-Length: 0\r\n\r\n",
+        )
+    }
+
+    fn classify(pp: &ParsedPacket, opts: &PipelineOptions) -> PacketAction {
+        let mut heur = crate::rtp::heuristic::RtpHeuristic::new();
+        let mut decrypt = MediaDecrypt::default();
+        classify_packet(pp, &mut heur, opts, &mut decrypt)
+    }
+
+    #[test]
+    fn default_reports_bad_parse() {
+        let pp = malformed_sip();
+        let logs = capture_logs(|| {
+            let action = classify(&pp, &PipelineOptions::default());
+            assert!(matches!(action, PacketAction::None), "bad parse → None");
+        });
+        assert!(
+            logs.contains("SIP parse error"),
+            "default must emit the bad-parse diagnostic; got {logs:?}"
+        );
+    }
+
+    #[test]
+    fn quiet_flag_suppresses_diagnostic() {
+        let pp = malformed_sip();
+        let opts = PipelineOptions {
+            quiet_bad_parse: true,
+            ..Default::default()
+        };
+        let logs = capture_logs(|| {
+            let action = classify(&pp, &opts);
+            assert!(matches!(action, PacketAction::None), "still dropped");
+        });
+        assert!(
+            !logs.contains("SIP parse error"),
+            "quiet_bad_parse must silence the diagnostic; got {logs:?}"
+        );
+    }
+
+    #[test]
+    fn quiet_flag_does_not_affect_valid_sip() {
+        // Adversarial: the flag must only gate the error notice, never change
+        // how a well-formed message classifies.
+        let pp = valid_invite();
+        let opts = PipelineOptions {
+            quiet_bad_parse: true,
+            ..Default::default()
+        };
+        let action = classify(&pp, &opts);
+        assert!(
+            matches!(action, PacketAction::Sip { .. }),
+            "valid INVITE must still classify as Sip"
+        );
     }
 }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -155,7 +155,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2491 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2500 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -226,7 +226,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2491" data-suffix="">2491</span>
+        <span class="arch-stat" data-count="2500" data-suffix="">2500</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Closes the last two cosmetic sipgrep parity gaps (#9, final open item).

## Changes

- **`--proto-number`** (sipgrep `-N`): annotates the transport tag with the IANA IP protocol number — `INVITE UDP(17)`, `200 OK TCP(6)`. TLS/WS report their TCP carrier's number (6), since the number identifies the IP-layer transport, not the SIP framing. Long-only because `-N` is already `--no-tui`.
- **`-x` / `--quiet-bad-parse`** (sipgrep `-x`): suppresses the per-packet "SIP parse error" diagnostic for SIP-looking-but-unparseable packets. The packet is dropped either way; only the notice is silenced.

## Verification

- 9 new tests (TDD, red→green): IANA protocol mapping, `format_sip_message` rendering incl. an ANSI-color-boundary case, CLI flag parsing, and a tracing log-capture test proving the `-x` gate emits by default and silences when set, leaving valid SIP classification untouched.
- Full suite green: 1390 lib tests + all integration/doc suites, zero failures.
- Clippy `-Dwarnings` clean on default and `--all-features`.
- Feature matrix builds: default, all-features, no-default-features, wasm `--lib`.
- End-to-end on `tests/pcap-samples/sip-proxy.pcap`: `--proto-number` prints `INVITE UDP(17)`; `-x` leaves valid-capture output byte-identical (md5 match).
- Homepage test count updated 2491 → 2500 (pre-commit gate).

## Design note

No `PacketAction::BadParse` variant was added to count malformed packets — that enum sits on the shared hot path and isn't `#[non_exhaustive]`, so a variant would ripple through every match site for an explicitly cosmetic gap. Gating the existing debug log is the minimal faithful mapping of sipgrep's `-x`.