### PR TITLE
Add source-port spoofing for scanner-kill responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Security**: scanner-kill responses (`-K`/`--kill-target`, `--kill-scanner`)
+  can now **source-spoof** the victim's `ip:port` via a raw socket, so the
+  reply appears to come from the SIP listener the scanner targeted rather than
+  sipnab's ephemeral port. Controlled by `--kill-spoof {auto|raw|ephemeral}`
+  (default `auto`): `auto` spoofs when `CAP_NET_RAW` is available (already
+  granted for live capture) and falls back to the ephemeral source otherwise;
+  `raw` requires spoofing and errors if the raw socket cannot be opened;
+  `ephemeral` never spoofs. Linux-only; other platforms always use the
+  ephemeral source. New metric `sipnab_kill_responses_sent_total{mode="raw"|"ephemeral"}`
+  exposes which path was used.
+
 ## [0.5.11] - 2026-07-17
 
 ### Fixed

--- a/KILL-TARGET-SPOOFING-SPEC.md
+++ b/KILL-TARGET-SPOOFING-SPEC.md
@@ -1,0 +1,185 @@
+# Scanner-kill source-port spoofing — design scope
+
+Follow-up to v0.5.11 (PR #134), which made `-K`/`--kill-target` and
+`--kill-scanner` actually transmit the SIP kill response. The current send goes
+out from an **ephemeral UDP source port** on a normal `UdpSocket`, so the reply
+appears to come from `sipnab`'s own random port rather than from the SIP
+listener the scanner targeted. Scanners that validate the response's transport
+tuple (source IP + source port) against their request will drop it; only those
+keying purely on the SIP transaction (Call-ID/branch/CSeq/To-tag) accept it.
+
+**Goal:** send the kill response so it appears to originate from the exact
+`ip:port` the scanner sent its request to (the "victim"), maximizing the chance
+the scanner accepts and acts on it.
+
+---
+
+## 1. The core constraint: privilege timing
+
+Spoofing the UDP source requires either a raw socket (`CAP_NET_RAW`) or libpcap
+frame injection. sipnab's lifecycle (see `src/privilege.rs`, `src/app/bootstrap.rs`):
+
+1. `capture::start_capture()` opens the pcap handle — **privileged** (root or
+   `cap_net_raw,cap_net_admin+ep`).
+2. `privilege::drop_privileges()` → drops to `nobody`, then (Linux)
+   `set_no_new_privs()`.
+3. `batch.rs` spawns the scanner-kill worker — **already unprivileged**; its
+   sockets bind here.
+
+A raw send socket therefore **cannot be opened by the worker** — `CAP_NET_RAW`
+is gone. It must be opened during step 1's privileged window and handed down.
+
+---
+
+## 2. Injection approach — two options
+
+### Option A (recommended): raw `AF_INET`/`AF_INET6` socket with `IP_HDRINCL`
+
+- Open `socket(AF_INET, SOCK_RAW, IPPROTO_RAW)` in bootstrap (privileged), set
+  `IP_HDRINCL` so we supply the IP header. Wrap the fd in a `std::net::UdpSocket`-
+  free raw handle (via `libc`, already a dep).
+- The worker builds the full **IP + UDP** datagram: source = victim `ip:port`,
+  dest = scanner `ip:port`, payload = the existing `build_scanner_response`
+  bytes. The **kernel still does L2** (ARP, routing, egress iface) — we only
+  forge L3/L4.
+- Pros: no MAC/ARP handling; kernel routes correctly; smallest packet-builder
+  (IP+UDP only); works for off-link scanners.
+- Cons: need correct IP + UDP checksums by hand; IPv6 needs a parallel path
+  (`IPV6_HDRINCL`, and the v6 UDP checksum is mandatory).
+
+### Option B: `pcap::Capture::sendpacket()` (libpcap injection)
+
+- Reuse/duplicate the pcap handle (opened privileged) and inject a complete
+  **Ethernet + IP + UDP** frame.
+- Pros: reuses existing capture infrastructure; one privileged resource.
+- Cons: must build the **link layer** too — resolve the destination/gateway MAC
+  (ARP or `/proc/net/arp` sniff), handle per-linktype framing (EN10MB vs
+  loopback `DLT_NULL`/`DLT_LOOP` on `lo`), and the handle's `Send`-ness across
+  the worker thread boundary is unproven. More moving parts.
+
+**Recommendation: Option A.** L3 spoofing with kernel routing is the standard,
+portable-within-Linux approach and keeps the byte-builder small and unit-
+testable. Keep Option B noted as a fallback if raw sockets prove problematic in
+some deployment.
+
+---
+
+## 3. Data-flow change: carry the spoof source
+
+Today `KillRequest::SendResponse { dst_addr, dst_port, response_bytes }` only
+carries the scanner (destination). Add the victim as the spoof source:
+
+```rust
+KillRequest::SendResponse {
+    dst_addr, dst_port,            // scanner (unchanged)
+    src_addr: IpAddr, src_port: u16, // victim = sniffed packet's dst — NEW
+    response_bytes,
+}
+```
+
+The dispatch site in `batch.rs` already has both: the request is
+`sip_msg.src_addr:src_port` (scanner) and the victim is `sip_msg.dst_addr:dst_port`
+(both fields exist on `SipMessage`, confirmed). No new capture data needed.
+
+---
+
+## 4. Packet construction (Option A, IPv4)
+
+New module `src/security/kill_packet.rs`:
+
+- `build_ipv4_udp(src: SocketAddrV4, dst: SocketAddrV4, payload: &[u8]) -> Vec<u8>`
+  — 20-byte IPv4 header (IHL=5, TTL=64, proto=17, correct total-length, header
+  checksum) + 8-byte UDP header (ports, length, checksum over pseudo-header +
+  payload) + payload.
+- Mirror for IPv6 (`build_ipv6_udp`): 40-byte v6 header + UDP with mandatory
+  checksum over the v6 pseudo-header.
+- Pure functions, no I/O — **fully unit-testable** against hand-computed golden
+  bytes and independently-verified checksums.
+
+The worker's `process_send` picks the raw socket by family, builds the datagram,
+and `libc::sendto`s it to the scanner. All existing guards stay **in front** of
+the send: broadcast/multicast reject, empty-response reject, global rate limit,
+per-destination rate limit.
+
+---
+
+## 5. CLI / config surface
+
+- Auto-select with graceful fallback: if a raw socket was successfully opened in
+  the privileged window, spoof; otherwise fall back to today's ephemeral-port
+  `UdpSocket` send and log the downgrade once. This keeps `-K` working with only
+  the ephemeral path when run without `CAP_NET_RAW`.
+- Optional explicit override `--kill-spoof {auto|raw|ephemeral}` (default
+  `auto`) for operators who want to force or forbid spoofing.
+- No behavioral change for existing users who don't grant extra caps.
+
+---
+
+## 6. Security considerations
+
+- **Never spoof an arbitrary source.** The forged source is strictly the victim
+  `ip:port` from the *sniffed* request — never attacker-controllable beyond what
+  they already sent to. This is a targeted transaction reply, not a general
+  spoofer.
+- Keep both rate limiters (global 10/s default, per-dst 3/min) — spoofing does
+  not change the amplification surface, and the response is ~200 bytes ≤ the
+  request.
+- Broadcast/multicast destinations already rejected; keep that.
+- Document that raw-socket spoofing requires `cap_net_raw` (already granted for
+  capture) and that egress-filtering (BCP38) upstream may drop spoofed-source
+  packets — a deployment caveat, not a code bug.
+
+---
+
+## 7. Testing strategy (TDD, mandatory)
+
+- **Unit (no privilege):** golden-byte tests for `build_ipv4_udp` /
+  `build_ipv6_udp` — header fields, total length, and both checksums, including
+  adversarial payloads (empty-after-guard, NUL/high bytes, max-size). Verify the
+  UDP checksum with an independent reimplementation over the pseudo-header.
+- **Integration (privileged, gated):** a test that opens the raw socket, sends a
+  spoofed datagram to a bound loopback listener, and asserts `recv_from`'s
+  reported source `ip:port` equals the *forged* victim tuple (not sipnab's).
+  Gate behind `CAP_NET_RAW` detection so it's skipped (not failed) in
+  unprivileged CI; run it under `sudo` locally, mirroring the v0.5.11 live e2e.
+- **Regression:** existing worker tests (rate limit, reject paths, verbatim
+  bytes) must stay green against the new request shape.
+
+---
+
+## 8. Platform / multi-arch
+
+- Linux x86_64 + arm64: identical syscall path — the multi-arch requirement is
+  satisfied by one Linux implementation.
+- macOS: raw `IP_HDRINCL` behaves differently (BSD rewrites some fields) and the
+  privilege drop is already skipped there. Scope macOS as **ephemeral-only**
+  initially (feature-cfg the spoof path to Linux), with a note.
+- `#[cfg(target_os = "linux")]` gates the raw path; other targets compile to the
+  ephemeral fallback.
+
+---
+
+## 9. Effort & phasing
+
+- **P1 — packet builders + unit tests** (~0.5 day): pure, no privilege, lands
+  the risky checksum logic behind tests first.
+- **P2 — privileged raw-socket open + handoff to worker** (~0.5 day): bootstrap
+  wiring, `KillRequest` field, fallback logic.
+- **P3 — worker send path + gated integration test + live e2e** (~0.5 day).
+- **P4 — CLI flag, docs (man/CHANGELOG/help), IPv6** (~0.5 day).
+- Total ≈ **2 days**, shippable as a single `fix/kill-target-spoof` PR or split
+  P1–P2 / P3–P4.
+
+---
+
+## 10. Decisions (resolved) — implemented
+
+1. **Default posture:** `auto` (spoof when `CAP_NET_RAW` is available, else
+   ephemeral fallback), with an explicit `--kill-spoof {auto|raw|ephemeral}`
+   override. `raw` fails loudly if the socket can't be opened.
+2. **IPv6:** v4-first shipped; v6 deferred to a follow-up PR. IPv6 kill targets
+   safely take the ephemeral fallback in the meantime.
+3. **macOS:** ephemeral-only, `#[cfg(target_os = "linux")]`-gated raw path.
+4. **Metric:** added `sipnab_kill_responses_sent_total{mode="raw"|"ephemeral"}`.
+
+Implemented in P1–P4; P5 (IPv6) remains the only open item.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -141,6 +141,7 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--kill-ua` | `<PATTERN>` | -- | Add a custom scanner User-Agent pattern (regex) to `--kill-scanner` detection |
 | `--kill-response` | `<CODE>` | `200` | SIP response code for the kill response (100-699) |
 | `-K`, `--kill-target` | `<ADDR[:PORT-RANGE]>` | -- | Targeted kill (sipgrep `-K`): send the kill response to any SIP request whose source matches ADDR and an optional port range (`10.0.0.1:5060-5090`, `[::1]:5060`), regardless of UA/behavioral detection. Repeatable; spawns the kill worker on its own (no `--kill-scanner` needed) |
+| `--kill-spoof` | `<MODE>` | `auto` | Source-address strategy for the kill response (Linux only; other platforms always `ephemeral`). `auto` forges the victim's ip:port via a raw socket when `CAP_NET_RAW` is available (so the reply appears to come from the targeted SIP port), falling back to an ephemeral source otherwise; `raw` requires the spoof and errors if the raw socket can't be opened; `ephemeral` never spoofs |
 | `--fraud-detect` | -- | off | Enable fraud detection heuristics |
 | `--reg-flood` | -- | off | Detect registration flood attacks |
 | `--digest-leak` | -- | off | Detect digest credential leaks in SIP messages |

--- a/src/app/batch.rs
+++ b/src/app/batch.rs
@@ -170,6 +170,7 @@ pub fn run_cores_file(
 
 /// Run batch mode to completion: the multi-core offline fast path when
 /// `--cores N` applies, otherwise the single-threaded [`BatchRunner`].
+#[expect(clippy::too_many_arguments)]
 pub fn run(
     cli: Cli,
     config: &Config,
@@ -178,6 +179,7 @@ pub fn run(
     rx: capture::channel::PacketRx,
     batch: BatchProcessing,
     policy: CapturePolicy,
+    raw_kill_sock: Option<crate::process_isolation::RawKillSocket>,
 ) {
     let portrange = policy.portrange;
     let no_rtp = cli.no_rtp || config.capture.no_rtp.unwrap_or(false);
@@ -218,7 +220,11 @@ pub fn run(
         return;
     }
 
-    BatchRunner::new(cli, config, batch, policy).run_loop(capture_config, handle, rx);
+    BatchRunner::new(cli, config, batch, policy, raw_kill_sock).run_loop(
+        capture_config,
+        handle,
+        rx,
+    );
 }
 
 /// All owned batch-mode state: writer, detector engines, decryption state,
@@ -256,7 +262,13 @@ impl BatchRunner {
     /// Build every piece of batch state (bootstrap steps 16-17): output
     /// writer policy, HEP sender, stores, security detectors + alert engine,
     /// TLS/SRTP/DTLS decryption state, and the companion servers.
-    fn new(cli: Cli, config: &Config, batch: BatchProcessing, policy: CapturePolicy) -> Self {
+    fn new(
+        cli: Cli,
+        config: &Config,
+        batch: BatchProcessing,
+        policy: CapturePolicy,
+        raw_kill_sock: Option<crate::process_isolation::RawKillSocket>,
+    ) -> Self {
         let matcher = batch.matcher;
         let filter_expr = batch.filter_expr;
         let output_opts = batch.output_opts;
@@ -353,7 +365,7 @@ impl BatchRunner {
 
         // 17a-2. Spawn scanner-kill worker thread (D16: process isolation)
         let scanner_kill_handle: Option<ScannerKillHandle> = if kill_worker_active {
-            match process_isolation::spawn_scanner_kill_worker(None) {
+            match process_isolation::spawn_scanner_kill_worker(None, raw_kill_sock) {
                 Ok(handle) => Some(handle),
                 Err(e) => {
                     tracing::error!("Failed to spawn scanner-kill worker: {e}");
@@ -1237,6 +1249,8 @@ fn process_parsed_packet(
                     let _ = handle.send_kill(KillRequest::SendResponse {
                         dst_addr: sip_msg.src_addr,
                         dst_port: sip_msg.src_port,
+                        src_addr: sip_msg.dst_addr,
+                        src_port: sip_msg.dst_port,
                         response_bytes,
                     });
                 }
@@ -1269,6 +1283,8 @@ fn process_parsed_packet(
                     let _ = handle.send_kill(KillRequest::SendResponse {
                         dst_addr: sip_msg.src_addr,
                         dst_port: sip_msg.src_port,
+                        src_addr: sip_msg.dst_addr,
+                        src_port: sip_msg.dst_port,
                         response_bytes,
                     });
                 }

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -268,6 +268,10 @@ pub struct Launched {
     pub handle: capture::CaptureHandle,
     /// Receiving side of the packet channel.
     pub rx: capture::channel::PacketRx,
+    /// Raw socket for source-spoofed scanner-kill responses, opened in the
+    /// privileged window when the kill feature is active and `--kill-spoof`
+    /// permits it. `None` → the worker uses the ephemeral UDP send.
+    pub raw_kill_sock: Option<crate::process_isolation::RawKillSocket>,
 }
 
 /// Perform the side-effectful launch sequence exactly as main() did:
@@ -409,6 +413,36 @@ pub fn launch(
         std::process::exit(1);
     }
 
+    // 16-kill. Open the raw scanner-kill socket while still privileged (it
+    //         needs CAP_NET_RAW, which the drop below sheds). Only when the
+    //         kill feature is active and --kill-spoof permits it.
+    let kill_active = cli.kill_scanner || !cli.kill_target.is_empty();
+    let raw_kill_sock = if kill_active && cli.kill_spoof != crate::cli::KillSpoof::Ephemeral {
+        match crate::process_isolation::RawKillSocket::open_v4() {
+            Ok(sock) => {
+                tracing::info!("Scanner-kill: source-spoofing enabled (raw socket)");
+                Some(sock)
+            }
+            Err(e) => {
+                if cli.kill_spoof == crate::cli::KillSpoof::Raw {
+                    tracing::error!(
+                        "--kill-spoof raw requires a raw socket but it could not be opened: {e}. \
+                         Grant CAP_NET_RAW (sipnab --setup-caps / run under sudo) or use \
+                         --kill-spoof ephemeral."
+                    );
+                    std::process::exit(1);
+                }
+                tracing::warn!(
+                    "Scanner-kill: raw socket unavailable ({e}); falling back to ephemeral \
+                     source port. Kill responses will come from sipnab's own port."
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // 16a. Drop privileges now that capture devices are open and chroot is applied (D15)
     let effective_user = cli.user.as_deref().or(config.privilege.user.as_deref());
     let effective_no_priv_drop = cli.no_priv_drop || config.privilege.no_priv_drop.unwrap_or(false);
@@ -516,7 +550,11 @@ pub fn launch(
         std::process::exit(1);
     }
 
-    Launched { handle, rx }
+    Launched {
+        handle,
+        rx,
+        raw_kill_sock,
+    }
 }
 
 /// Initialize the tracing/log subscriber from `SIPNAB_LOG` and the CLI's

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -520,6 +520,22 @@ pub struct Cli {
     )]
     pub kill_target: Vec<String>,
 
+    /// How to source the scanner-kill response packet (Linux only; other
+    /// platforms always use `ephemeral`). `auto` forges the victim's ip:port
+    /// via a raw socket when `CAP_NET_RAW` is available (already granted for
+    /// live capture), so the reply appears to come from the port the scanner
+    /// targeted — falling back to an ephemeral UDP source otherwise. `raw`
+    /// requires the spoof and errors if the raw socket cannot be opened;
+    /// `ephemeral` never spoofs.
+    #[arg(
+        help_heading = "Security",
+        long = "kill-spoof",
+        value_name = "MODE",
+        value_enum,
+        default_value = "auto"
+    )]
+    pub kill_spoof: KillSpoof,
+
     /// Enable fraud detection heuristics.
     #[arg(help_heading = "Security", long)]
     pub fraud_detect: bool,
@@ -945,6 +961,19 @@ pub struct Cli {
 /// clap renders the variants in kebab-case (`default`, `host-port`, `user`,
 /// `user-host-port`), matching the `[display] from_to` config spellings and
 /// `tui::FromToMode::as_config_str`.
+/// Source-address strategy for the scanner-kill response packet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum KillSpoof {
+    /// Spoof the victim's ip:port via a raw socket when `CAP_NET_RAW` is
+    /// available, else fall back to an ephemeral UDP source.
+    #[default]
+    Auto,
+    /// Require raw-socket spoofing; error if it cannot be opened.
+    Raw,
+    /// Never spoof; always send from an ephemeral UDP source.
+    Ephemeral,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum FromToModeArg {
     Default,
@@ -1288,6 +1317,21 @@ mod tests {
         assert!(Cli::parse_from_args(["sipnab", "-p"]).no_promisc);
         assert!(Cli::parse_from_args(["sipnab", "--no-promisc"]).no_promisc);
         assert!(!Cli::parse_from_args(["sipnab"]).no_promisc);
+    }
+
+    #[test]
+    fn kill_spoof_flag_parses_with_auto_default() {
+        assert_eq!(Cli::parse_from_args(["sipnab"]).kill_spoof, KillSpoof::Auto);
+        assert_eq!(
+            Cli::parse_from_args(["sipnab", "--kill-spoof", "raw"]).kill_spoof,
+            KillSpoof::Raw
+        );
+        assert_eq!(
+            Cli::parse_from_args(["sipnab", "--kill-spoof", "ephemeral"]).kill_spoof,
+            KillSpoof::Ephemeral
+        );
+        // Unknown mode is rejected by clap's value-enum parsing.
+        assert!(Cli::try_parse_from(["sipnab", "--kill-spoof", "bogus"]).is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,7 @@ fn main() {
                     event_exec: plan.event_exec,
                 },
                 plan.policy,
+                launched.raw_kill_sock,
             );
         }
         RunMode::CoresFile => unreachable!("handled before launch"),

--- a/src/output/prometheus.rs
+++ b/src/output/prometheus.rs
@@ -156,6 +156,29 @@ pub fn format_metrics(metrics: &PrometheusMetrics) -> String {
         &metrics.security_alerts_total,
     );
 
+    // Scanner-kill responses sent, split by how the source was set: `raw`
+    // (source-spoofed via a raw socket) vs `ephemeral` (sipnab's own port).
+    // Alert on an unexpected `ephemeral` count to catch a silent fallback.
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native"))]
+    {
+        let (raw, ephemeral) = crate::process_isolation::kill_responses_sent();
+        write_help_type(
+            &mut out,
+            "sipnab_kill_responses_sent_total",
+            "Total scanner-kill responses sent, by source mode",
+            "counter",
+        );
+        let _ = writeln!(
+            out,
+            "sipnab_kill_responses_sent_total{{mode=\"raw\"}} {raw}"
+        );
+        let _ = writeln!(
+            out,
+            "sipnab_kill_responses_sent_total{{mode=\"ephemeral\"}} {ephemeral}"
+        );
+        out.push('\n');
+    }
+
     // Reassembly timeouts
     write_help_type(
         &mut out,

--- a/src/process_isolation.rs
+++ b/src/process_isolation.rs
@@ -10,21 +10,141 @@
 //! process-level isolation with separate address spaces.
 
 use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, UdpSocket};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, UdpSocket};
 use std::time::Instant;
 
 use crossbeam_channel::{Receiver, Sender};
 use serde::{Deserialize, Serialize};
+
+/// Raw IPv4 socket (`IP_HDRINCL`) for source-spoofed scanner-kill responses.
+///
+/// Must be opened during the privileged window (before `drop_privileges`),
+/// since it needs `CAP_NET_RAW`; it is then moved into the worker thread and
+/// remains usable after the drop. Linux-only — on other platforms `open_v4`
+/// returns an error and the worker falls back to the ephemeral UDP send.
+pub struct RawKillSocket {
+    #[cfg(target_os = "linux")]
+    fd: std::os::fd::OwnedFd,
+}
+
+impl RawKillSocket {
+    /// Open a raw `AF_INET`/`IPPROTO_RAW` socket with `IP_HDRINCL`. Requires
+    /// `CAP_NET_RAW`; call before dropping privileges.
+    #[cfg(target_os = "linux")]
+    pub fn open_v4() -> std::io::Result<Self> {
+        use std::os::fd::FromRawFd;
+        // SAFETY: raw syscall; the returned fd is immediately adopted by an
+        // OwnedFd so it is closed exactly once on drop.
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_RAW, libc::IPPROTO_RAW) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: `fd` is a fresh, valid, owned descriptor from socket() above;
+        // adopting it here gives it a single owner that closes it on drop.
+        let owned = unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) };
+        let one: libc::c_int = 1;
+        // SAFETY: fd is valid; &one outlives the call.
+        let rc = unsafe {
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_IP,
+                libc::IP_HDRINCL,
+                std::ptr::addr_of!(one).cast(),
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        };
+        if rc < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(Self { fd: owned })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn open_v4() -> std::io::Result<Self> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "raw-socket kill-response spoofing is only supported on Linux",
+        ))
+    }
+
+    /// Send a pre-built IPv4 datagram (its own IP header carries the spoofed
+    /// source) to `dst`. The kernel routes on `dst`; the datagram's L3/L4
+    /// headers are ours.
+    #[cfg(target_os = "linux")]
+    fn send_to_v4(&self, packet: &[u8], dst: SocketAddrV4) -> std::io::Result<usize> {
+        use std::os::fd::AsRawFd;
+        // SAFETY: sockaddr_in is a plain-old-data C struct; an all-zero bit
+        // pattern is a valid (unspecified) value that we fully populate below.
+        let mut sa: libc::sockaddr_in = unsafe { std::mem::zeroed() };
+        sa.sin_family = libc::AF_INET as libc::sa_family_t;
+        sa.sin_port = dst.port().to_be();
+        sa.sin_addr.s_addr = u32::from_ne_bytes(dst.ip().octets());
+        // SAFETY: fd is valid; packet slice and sockaddr outlive the call.
+        let n = unsafe {
+            libc::sendto(
+                self.fd.as_raw_fd(),
+                packet.as_ptr().cast(),
+                packet.len(),
+                0,
+                std::ptr::addr_of!(sa).cast(),
+                std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+            )
+        };
+        if n < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(n as usize)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn send_to_v4(&self, _packet: &[u8], _dst: SocketAddrV4) -> std::io::Result<usize> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "raw-socket send is only supported on Linux",
+        ))
+    }
+}
+
+/// Count of scanner-kill responses sent via the source-spoofed raw path.
+static KILL_SENT_RAW: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+/// Count of scanner-kill responses sent via the ephemeral UDP fallback.
+static KILL_SENT_EPHEMERAL: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Increment the per-mode scanner-kill send counter.
+fn inc_kill_response_sent(raw: bool) {
+    let c = if raw {
+        &KILL_SENT_RAW
+    } else {
+        &KILL_SENT_EPHEMERAL
+    };
+    c.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Scanner-kill responses sent, as `(raw, ephemeral)`, for the metrics
+/// exporter. Process-global and monotonic.
+pub fn kill_responses_sent() -> (u64, u64) {
+    use std::sync::atomic::Ordering::Relaxed;
+    (
+        KILL_SENT_RAW.load(Relaxed),
+        KILL_SENT_EPHEMERAL.load(Relaxed),
+    )
+}
 
 /// Message types sent from the main thread to the scanner-kill worker.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum KillRequest {
     /// Request to send a SIP response to a scanner.
     SendResponse {
-        /// Destination IP address.
+        /// Destination IP address (the scanner).
         dst_addr: IpAddr,
-        /// Destination transport port.
+        /// Destination transport port (the scanner's source port).
         dst_port: u16,
+        /// Spoof source: the victim IP the scanner targeted. Used as the
+        /// forged source when raw-socket spoofing is active; ignored by the
+        /// ephemeral fallback.
+        src_addr: IpAddr,
+        /// Spoof source port: the victim port the scanner targeted.
+        src_port: u16,
         /// Pre-built SIP response bytes to inject.
         response_bytes: Vec<u8>,
     },
@@ -233,6 +353,9 @@ struct ScannerKillWorker {
     /// UDP socket for IPv6 destinations (bound to `[::]:0`); `None` if the
     /// bind failed at spawn.
     sock_v6: Option<UdpSocket>,
+    /// Raw socket for source-spoofed IPv4 responses, opened privileged and
+    /// moved in at spawn. `None` → the ephemeral UDP send is used.
+    raw_sock: Option<RawKillSocket>,
 }
 
 impl ScannerKillWorker {
@@ -261,9 +384,12 @@ impl ScannerKillWorker {
                 KillRequest::SendResponse {
                     dst_addr,
                     dst_port,
+                    src_addr,
+                    src_port,
                     response_bytes,
                 } => {
-                    let response = self.process_send(dst_addr, dst_port, &response_bytes);
+                    let response =
+                        self.process_send(dst_addr, dst_port, src_addr, src_port, &response_bytes);
                     // Best-effort send of response; ignore if main thread dropped its end
                     let _ = self.resp_tx.send(response);
                 }
@@ -276,6 +402,8 @@ impl ScannerKillWorker {
         &mut self,
         dst_addr: IpAddr,
         dst_port: u16,
+        src_addr: IpAddr,
+        src_port: u16,
         response_bytes: &[u8],
     ) -> KillResponse {
         // Reject broadcast addresses
@@ -307,7 +435,40 @@ impl ScannerKillWorker {
         // Periodic cleanup of per-dst limiter
         self.per_dst_limiter.cleanup();
 
-        // Transmit the response to the scanner over UDP.
+        // Prefer source-spoofed raw send when a raw socket is available and
+        // both endpoints are IPv4 (the only spoof path implemented). The
+        // forged source is the victim ip:port the scanner targeted, so the
+        // reply appears to come from the SIP listener rather than sipnab's
+        // ephemeral port. Fall back to the plain UDP send otherwise.
+        if let (Some(raw), IpAddr::V4(dst_v4), IpAddr::V4(src_v4)) =
+            (self.raw_sock.as_ref(), dst_addr, src_addr)
+        {
+            let dst = SocketAddrV4::new(dst_v4, dst_port);
+            let src = SocketAddrV4::new(src_v4, src_port);
+            if let Some(packet) =
+                crate::security::kill_packet::build_ipv4_udp(src, dst, response_bytes)
+            {
+                match raw.send_to_v4(&packet, dst) {
+                    Ok(_) => {
+                        inc_kill_response_sent(true);
+                        tracing::info!(
+                            "Scanner-kill: sent {} byte spoofed response to {dst_addr}:{dst_port} (source {src_addr}:{src_port})",
+                            response_bytes.len(),
+                        );
+                        return KillResponse::Sent;
+                    }
+                    Err(e) => {
+                        // Raw send failed at runtime; fall through to the
+                        // ephemeral path rather than dropping the response.
+                        tracing::warn!(
+                            "Scanner-kill: spoofed send to {dst_addr}:{dst_port} failed ({e}); falling back to ephemeral source"
+                        );
+                    }
+                }
+            }
+        }
+
+        // Ephemeral fallback: plain UDP send from our own source port.
         let sock = match dst_addr {
             IpAddr::V4(_) => self.sock_v4.as_ref(),
             IpAddr::V6(_) => self.sock_v6.as_ref(),
@@ -319,6 +480,7 @@ impl ScannerKillWorker {
         };
         match sock.send_to(response_bytes, (dst_addr, dst_port)) {
             Ok(n) => {
+                inc_kill_response_sent(false);
                 tracing::info!("Scanner-kill: sent {n} byte response to {dst_addr}:{dst_port}");
                 KillResponse::Sent
             }
@@ -353,12 +515,15 @@ const DEFAULT_RATE_LIMIT: u32 = 10;
 ///
 /// * `rate_limit` — Maximum responses per second. Pass `None` for the
 ///   default of 10/sec.
+/// * `raw_sock` — Raw IPv4 socket for source-spoofed responses, opened during
+///   the privileged window. Pass `None` to always use the ephemeral UDP send.
 ///
 /// # Errors
 ///
 /// Returns an error if the worker thread cannot be spawned.
 pub fn spawn_scanner_kill_worker(
     rate_limit: Option<u32>,
+    raw_sock: Option<RawKillSocket>,
 ) -> Result<ScannerKillHandle, std::io::Error> {
     let rate = rate_limit.unwrap_or(DEFAULT_RATE_LIMIT);
     let (tx, rx) = crossbeam_channel::bounded(256);
@@ -382,6 +547,7 @@ pub fn spawn_scanner_kill_worker(
         per_dst_limiter: PerDstRateLimiter::new(),
         sock_v4,
         sock_v6,
+        raw_sock,
     };
 
     let thread = std::thread::Builder::new()
@@ -429,14 +595,78 @@ mod tests {
         b"SIP/2.0 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec()
     }
 
+    /// Source-spoofed raw send: the datagram must arrive at the listener with
+    /// the **forged victim** source ip:port, not sipnab's own. Requires
+    /// `CAP_NET_RAW`; skipped (not failed) when the raw socket can't be opened,
+    /// so unprivileged CI stays green. Run under sudo to exercise it.
+    #[test]
+    fn spoofed_send_forges_source_ip_and_port() {
+        let raw = match RawKillSocket::open_v4() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("skipping spoof test: raw socket unavailable ({e})");
+                return;
+            }
+        };
+
+        let listener = std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind listener");
+        listener
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .expect("set read timeout");
+        let port = listener.local_addr().expect("local addr").port();
+
+        // Forge the source as a distinctive loopback "victim" the scanner
+        // would have targeted.
+        let victim_ip = Ipv4Addr::new(127, 0, 0, 9);
+        let victim_port = 5060u16;
+
+        let mut handle = spawn_scanner_kill_worker(Some(10), Some(raw)).expect("spawn worker");
+        let payload = b"SIP/2.0 403 Forbidden\r\nContent-Length: 0\r\n\r\n".to_vec();
+        handle
+            .send_kill(KillRequest::SendResponse {
+                dst_addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
+                dst_port: port,
+                src_addr: IpAddr::V4(victim_ip),
+                src_port: victim_port,
+                response_bytes: payload.clone(),
+            })
+            .expect("send should succeed");
+
+        let mut buf = [0u8; 2048];
+        let (n, from) = listener
+            .recv_from(&mut buf)
+            .expect("listener must receive the spoofed packet");
+        assert_eq!(&buf[..n], &payload[..], "payload delivered verbatim");
+        assert_eq!(
+            from.ip(),
+            IpAddr::V4(victim_ip),
+            "source IP must be the forged victim, not sipnab's"
+        );
+        assert_eq!(
+            from.port(),
+            victim_port,
+            "source port must be the forged victim port"
+        );
+
+        let resp = recv_response_within(&handle, std::time::Duration::from_secs(5));
+        assert_eq!(resp, Some(KillResponse::Sent));
+
+        let (raw_sent, _ephemeral) = kill_responses_sent();
+        assert!(raw_sent >= 1, "raw-mode send counter must have incremented");
+
+        handle.shutdown();
+    }
+
     #[test]
     fn handle_send_and_receive() {
-        let mut handle = spawn_scanner_kill_worker(Some(10)).expect("spawn worker");
+        let mut handle = spawn_scanner_kill_worker(Some(10), None).expect("spawn worker");
 
         handle
             .send_kill(KillRequest::SendResponse {
                 dst_addr: localhost_v4(),
                 dst_port: 5060,
+                src_addr: localhost_v4(),
+                src_port: 5060,
                 response_bytes: sample_response(),
             })
             .expect("send should succeed");
@@ -449,7 +679,7 @@ mod tests {
 
     #[test]
     fn rate_limiter_enforces_limit() {
-        let mut handle = spawn_scanner_kill_worker(Some(10)).expect("spawn worker");
+        let mut handle = spawn_scanner_kill_worker(Some(10), None).expect("spawn worker");
 
         // Send 15 requests to different destination IPs so the per-dst
         // limiter doesn't interfere with the global rate limit test. Loopback
@@ -459,6 +689,8 @@ mod tests {
             let _ = handle.send_kill(KillRequest::SendResponse {
                 dst_addr: dst,
                 dst_port: 5060,
+                src_addr: localhost_v4(),
+                src_port: 5060,
                 response_bytes: sample_response(),
             });
         }
@@ -491,12 +723,14 @@ mod tests {
 
     #[test]
     fn broadcast_address_rejected() {
-        let mut handle = spawn_scanner_kill_worker(Some(10)).expect("spawn worker");
+        let mut handle = spawn_scanner_kill_worker(Some(10), None).expect("spawn worker");
 
         handle
             .send_kill(KillRequest::SendResponse {
                 dst_addr: IpAddr::V4(Ipv4Addr::BROADCAST),
                 dst_port: 5060,
+                src_addr: localhost_v4(),
+                src_port: 5060,
                 response_bytes: sample_response(),
             })
             .expect("send should succeed");
@@ -512,13 +746,15 @@ mod tests {
 
     #[test]
     fn multicast_v4_rejected() {
-        let mut handle = spawn_scanner_kill_worker(Some(10)).expect("spawn worker");
+        let mut handle = spawn_scanner_kill_worker(Some(10), None).expect("spawn worker");
 
         // 224.0.0.1 is multicast
         handle
             .send_kill(KillRequest::SendResponse {
                 dst_addr: IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),
                 dst_port: 5060,
+                src_addr: localhost_v4(),
+                src_port: 5060,
                 response_bytes: sample_response(),
             })
             .expect("send should succeed");
@@ -534,7 +770,7 @@ mod tests {
 
     #[test]
     fn multicast_v6_rejected() {
-        let mut handle = spawn_scanner_kill_worker(Some(10)).expect("spawn worker");
+        let mut handle = spawn_scanner_kill_worker(Some(10), None).expect("spawn worker");
 
         // ff02::1 is IPv6 multicast
         let multicast_v6 = IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1));
@@ -542,6 +778,8 @@ mod tests {
             .send_kill(KillRequest::SendResponse {
                 dst_addr: multicast_v6,
                 dst_port: 5060,
+                src_addr: localhost_v4(),
+                src_port: 5060,
                 response_bytes: sample_response(),
             })
             .expect("send should succeed");
@@ -557,19 +795,21 @@ mod tests {
 
     #[test]
     fn shutdown_exits_cleanly() {
-        let mut handle = spawn_scanner_kill_worker(Some(10)).expect("spawn worker");
+        let mut handle = spawn_scanner_kill_worker(Some(10), None).expect("spawn worker");
         handle.shutdown();
         // No panic, thread joined successfully
     }
 
     #[test]
     fn empty_response_rejected() {
-        let mut handle = spawn_scanner_kill_worker(Some(10)).expect("spawn worker");
+        let mut handle = spawn_scanner_kill_worker(Some(10), None).expect("spawn worker");
 
         handle
             .send_kill(KillRequest::SendResponse {
                 dst_addr: localhost_v4(),
                 dst_port: 5060,
+                src_addr: localhost_v4(),
+                src_port: 5060,
                 response_bytes: vec![],
             })
             .expect("send should succeed");
@@ -593,12 +833,14 @@ mod tests {
             .expect("set read timeout");
         let port = listener.local_addr().expect("local addr").port();
 
-        let mut handle = spawn_scanner_kill_worker(Some(10)).expect("spawn worker");
+        let mut handle = spawn_scanner_kill_worker(Some(10), None).expect("spawn worker");
         let payload = b"SIP/2.0 403 Forbidden\r\nContent-Length: 0\r\n\r\n".to_vec();
         handle
             .send_kill(KillRequest::SendResponse {
                 dst_addr: localhost_v4(),
                 dst_port: port,
+                src_addr: localhost_v4(),
+                src_port: 5060,
                 response_bytes: payload.clone(),
             })
             .expect("send should succeed");
@@ -629,7 +871,7 @@ mod tests {
             .expect("set read timeout");
         let port = listener.local_addr().expect("local addr").port();
 
-        let mut handle = spawn_scanner_kill_worker(Some(10)).expect("spawn worker");
+        let mut handle = spawn_scanner_kill_worker(Some(10), None).expect("spawn worker");
         let payload = vec![
             0x00u8, 0xff, b'S', b'I', b'P', b'\\', 0x0d, 0x0a, 0x00, 0x80, 0x7f,
         ];
@@ -637,6 +879,8 @@ mod tests {
             .send_kill(KillRequest::SendResponse {
                 dst_addr: localhost_v4(),
                 dst_port: port,
+                src_addr: localhost_v4(),
+                src_port: 5060,
                 response_bytes: payload.clone(),
             })
             .expect("send should succeed");
@@ -665,7 +909,7 @@ mod tests {
 
     #[test]
     fn is_alive_true_for_running_worker() {
-        let mut handle = spawn_scanner_kill_worker(Some(10)).expect("spawn worker");
+        let mut handle = spawn_scanner_kill_worker(Some(10), None).expect("spawn worker");
         assert!(handle.is_alive(), "freshly spawned worker must be alive");
         assert!(!handle.defense_disabled());
         handle.shutdown();
@@ -704,6 +948,8 @@ mod tests {
         let result = handle.send_kill(KillRequest::SendResponse {
             dst_addr: localhost_v4(),
             dst_port: 5060,
+            src_addr: localhost_v4(),
+            src_port: 5060,
             response_bytes: sample_response(),
         });
         assert!(result.is_err(), "send to dead worker must fail, not vanish");

--- a/src/security/kill_packet.rs
+++ b/src/security/kill_packet.rs
@@ -1,0 +1,247 @@
+//! Raw IPv4/UDP datagram construction for source-spoofed scanner-kill
+//! responses.
+//!
+//! The scanner-kill worker sends its SIP response so it appears to originate
+//! from the `ip:port` the scanner targeted (the victim), not from sipnab's own
+//! ephemeral port. That requires forging the IP and UDP headers and injecting
+//! the result through a raw socket (`IP_HDRINCL`); the kernel still handles L2
+//! (ARP, routing). These builders produce the fully-formed, checksummed
+//! datagram and are pure (no I/O), so the header/checksum logic is unit-tested
+//! against golden bytes independently of any privileged socket.
+
+use std::net::SocketAddrV4;
+
+/// IPv4 header length without options, in bytes.
+const IPV4_HEADER_LEN: usize = 20;
+/// UDP header length, in bytes.
+const UDP_HEADER_LEN: usize = 8;
+/// IANA protocol number for UDP.
+const IPPROTO_UDP: u8 = 17;
+
+/// Largest UDP payload that fits in a single IPv4 datagram
+/// (`u16::MAX` total length − IPv4 header − UDP header).
+const MAX_UDP_PAYLOAD_V4: usize = u16::MAX as usize - IPV4_HEADER_LEN - UDP_HEADER_LEN;
+
+/// Build a complete IPv4 + UDP datagram with the given (possibly spoofed)
+/// source, destination, and payload.
+///
+/// Returns the wire bytes (20-byte IPv4 header + 8-byte UDP header + payload)
+/// with correct IPv4 header checksum and UDP checksum, ready to hand to a
+/// raw `IP_HDRINCL` socket. Returns `None` if `payload` is too large to fit in
+/// a single IPv4 datagram.
+pub fn build_ipv4_udp(src: SocketAddrV4, dst: SocketAddrV4, payload: &[u8]) -> Option<Vec<u8>> {
+    if payload.len() > MAX_UDP_PAYLOAD_V4 {
+        return None;
+    }
+
+    let total_len = (IPV4_HEADER_LEN + UDP_HEADER_LEN + payload.len()) as u16;
+    let udp_len = (UDP_HEADER_LEN + payload.len()) as u16;
+
+    let mut pkt = Vec::with_capacity(total_len as usize);
+
+    // ── IPv4 header ──
+    pkt.push(0x45); // version 4, IHL 5 (no options)
+    pkt.push(0x00); // DSCP / ECN
+    pkt.extend_from_slice(&total_len.to_be_bytes());
+    pkt.extend_from_slice(&0u16.to_be_bytes()); // identification
+    pkt.extend_from_slice(&0x4000u16.to_be_bytes()); // flags=DF, fragment offset 0
+    pkt.push(64); // TTL
+    pkt.push(IPPROTO_UDP);
+    pkt.extend_from_slice(&0u16.to_be_bytes()); // checksum placeholder
+    pkt.extend_from_slice(&src.ip().octets());
+    pkt.extend_from_slice(&dst.ip().octets());
+    let ip_csum = checksum16(&pkt[..IPV4_HEADER_LEN]);
+    pkt[10..12].copy_from_slice(&ip_csum.to_be_bytes());
+
+    // ── UDP header ──
+    pkt.extend_from_slice(&src.port().to_be_bytes());
+    pkt.extend_from_slice(&dst.port().to_be_bytes());
+    pkt.extend_from_slice(&udp_len.to_be_bytes());
+    pkt.extend_from_slice(&0u16.to_be_bytes()); // checksum placeholder
+    pkt.extend_from_slice(payload);
+
+    // UDP checksum covers a pseudo-header + the UDP header + payload.
+    let mut pseudo = Vec::with_capacity(12 + udp_len as usize);
+    pseudo.extend_from_slice(&src.ip().octets());
+    pseudo.extend_from_slice(&dst.ip().octets());
+    pseudo.push(0);
+    pseudo.push(IPPROTO_UDP);
+    pseudo.extend_from_slice(&udp_len.to_be_bytes());
+    pseudo.extend_from_slice(&pkt[IPV4_HEADER_LEN..]); // UDP header (csum 0) + payload
+    let mut udp_csum = checksum16(&pseudo);
+    // A computed checksum of zero is transmitted as all-ones; zero means
+    // "no checksum" in UDP and must never be sent for a real checksum.
+    if udp_csum == 0 {
+        udp_csum = 0xffff;
+    }
+    let udp_csum_off = IPV4_HEADER_LEN + 6;
+    pkt[udp_csum_off..udp_csum_off + 2].copy_from_slice(&udp_csum.to_be_bytes());
+
+    Some(pkt)
+}
+
+/// Internet checksum (RFC 1071): one's-complement sum of 16-bit big-endian
+/// words, with a trailing odd byte padded with a zero low byte.
+fn checksum16(data: &[u8]) -> u16 {
+    let mut sum: u32 = 0;
+    let mut chunks = data.chunks_exact(2);
+    for c in &mut chunks {
+        sum += u16::from_be_bytes([c[0], c[1]]) as u32;
+    }
+    if let [last] = chunks.remainder() {
+        sum += (*last as u32) << 8;
+    }
+    while (sum >> 16) != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn addr(a: [u8; 4], p: u16) -> SocketAddrV4 {
+        SocketAddrV4::new(Ipv4Addr::from(a), p)
+    }
+
+    /// Independent reference implementation of the internet checksum, used to
+    /// cross-check the builder's own checksums.
+    fn ref_checksum(data: &[u8]) -> u16 {
+        let mut sum: u32 = 0;
+        let mut i = 0;
+        while i + 1 < data.len() {
+            sum += ((data[i] as u32) << 8) | data[i + 1] as u32;
+            i += 2;
+        }
+        if i < data.len() {
+            sum += (data[i] as u32) << 8;
+        }
+        while sum >> 16 != 0 {
+            sum = (sum & 0xffff) + (sum >> 16);
+        }
+        !(sum as u16)
+    }
+
+    #[test]
+    fn builds_expected_header_fields() {
+        let src = addr([10, 0, 0, 1], 5060);
+        let dst = addr([192, 168, 1, 9], 40000);
+        let payload = b"SIP/2.0 403 Forbidden\r\n\r\n";
+        let pkt = build_ipv4_udp(src, dst, payload).expect("should build");
+
+        assert_eq!(pkt.len(), 20 + 8 + payload.len());
+        assert_eq!(pkt[0], 0x45, "version/IHL");
+        assert_eq!(pkt[9], 17, "protocol UDP");
+        assert_eq!(&pkt[2..4], &((20 + 8 + payload.len()) as u16).to_be_bytes());
+        assert_eq!(&pkt[12..16], &[10, 0, 0, 1], "source IP (spoofed)");
+        assert_eq!(&pkt[16..20], &[192, 168, 1, 9], "dest IP");
+        // UDP ports
+        assert_eq!(
+            &pkt[20..22],
+            &5060u16.to_be_bytes(),
+            "udp src port (spoofed)"
+        );
+        assert_eq!(&pkt[22..24], &40000u16.to_be_bytes(), "udp dst port");
+        assert_eq!(
+            &pkt[24..26],
+            &((8 + payload.len()) as u16).to_be_bytes(),
+            "udp len"
+        );
+    }
+
+    #[test]
+    fn ip_header_checksum_is_valid() {
+        let pkt = build_ipv4_udp(addr([10, 0, 0, 1], 5060), addr([10, 0, 0, 2], 5060), b"x")
+            .expect("build");
+        // A correct IPv4 header checksums to zero when re-summed including the
+        // checksum field.
+        assert_eq!(ref_checksum(&pkt[..20]), 0, "IP header must checksum to 0");
+        // And the stored checksum matches an independent computation over the
+        // header with the checksum field zeroed.
+        let mut hdr = pkt[..20].to_vec();
+        hdr[10] = 0;
+        hdr[11] = 0;
+        assert_eq!(u16::from_be_bytes([pkt[10], pkt[11]]), ref_checksum(&hdr));
+    }
+
+    #[test]
+    fn udp_checksum_is_valid() {
+        let src = addr([10, 0, 0, 1], 5060);
+        let dst = addr([10, 0, 0, 2], 5061);
+        let payload = b"SIP/2.0 200 OK\r\nContent-Length: 0\r\n\r\n";
+        let pkt = build_ipv4_udp(src, dst, payload).expect("build");
+
+        // Rebuild the pseudo-header + UDP segment (with the real checksum in
+        // place) and confirm it re-sums to zero — the receiver's validity test.
+        let udp_len = (8 + payload.len()) as u16;
+        let mut check = Vec::new();
+        check.extend_from_slice(&[10, 0, 0, 1]);
+        check.extend_from_slice(&[10, 0, 0, 2]);
+        check.push(0);
+        check.push(17);
+        check.extend_from_slice(&udp_len.to_be_bytes());
+        check.extend_from_slice(&pkt[20..]);
+        assert_eq!(ref_checksum(&check), 0, "UDP checksum must validate to 0");
+        assert_ne!(&pkt[26..28], &[0, 0], "checksum must be present, not zero");
+    }
+
+    #[test]
+    fn empty_payload_still_builds_valid_headers() {
+        // The worker guards against empty responses, but the builder must not
+        // panic or produce a malformed datagram on an empty payload.
+        let pkt = build_ipv4_udp(addr([10, 0, 0, 1], 5060), addr([10, 0, 0, 2], 5060), b"")
+            .expect("build");
+        assert_eq!(pkt.len(), 28);
+        assert_eq!(&pkt[24..26], &8u16.to_be_bytes(), "udp len is header-only");
+        assert_eq!(ref_checksum(&pkt[..20]), 0);
+    }
+
+    #[test]
+    fn adversarial_payload_bytes_are_carried_verbatim() {
+        // Embedded NUL, high bytes, backslash, CR/LF must appear untouched
+        // after the 28-byte header, and both checksums must still validate.
+        let payload = vec![0x00u8, 0xff, b'\\', 0x0d, 0x0a, 0x80, 0x7f, 0x00, b'S'];
+        let pkt = build_ipv4_udp(
+            addr([172, 16, 0, 1], 5060),
+            addr([172, 16, 0, 9], 5062),
+            &payload,
+        )
+        .expect("build");
+        assert_eq!(&pkt[28..], &payload[..], "payload carried byte-for-byte");
+        assert_eq!(ref_checksum(&pkt[..20]), 0);
+
+        let udp_len = (8 + payload.len()) as u16;
+        let mut check = Vec::new();
+        check.extend_from_slice(&[172, 16, 0, 1]);
+        check.extend_from_slice(&[172, 16, 0, 9]);
+        check.push(0);
+        check.push(17);
+        check.extend_from_slice(&udp_len.to_be_bytes());
+        check.extend_from_slice(&pkt[20..]);
+        assert_eq!(
+            ref_checksum(&check),
+            0,
+            "UDP checksum valid for binary payload"
+        );
+    }
+
+    #[test]
+    fn oversize_payload_rejected() {
+        let too_big = vec![0u8; MAX_UDP_PAYLOAD_V4 + 1];
+        assert!(
+            build_ipv4_udp(
+                addr([10, 0, 0, 1], 5060),
+                addr([10, 0, 0, 2], 5060),
+                &too_big
+            )
+            .is_none()
+        );
+        // Exactly the maximum still builds.
+        let max = vec![0u8; MAX_UDP_PAYLOAD_V4];
+        assert!(
+            build_ipv4_udp(addr([10, 0, 0, 1], 5060), addr([10, 0, 0, 2], 5060), &max).is_some()
+        );
+    }
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -8,6 +8,7 @@
 pub mod alerting;
 pub mod digest_leak;
 pub mod fraud_detect;
+pub mod kill_packet;
 pub mod reg_flood;
 pub mod scanner_detect;
 pub mod scanner_kill;

--- a/tests/security_test.rs
+++ b/tests/security_test.rs
@@ -1110,9 +1110,10 @@ fn writer_warns_on_path_traversal() {
 fn scanner_kill_per_destination_rate_limit() {
     use sipnab::process_isolation::{KillRequest, KillResponse, spawn_scanner_kill_worker};
 
-    let mut handle = spawn_scanner_kill_worker(Some(100)).expect("spawn worker");
+    let mut handle = spawn_scanner_kill_worker(Some(100), None).expect("spawn worker");
 
-    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 50));
+    // Loopback destination so the real UDP send never leaves the host.
+    let dst = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 50));
     let response_bytes = b"SIP/2.0 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec();
 
     // Send 5 kill requests to the same destination IP
@@ -1121,6 +1122,8 @@ fn scanner_kill_per_destination_rate_limit() {
             .send_kill(KillRequest::SendResponse {
                 dst_addr: dst,
                 dst_port: 5060,
+                src_addr: dst,
+                src_port: 5060,
                 response_bytes: response_bytes.clone(),
             })
             .expect("send");

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -744,6 +744,7 @@ Metric names emitted by `src/output/prometheus.rs`:
 | `sipnab_messages_total{method}` | counter | SIP messages by method (`INVITE`, `REGISTER`, …). |
 | `sipnab_rtp_streams_active` | gauge | RTP streams currently in the `Established` state. |
 | `sipnab_rtp_streams_total{status}` | counter | RTP streams by status (`established`, `orphaned`). |
+| `sipnab_kill_responses_sent_total{mode}` | counter | Scanner-kill responses sent, by source mode: `raw` (source-spoofed via a raw socket) or `ephemeral` (sipnab's own port). Alert on unexpected `ephemeral` to catch a silent spoof fallback. |
 | `sipnab_capture_queue_depth_packets` | gauge | Packets currently queued between the capture reader and the processing thread (standalone `--metrics` server). |
 | `sipnab_capture_backpressure_blocks_total` | counter | Times the capture reader blocked on a full queue (standalone `--metrics` server). |
 | `sipnab_pdd_seconds` | histogram | Post-dial delay distribution (buckets at 0.5/1/2/3/5/10s). Emits `sipnab_pdd_seconds_bucket{le}`, `_count`, `_sum`. |

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -155,7 +155,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2502 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2510 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -226,7 +226,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2502" data-suffix="">2502</span>
+        <span class="arch-stat" data-count="2510" data-suffix="">2510</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Follow-up to #134. The scanner-kill response previously left from an **ephemeral UDP source port**, so it appeared to come from sipnab's own port rather than the SIP listener the scanner targeted — scanners that validate the response's transport tuple would drop it. This forges the victim's `ip:port` as the source so the reply looks like it came from the targeted listener.

## Changes

- **`src/security/kill_packet.rs`** — pure IPv4+UDP datagram builder with correct IP header and UDP (pseudo-header) checksums. No I/O; unit-tested against golden bytes and an independent checksum reimplementation, including empty / NUL / binary-verbatim / oversize cases.
- **`RawKillSocket`** (`AF_INET`/`IPPROTO_RAW` + `IP_HDRINCL`) — opened in bootstrap's **privileged window before `drop_privileges`** (it needs `CAP_NET_RAW`, which the drop sheds) and moved into the worker thread. Linux-only; other platforms use the ephemeral fallback.
- `KillRequest` carries the spoof source (the sniffed packet's destination = the victim). `process_send` spoofs when a raw socket is present and both endpoints are IPv4, else falls back to the ephemeral UDP send. All existing guards (broadcast/multicast reject, empty reject, global + per-dst rate limits) still run first.
- **`--kill-spoof {auto|raw|ephemeral}`** (default `auto`): `auto` spoofs when the raw socket opened, else ephemeral; `raw` requires the spoof and errors if the socket can't open; `ephemeral` never spoofs.
- Metric **`sipnab_kill_responses_sent_total{mode="raw"|"ephemeral"}`** to catch a silent fallback.

## Known limitation

IPv6 spoofing is **deferred to a follow-up** (needs `IPV6_HDRINCL` + mandatory v6 UDP checksum + a separate raw socket). IPv6 kill targets take the ephemeral fallback in the meantime — unchanged from #134.

## Tests

- Pure builder unit tests (6): header fields, IP + UDP checksum validity, empty/adversarial/oversize.
- **`CAP_NET_RAW`-gated integration test**: asserts the listener receives the datagram with the **forged victim** source ip:port (not sipnab's). Skipped (not failed) when unprivileged, so CI stays green; runs under sudo.
- CLI parse test for `--kill-spoof`.
- **Live e2e**: `-K … --kill-spoof raw` → the scanner's socket receives `SIP/2.0 200 OK` with source = the victim's `:5060`.
- Full suite 2510 tests green; clippy `-Dwarnings` clean on default + `--all-features`; feature matrix (default/all-features/no-default/wasm) builds.

Design notes in `KILL-TARGET-SPOOFING-SPEC.md`.