### PR TITLE
Release 0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.10] - 2026-07-17
+
+### Added
+
+- **Display**: `--proto-number` (sipgrep `-N`) — annotate the transport tag
+  with the IANA IP protocol number (`UDP(17)`, `TCP(6)`). TLS and WS report
+  their TCP carrier's number, since the number identifies the IP-layer
+  transport, not the SIP framing.
+- **Capture**: `-x` / `--quiet-bad-parse` (sipgrep `-x`) — suppress the
+  per-packet SIP parse-error diagnostic for SIP-looking-but-unparseable
+  packets. The packet is dropped either way; only the notice is silenced.
+
 ## [0.5.9] - 2026-07-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "aes",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 
 [package]
 name = "sipnab"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Norm Brandinger"]

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ curl -fsSL https://www.sipnab.com/install.sh | sh
 ```
 
 Prefer to read it first: <https://www.sipnab.com/install.sh>. Pin a version
-with `SIPNAB_VERSION=0.5.9`, change the destination with `SIPNAB_INSTALL_DIR`.
+with `SIPNAB_VERSION=0.5.10`, change the destination with `SIPNAB_INSTALL_DIR`.
 
 ## Pre-built Binaries
 
@@ -27,7 +27,7 @@ you which one you are.
 
 ```bash
 # Linux x86_64 (static musl -- runs on any distro, any glibc, Alpine included)
-# Replace <version> with the latest, e.g. 0.5.9
+# Replace <version> with the latest, e.g. 0.5.10
 curl -LO https://github.com/NormB/sipnab/releases/download/v<version>/sipnab-<version>-x86_64-unknown-linux-musl.tar.gz
 tar xzf sipnab-<version>-x86_64-unknown-linux-musl.tar.gz
 sudo install -m 755 sipnab-<version>-x86_64-unknown-linux-musl/sipnab /usr/local/bin/sipnab
@@ -56,7 +56,7 @@ cargo install sipnab --features full
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install with `apt` (it resolves the `libpcap0.8` runtime dependency). The `.deb` needs glibc >= 2.39, i.e. Debian 13+ / Ubuntu 24.04+ -- on older releases use the static musl tarball above:
 
 ```bash
-# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.9
+# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.10
 curl -LO https://github.com/NormB/sipnab/releases/latest/download/sipnab_<version>_amd64.deb
 sudo apt install ./sipnab_<version>_amd64.deb
 
@@ -96,11 +96,11 @@ standard and a `-noaudio` variant (no audio plugin, no `alsa-lib` weak
 dependency — for headless servers, mirroring the `.deb` variants):
 
 ```bash
-sudo rpm -i sipnab-0.5.9-1.x86_64.rpm
+sudo rpm -i sipnab-0.5.10-1.x86_64.rpm
 # headless / no-ALSA variant:
-sudo rpm -i sipnab-0.5.9-1.x86_64-noaudio.rpm
+sudo rpm -i sipnab-0.5.10-1.x86_64-noaudio.rpm
 # arm64 hosts:
-sudo rpm -i sipnab-0.5.9-1.aarch64.rpm
+sudo rpm -i sipnab-0.5.10-1.aarch64.rpm
 ```
 
 ### Homebrew (macOS)
@@ -282,7 +282,7 @@ sipnab --help
 `--version` lists the Cargo features compiled into the binary, e.g.
 
 ```
-sipnab 0.5.9 (2595058) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+sipnab 0.5.10 (2595058) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 ```
 
 This is the fastest way to confirm a build was produced with the feature set

--- a/man/sipnab.1
+++ b/man/sipnab.1
@@ -1,7 +1,7 @@
 .\" sipnab.1 -- man page for sipnab
 .\" Copyright 2024-2026 Norm Brandinger
 .\" License: MIT OR Apache-2.0
-.TH SIPNAB 1 "2026-07-16" "sipnab 0.5.9" "User Commands"
+.TH SIPNAB 1 "2026-07-17" "sipnab 0.5.10" "User Commands"
 .SH NAME
 sipnab \- SIP & RTP capture, analysis, and security tool
 .SH SYNOPSIS

--- a/website/config.toml
+++ b/website/config.toml
@@ -26,7 +26,7 @@ theme = "ayu-dark"
 # overwrites this from Cargo.toml at build time (single source of truth), and a
 # pre-commit hook fails if the two drift — so the homepage version badge and the
 # download links always match the released crate. Update Cargo.toml, not this.
-version = "0.5.9"
+version = "0.5.10"
 # Minimum glibc of the released -gnu binaries and .debs (see the "Enforce
 # glibc floor" step in release.yml). Drives the guidance on /download and
 # must match SIPNAB_GLIBC_FLOOR in static/install.sh. 2.39 = Debian 13 /

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -751,7 +751,7 @@ Metric names emitted by `src/output/prometheus.rs`:
 | `sipnab_jitter_ms` | histogram | RTP jitter distribution (buckets at 5/10/20/50/100/200ms). |
 | `sipnab_loss_percent` | histogram | RTP packet-loss distribution (buckets at 0.1/0.5/1/2/5/10%). |
 
-The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.9 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
+The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.10 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
 
 ## Client Examples
 

--- a/website/content/docs/benchmarks.md
+++ b/website/content/docs/benchmarks.md
@@ -7,7 +7,7 @@ description = "Reproducible throughput and memory benchmarks: sipnab multi-core 
 How fast sipnab is, measured honestly. Every number here is reproducible — the
 host, corpus, tool versions, and exact commands are listed so you can re-run it.
 
-Measured on sipnab 0.4.16 (2026-06-24); current release 0.5.9 — numbers not
+Measured on sipnab 0.4.16 (2026-06-24); current release 0.5.10 — numbers not
 yet re-validated.
 
 > **Read this first.** These tools do *different amounts of work*, so a raw

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -36,7 +36,7 @@ Every [GitHub release](https://github.com/NormB/sipnab/releases) ships versioned
 - `sipnab-<version>-aarch64-unknown-linux-musl.tar.gz` — same, for arm64
 - `sipnab-<version>-x86_64-apple-darwin.tar.gz` / `sipnab-<version>-aarch64-apple-darwin.tar.gz` — macOS
 
-Manual download with checksum verification (replace `<version>` with the latest, e.g. 0.5.9):
+Manual download with checksum verification (replace `<version>` with the latest, e.g. 0.5.10):
 
 ```bash
 V=<version> T=x86_64-unknown-linux-gnu
@@ -83,7 +83,7 @@ cargo install sipnab --features full
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install it with `apt`, which resolves the `libpcap0.8` runtime dependency automatically:
 
 ```bash
-# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.9
+# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.10
 curl -LO https://github.com/NormB/sipnab/releases/latest/download/sipnab_<version>_amd64.deb
 sudo apt install ./sipnab_<version>_amd64.deb
 
@@ -115,7 +115,7 @@ standard and a `-noaudio` variant (no audio plugin, no `alsa-lib` weak
 dependency — for headless servers, mirroring the `.deb` variants):
 
 ```bash
-sudo rpm -i sipnab-<version>-1.x86_64.rpm  # replace <version> with the latest, e.g. 0.5.9
+sudo rpm -i sipnab-<version>-1.x86_64.rpm  # replace <version> with the latest, e.g. 0.5.10
 # headless / no-ALSA variant:
 sudo rpm -i sipnab-<version>-1.x86_64-noaudio.rpm
 # arm64 hosts:
@@ -344,7 +344,7 @@ sipnab -D
 <span class="terminal-title">Verify Installation</span>
 </div>
 <pre class="terminal-body"><span class="t-muted">$</span> sipnab --version
-sipnab 0.5.9 (c9620a5f) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+sipnab 0.5.10 (c9620a5f) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 
 <span class="t-muted">$</span> sipnab -N -I demo.pcap | head -3
 <span class="t-accent">INVITE</span> alice -> bob  10.0.0.1:5060 -> 10.0.0.2:5060  <span class="t-good">InCall</span>  PDD=847ms


### PR DESCRIPTION
Bump 0.5.9 → 0.5.10 across the drift-gated sync points (Cargo.toml/lock, man page, docs/install.md, website config + docs) and add the CHANGELOG `[0.5.10]` entry (PR #132 landed without one).

0.5.10 ships the final sipgrep-parity pair:

- `--proto-number` (sipgrep `-N`) — IANA IP protocol number on the transport tag (`UDP(17)`, `TCP(6)`)
- `-x` / `--quiet-bad-parse` (sipgrep `-x`) — suppress the per-packet SIP parse-error diagnostic

After merge: tag the merge commit `v0.5.10` to trigger the release artifact builds.