### PR TITLE
Add IPv6 source-port spoofing for scanner-kill responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Security**: scanner-kill source-port spoofing (`--kill-spoof`, added in
+  0.5.12) now covers **IPv6** as well as IPv4. A raw `AF_INET6` socket
+  (`IPV6_HDRINCL`) forges the victim's IPv6 `ip:port` so the reply appears to
+  come from the targeted listener; the `sipnab_kill_responses_sent_total{mode}`
+  metric is unchanged. Each family is opened best-effort, so a host with only
+  one stack still spoofs that family.
+
 ## [0.5.12] - 2026-07-17
 
 ### Added

--- a/KILL-TARGET-SPOOFING-SPEC.md
+++ b/KILL-TARGET-SPOOFING-SPEC.md
@@ -177,8 +177,8 @@ per-destination rate limit.
 1. **Default posture:** `auto` (spoof when `CAP_NET_RAW` is available, else
    ephemeral fallback), with an explicit `--kill-spoof {auto|raw|ephemeral}`
    override. `raw` fails loudly if the socket can't be opened.
-2. **IPv6:** v4-first shipped; v6 deferred to a follow-up PR. IPv6 kill targets
-   safely take the ephemeral fallback in the meantime.
+2. **IPv6:** v4 shipped in 0.5.12; **IPv6 now implemented** (raw `AF_INET6` +
+   `IPV6_HDRINCL`, `sin6_port` 0 on send). Both families spoof.
 3. **macOS:** ephemeral-only, `#[cfg(target_os = "linux")]`-gated raw path.
 4. **Metric:** added `sipnab_kill_responses_sent_total{mode="raw"|"ephemeral"}`.
 

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -418,7 +418,7 @@ pub fn launch(
     //         kill feature is active and --kill-spoof permits it.
     let kill_active = cli.kill_scanner || !cli.kill_target.is_empty();
     let raw_kill_sock = if kill_active && cli.kill_spoof != crate::cli::KillSpoof::Ephemeral {
-        match crate::process_isolation::RawKillSocket::open_v4() {
+        match crate::process_isolation::RawKillSocket::open() {
             Ok(sock) => {
                 tracing::info!("Scanner-kill: source-spoofing enabled (raw socket)");
                 Some(sock)

--- a/src/process_isolation.rs
+++ b/src/process_isolation.rs
@@ -16,51 +16,102 @@ use std::time::Instant;
 use crossbeam_channel::{Receiver, Sender};
 use serde::{Deserialize, Serialize};
 
-/// Raw IPv4 socket (`IP_HDRINCL`) for source-spoofed scanner-kill responses.
+/// `IPV6_HDRINCL` socket option (Linux ≥4.5) — not exposed by the `libc`
+/// crate, so we name the kernel constant directly.
+#[cfg(target_os = "linux")]
+const IPV6_HDRINCL: libc::c_int = 36;
+
+/// Raw sockets (`IP_HDRINCL` / `IPV6_HDRINCL`) for source-spoofed
+/// scanner-kill responses.
 ///
 /// Must be opened during the privileged window (before `drop_privileges`),
-/// since it needs `CAP_NET_RAW`; it is then moved into the worker thread and
-/// remains usable after the drop. Linux-only — on other platforms `open_v4`
-/// returns an error and the worker falls back to the ephemeral UDP send.
+/// since they need `CAP_NET_RAW`; they are then moved into the worker thread
+/// and remain usable after the drop. Linux-only — on other platforms `open`
+/// returns an error and the worker falls back to the ephemeral UDP send. Each
+/// family is opened best-effort: a host without an IPv6 stack still spoofs
+/// IPv4, and vice-versa.
 pub struct RawKillSocket {
     #[cfg(target_os = "linux")]
-    fd: std::os::fd::OwnedFd,
+    fd_v4: Option<std::os::fd::OwnedFd>,
+    #[cfg(target_os = "linux")]
+    fd_v6: Option<std::os::fd::OwnedFd>,
 }
 
 impl RawKillSocket {
-    /// Open a raw `AF_INET`/`IPPROTO_RAW` socket with `IP_HDRINCL`. Requires
-    /// `CAP_NET_RAW`; call before dropping privileges.
+    /// Open a raw `SOCK_RAW`/`IPPROTO_RAW` socket for `domain`. `IPPROTO_RAW`
+    /// already implies header inclusion (we supply the full IP header). For
+    /// IPv4 we still set `IP_HDRINCL` explicitly (`hdrincl`); for IPv6 the
+    /// `IPPROTO_RAW` socket includes the header implicitly and setting
+    /// `IPV6_HDRINCL` is unnecessary and rejected on some kernels, so it is
+    /// applied best-effort and its failure is ignored.
     #[cfg(target_os = "linux")]
-    pub fn open_v4() -> std::io::Result<Self> {
+    fn open_family(
+        domain: libc::c_int,
+        hdrincl: Option<(libc::c_int, libc::c_int)>,
+        hdrincl_required: bool,
+    ) -> std::io::Result<std::os::fd::OwnedFd> {
         use std::os::fd::FromRawFd;
         // SAFETY: raw syscall; the returned fd is immediately adopted by an
         // OwnedFd so it is closed exactly once on drop.
-        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_RAW, libc::IPPROTO_RAW) };
+        let fd = unsafe { libc::socket(domain, libc::SOCK_RAW, libc::IPPROTO_RAW) };
         if fd < 0 {
             return Err(std::io::Error::last_os_error());
         }
         // SAFETY: `fd` is a fresh, valid, owned descriptor from socket() above;
         // adopting it here gives it a single owner that closes it on drop.
         let owned = unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) };
-        let one: libc::c_int = 1;
-        // SAFETY: fd is valid; &one outlives the call.
-        let rc = unsafe {
-            libc::setsockopt(
-                fd,
-                libc::IPPROTO_IP,
-                libc::IP_HDRINCL,
-                std::ptr::addr_of!(one).cast(),
-                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-            )
-        };
-        if rc < 0 {
-            return Err(std::io::Error::last_os_error());
+        if let Some((level, name)) = hdrincl {
+            let one: libc::c_int = 1;
+            // SAFETY: fd is valid; &one outlives the call.
+            let rc = unsafe {
+                libc::setsockopt(
+                    fd,
+                    level,
+                    name,
+                    std::ptr::addr_of!(one).cast(),
+                    std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+                )
+            };
+            if rc < 0 && hdrincl_required {
+                return Err(std::io::Error::last_os_error());
+            }
         }
-        Ok(Self { fd: owned })
+        Ok(owned)
+    }
+
+    /// Open the raw IPv4 and IPv6 send sockets. Requires `CAP_NET_RAW`; call
+    /// before dropping privileges. Succeeds if at least one family opens; the
+    /// IPv4 error is surfaced when both fail (the common permission case).
+    #[cfg(target_os = "linux")]
+    pub fn open() -> std::io::Result<Self> {
+        let v4 = Self::open_family(
+            libc::AF_INET,
+            Some((libc::IPPROTO_IP, libc::IP_HDRINCL)),
+            true,
+        );
+        // IPPROTO_RAW already includes the IPv6 header; IPV6_HDRINCL is a
+        // best-effort belt-and-braces (ignored if the kernel rejects it).
+        let v6 = Self::open_family(
+            libc::AF_INET6,
+            Some((libc::IPPROTO_IPV6, IPV6_HDRINCL)),
+            false,
+        );
+        match (v4, v6) {
+            (Ok(a), b) => Ok(Self {
+                fd_v4: Some(a),
+                fd_v6: b.ok(),
+            }),
+            (Err(_), Ok(b)) => Ok(Self {
+                fd_v4: None,
+                fd_v6: Some(b),
+            }),
+            // Both failed — report the IPv4 error (usually EPERM).
+            (Err(e4), Err(_)) => Err(e4),
+        }
     }
 
     #[cfg(not(target_os = "linux"))]
-    pub fn open_v4() -> std::io::Result<Self> {
+    pub fn open() -> std::io::Result<Self> {
         Err(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             "raw-socket kill-response spoofing is only supported on Linux",
@@ -73,6 +124,9 @@ impl RawKillSocket {
     #[cfg(target_os = "linux")]
     fn send_to_v4(&self, packet: &[u8], dst: SocketAddrV4) -> std::io::Result<usize> {
         use std::os::fd::AsRawFd;
+        let fd = self.fd_v4.as_ref().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::Unsupported, "no IPv4 raw socket")
+        })?;
         // SAFETY: sockaddr_in is a plain-old-data C struct; an all-zero bit
         // pattern is a valid (unspecified) value that we fully populate below.
         let mut sa: libc::sockaddr_in = unsafe { std::mem::zeroed() };
@@ -82,7 +136,7 @@ impl RawKillSocket {
         // SAFETY: fd is valid; packet slice and sockaddr outlive the call.
         let n = unsafe {
             libc::sendto(
-                self.fd.as_raw_fd(),
+                fd.as_raw_fd(),
                 packet.as_ptr().cast(),
                 packet.len(),
                 0,
@@ -96,8 +150,49 @@ impl RawKillSocket {
         Ok(n as usize)
     }
 
+    /// Send a pre-built IPv6 datagram (its own IPv6 header carries the spoofed
+    /// source) to `dst`.
+    #[cfg(target_os = "linux")]
+    fn send_to_v6(&self, packet: &[u8], dst: std::net::SocketAddrV6) -> std::io::Result<usize> {
+        use std::os::fd::AsRawFd;
+        let fd = self.fd_v6.as_ref().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::Unsupported, "no IPv6 raw socket")
+        })?;
+        // SAFETY: sockaddr_in6 is a plain-old-data C struct; an all-zero bit
+        // pattern is a valid value that we fully populate below.
+        let mut sa: libc::sockaddr_in6 = unsafe { std::mem::zeroed() };
+        sa.sin6_family = libc::AF_INET6 as libc::sa_family_t;
+        // Raw IPv6 sockets require sin6_port == 0 (the real dest port lives in
+        // our own UDP header); a nonzero value here yields EINVAL.
+        sa.sin6_port = 0;
+        sa.sin6_addr.s6_addr = dst.ip().octets();
+        // SAFETY: fd is valid; packet slice and sockaddr outlive the call.
+        let n = unsafe {
+            libc::sendto(
+                fd.as_raw_fd(),
+                packet.as_ptr().cast(),
+                packet.len(),
+                0,
+                std::ptr::addr_of!(sa).cast(),
+                std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t,
+            )
+        };
+        if n < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(n as usize)
+    }
+
     #[cfg(not(target_os = "linux"))]
     fn send_to_v4(&self, _packet: &[u8], _dst: SocketAddrV4) -> std::io::Result<usize> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "raw-socket send is only supported on Linux",
+        ))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn send_to_v6(&self, _packet: &[u8], _dst: std::net::SocketAddrV6) -> std::io::Result<usize> {
         Err(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             "raw-socket send is only supported on Linux",
@@ -435,36 +530,45 @@ impl ScannerKillWorker {
         // Periodic cleanup of per-dst limiter
         self.per_dst_limiter.cleanup();
 
-        // Prefer source-spoofed raw send when a raw socket is available and
-        // both endpoints are IPv4 (the only spoof path implemented). The
+        // Prefer a source-spoofed raw send when a raw socket is available. The
         // forged source is the victim ip:port the scanner targeted, so the
         // reply appears to come from the SIP listener rather than sipnab's
-        // ephemeral port. Fall back to the plain UDP send otherwise.
-        if let (Some(raw), IpAddr::V4(dst_v4), IpAddr::V4(src_v4)) =
-            (self.raw_sock.as_ref(), dst_addr, src_addr)
-        {
-            let dst = SocketAddrV4::new(dst_v4, dst_port);
-            let src = SocketAddrV4::new(src_v4, src_port);
-            if let Some(packet) =
-                crate::security::kill_packet::build_ipv4_udp(src, dst, response_bytes)
-            {
-                match raw.send_to_v4(&packet, dst) {
-                    Ok(_) => {
-                        inc_kill_response_sent(true);
-                        tracing::info!(
-                            "Scanner-kill: sent {} byte spoofed response to {dst_addr}:{dst_port} (source {src_addr}:{src_port})",
-                            response_bytes.len(),
-                        );
-                        return KillResponse::Sent;
-                    }
-                    Err(e) => {
-                        // Raw send failed at runtime; fall through to the
-                        // ephemeral path rather than dropping the response.
-                        tracing::warn!(
-                            "Scanner-kill: spoofed send to {dst_addr}:{dst_port} failed ({e}); falling back to ephemeral source"
-                        );
-                    }
+        // ephemeral port. Build the datagram for the matching address family
+        // (mixed families never occur — src and dst come from one packet) and
+        // fall back to the plain UDP send on any failure.
+        if let Some(raw) = self.raw_sock.as_ref() {
+            let spoofed: Option<std::io::Result<usize>> = match (dst_addr, src_addr) {
+                (IpAddr::V4(dst_v4), IpAddr::V4(src_v4)) => {
+                    let dst = SocketAddrV4::new(dst_v4, dst_port);
+                    let src = SocketAddrV4::new(src_v4, src_port);
+                    crate::security::kill_packet::build_ipv4_udp(src, dst, response_bytes)
+                        .map(|pkt| raw.send_to_v4(&pkt, dst))
                 }
+                (IpAddr::V6(dst_v6), IpAddr::V6(src_v6)) => {
+                    let dst = std::net::SocketAddrV6::new(dst_v6, dst_port, 0, 0);
+                    let src = std::net::SocketAddrV6::new(src_v6, src_port, 0, 0);
+                    crate::security::kill_packet::build_ipv6_udp(src, dst, response_bytes)
+                        .map(|pkt| raw.send_to_v6(&pkt, dst))
+                }
+                _ => None,
+            };
+            match spoofed {
+                Some(Ok(_)) => {
+                    inc_kill_response_sent(true);
+                    tracing::info!(
+                        "Scanner-kill: sent {} byte spoofed response to {dst_addr}:{dst_port} (source {src_addr}:{src_port})",
+                        response_bytes.len(),
+                    );
+                    return KillResponse::Sent;
+                }
+                Some(Err(e)) => {
+                    // Raw send failed at runtime; fall through to the ephemeral
+                    // path rather than dropping the response.
+                    tracing::warn!(
+                        "Scanner-kill: spoofed send to {dst_addr}:{dst_port} failed ({e}); falling back to ephemeral source"
+                    );
+                }
+                None => {}
             }
         }
 
@@ -601,7 +705,7 @@ mod tests {
     /// so unprivileged CI stays green. Run under sudo to exercise it.
     #[test]
     fn spoofed_send_forges_source_ip_and_port() {
-        let raw = match RawKillSocket::open_v4() {
+        let raw = match RawKillSocket::open() {
             Ok(s) => s,
             Err(e) => {
                 eprintln!("skipping spoof test: raw socket unavailable ({e})");
@@ -653,6 +757,69 @@ mod tests {
 
         let (raw_sent, _ephemeral) = kill_responses_sent();
         assert!(raw_sent >= 1, "raw-mode send counter must have incremented");
+
+        handle.shutdown();
+    }
+
+    /// IPv6 source-spoofed raw send: the datagram must arrive at a `::1`
+    /// listener with the **forged** source port (an ephemeral send would show a
+    /// random port). Requires `CAP_NET_RAW`; skipped when unprivileged.
+    #[test]
+    fn spoofed_send_forges_source_over_ipv6() {
+        let raw = match RawKillSocket::open() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("skipping v6 spoof test: raw socket unavailable ({e})");
+                return;
+            }
+        };
+
+        let listener = match std::net::UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("skipping v6 spoof test: no IPv6 loopback ({e})");
+                return;
+            }
+        };
+        listener
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .expect("set read timeout");
+        let port = listener.local_addr().expect("local addr").port();
+
+        // Forge a distinctive source port; the address is ::1 (the only v6
+        // loopback that delivers), so the port is the discriminating field.
+        let victim_port = 5060u16;
+
+        let mut handle = spawn_scanner_kill_worker(Some(10), Some(raw)).expect("spawn worker");
+        let payload = b"SIP/2.0 403 Forbidden\r\nContent-Length: 0\r\n\r\n".to_vec();
+        handle
+            .send_kill(KillRequest::SendResponse {
+                dst_addr: IpAddr::V6(Ipv6Addr::LOCALHOST),
+                dst_port: port,
+                src_addr: IpAddr::V6(Ipv6Addr::LOCALHOST),
+                src_port: victim_port,
+                response_bytes: payload.clone(),
+            })
+            .expect("send should succeed");
+
+        let mut buf = [0u8; 2048];
+        let (n, from) = match listener.recv_from(&mut buf) {
+            Ok(v) => v,
+            Err(e) => {
+                // Some environments block raw v6 loopback injection; treat as a
+                // skip rather than a hard failure (the builder is unit-tested).
+                eprintln!("skipping v6 spoof test: no packet received ({e})");
+                handle.shutdown();
+                return;
+            }
+        };
+        assert_eq!(&buf[..n], &payload[..], "payload delivered verbatim");
+        assert_eq!(from.ip(), IpAddr::V6(Ipv6Addr::LOCALHOST), "source is ::1");
+        assert_eq!(
+            from.port(),
+            victim_port,
+            "source port must be the forged victim port, not an ephemeral one"
+        );
 
         handle.shutdown();
     }

--- a/src/security/kill_packet.rs
+++ b/src/security/kill_packet.rs
@@ -1,15 +1,15 @@
-//! Raw IPv4/UDP datagram construction for source-spoofed scanner-kill
+//! Raw IPv4/IPv6 UDP datagram construction for source-spoofed scanner-kill
 //! responses.
 //!
 //! The scanner-kill worker sends its SIP response so it appears to originate
 //! from the `ip:port` the scanner targeted (the victim), not from sipnab's own
 //! ephemeral port. That requires forging the IP and UDP headers and injecting
-//! the result through a raw socket (`IP_HDRINCL`); the kernel still handles L2
-//! (ARP, routing). These builders produce the fully-formed, checksummed
-//! datagram and are pure (no I/O), so the header/checksum logic is unit-tested
-//! against golden bytes independently of any privileged socket.
+//! the result through a raw socket (`IP_HDRINCL` / `IPV6_HDRINCL`); the kernel
+//! still handles L2 (ARP/ND, routing). These builders produce the fully-formed,
+//! checksummed datagram and are pure (no I/O), so the header/checksum logic is
+//! unit-tested against golden bytes independently of any privileged socket.
 
-use std::net::SocketAddrV4;
+use std::net::{SocketAddrV4, SocketAddrV6};
 
 /// IPv4 header length without options, in bytes.
 const IPV4_HEADER_LEN: usize = 20;
@@ -75,6 +75,64 @@ pub fn build_ipv4_udp(src: SocketAddrV4, dst: SocketAddrV4, payload: &[u8]) -> O
         udp_csum = 0xffff;
     }
     let udp_csum_off = IPV4_HEADER_LEN + 6;
+    pkt[udp_csum_off..udp_csum_off + 2].copy_from_slice(&udp_csum.to_be_bytes());
+
+    Some(pkt)
+}
+
+/// IPv6 fixed header length, in bytes.
+const IPV6_HEADER_LEN: usize = 40;
+
+/// Largest UDP payload that fits in a single (non-jumbogram) IPv6 datagram
+/// (`u16::MAX` payload-length − UDP header).
+const MAX_UDP_PAYLOAD_V6: usize = u16::MAX as usize - UDP_HEADER_LEN;
+
+/// Build a complete IPv6 + UDP datagram with the given (possibly spoofed)
+/// source, destination, and payload.
+///
+/// Returns the wire bytes (40-byte IPv6 header + 8-byte UDP header + payload)
+/// with the mandatory UDP checksum, ready to hand to a raw `IPV6_HDRINCL`
+/// socket. Returns `None` if `payload` is too large for a single datagram.
+pub fn build_ipv6_udp(src: SocketAddrV6, dst: SocketAddrV6, payload: &[u8]) -> Option<Vec<u8>> {
+    if payload.len() > MAX_UDP_PAYLOAD_V6 {
+        return None;
+    }
+
+    let udp_len = (UDP_HEADER_LEN + payload.len()) as u16;
+
+    let mut pkt = Vec::with_capacity(IPV6_HEADER_LEN + udp_len as usize);
+
+    // ── IPv6 header ──
+    // version 6 (top nibble), traffic class 0, flow label 0.
+    pkt.extend_from_slice(&0x6000_0000u32.to_be_bytes());
+    pkt.extend_from_slice(&udp_len.to_be_bytes()); // payload length
+    pkt.push(IPPROTO_UDP); // next header
+    pkt.push(64); // hop limit
+    pkt.extend_from_slice(&src.ip().octets());
+    pkt.extend_from_slice(&dst.ip().octets());
+
+    // ── UDP header ──
+    pkt.extend_from_slice(&src.port().to_be_bytes());
+    pkt.extend_from_slice(&dst.port().to_be_bytes());
+    pkt.extend_from_slice(&udp_len.to_be_bytes());
+    pkt.extend_from_slice(&0u16.to_be_bytes()); // checksum placeholder
+    pkt.extend_from_slice(payload);
+
+    // UDP checksum over the IPv6 pseudo-header + UDP header + payload.
+    let mut pseudo = Vec::with_capacity(40 + udp_len as usize);
+    pseudo.extend_from_slice(&src.ip().octets());
+    pseudo.extend_from_slice(&dst.ip().octets());
+    pseudo.extend_from_slice(&(udp_len as u32).to_be_bytes()); // upper-layer length
+    pseudo.extend_from_slice(&[0, 0, 0]); // zeros
+    pseudo.push(IPPROTO_UDP); // next header
+    pseudo.extend_from_slice(&pkt[IPV6_HEADER_LEN..]); // UDP header (csum 0) + payload
+    let mut udp_csum = checksum16(&pseudo);
+    // For IPv6 the UDP checksum is mandatory; a computed zero is sent as
+    // all-ones (zero would mean "no checksum", which IPv6 forbids).
+    if udp_csum == 0 {
+        udp_csum = 0xffff;
+    }
+    let udp_csum_off = IPV6_HEADER_LEN + 6;
     pkt[udp_csum_off..udp_csum_off + 2].copy_from_slice(&udp_csum.to_be_bytes());
 
     Some(pkt)
@@ -243,5 +301,101 @@ mod tests {
         assert!(
             build_ipv4_udp(addr([10, 0, 0, 1], 5060), addr([10, 0, 0, 2], 5060), &max).is_some()
         );
+    }
+
+    // ── IPv6 ──
+
+    fn addr6(a: [u16; 8], p: u16) -> SocketAddrV6 {
+        SocketAddrV6::new(std::net::Ipv6Addr::from(a), p, 0, 0)
+    }
+
+    /// The IPv6 UDP checksum validates over its pseudo-header, and the header
+    /// fields (version, next-header, payload length, addresses, ports) are
+    /// correct. Rebuilding the pseudo-header + segment with the stored checksum
+    /// must re-sum to zero — the receiver's validity test.
+    fn ipv6_udp_check(pkt: &[u8], src: [u16; 8], dst: [u16; 8]) {
+        let sip = std::net::Ipv6Addr::from(src).octets();
+        let dip = std::net::Ipv6Addr::from(dst).octets();
+        let udp_len = u16::from_be_bytes([pkt[44], pkt[45]]);
+        let mut check = Vec::new();
+        check.extend_from_slice(&sip);
+        check.extend_from_slice(&dip);
+        check.extend_from_slice(&(udp_len as u32).to_be_bytes());
+        check.extend_from_slice(&[0, 0, 0]);
+        check.push(17);
+        check.extend_from_slice(&pkt[40..]);
+        assert_eq!(
+            ref_checksum(&check),
+            0,
+            "IPv6 UDP checksum must validate to 0"
+        );
+    }
+
+    #[test]
+    fn builds_ipv6_expected_header_and_checksum() {
+        let src = [0x2001, 0xdb8, 0, 0, 0, 0, 0, 1];
+        let dst = [0x2001, 0xdb8, 0, 0, 0, 0, 0, 2];
+        let payload = b"SIP/2.0 403 Forbidden\r\n\r\n";
+        let pkt = build_ipv6_udp(addr6(src, 5060), addr6(dst, 40000), payload).expect("build");
+
+        assert_eq!(pkt.len(), 40 + 8 + payload.len());
+        assert_eq!(pkt[0] >> 4, 6, "version 6");
+        assert_eq!(pkt[6], 17, "next header UDP");
+        assert_eq!(
+            &pkt[4..6],
+            &((8 + payload.len()) as u16).to_be_bytes(),
+            "payload length"
+        );
+        assert_eq!(
+            &pkt[8..24],
+            &std::net::Ipv6Addr::from(src).octets(),
+            "source addr (spoofed)"
+        );
+        assert_eq!(
+            &pkt[24..40],
+            &std::net::Ipv6Addr::from(dst).octets(),
+            "dest addr"
+        );
+        assert_eq!(
+            &pkt[40..42],
+            &5060u16.to_be_bytes(),
+            "udp src port (spoofed)"
+        );
+        assert_eq!(&pkt[42..44], &40000u16.to_be_bytes(), "udp dst port");
+        assert_ne!(
+            &pkt[46..48],
+            &[0, 0],
+            "IPv6 UDP checksum is mandatory, never zero"
+        );
+        ipv6_udp_check(&pkt, src, dst);
+    }
+
+    #[test]
+    fn ipv6_empty_and_adversarial_payloads() {
+        let src = [0xfe80, 0, 0, 0, 0, 0, 0, 1];
+        let dst = [0xfe80, 0, 0, 0, 0, 0, 0, 2];
+        let empty = build_ipv6_udp(addr6(src, 5060), addr6(dst, 5060), b"").expect("build");
+        assert_eq!(empty.len(), 48);
+        assert_eq!(
+            &empty[4..6],
+            &8u16.to_be_bytes(),
+            "payload length header-only"
+        );
+        ipv6_udp_check(&empty, src, dst);
+
+        let payload = vec![0x00u8, 0xff, b'\\', 0x0d, 0x0a, 0x80, 0x7f, 0x00, b'S'];
+        let pkt = build_ipv6_udp(addr6(src, 5060), addr6(dst, 5062), &payload).expect("build");
+        assert_eq!(&pkt[48..], &payload[..], "payload carried byte-for-byte");
+        ipv6_udp_check(&pkt, src, dst);
+    }
+
+    #[test]
+    fn ipv6_oversize_payload_rejected() {
+        let src = [0x2001, 0xdb8, 0, 0, 0, 0, 0, 1];
+        let dst = [0x2001, 0xdb8, 0, 0, 0, 0, 0, 2];
+        let too_big = vec![0u8; MAX_UDP_PAYLOAD_V6 + 1];
+        assert!(build_ipv6_udp(addr6(src, 5060), addr6(dst, 5060), &too_big).is_none());
+        let max = vec![0u8; MAX_UDP_PAYLOAD_V6];
+        assert!(build_ipv6_udp(addr6(src, 5060), addr6(dst, 5060), &max).is_some());
     }
 }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -155,7 +155,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2510 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2514 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -226,7 +226,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2510" data-suffix="">2510</span>
+        <span class="arch-stat" data-count="2514" data-suffix="">2514</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Completes the scanner-kill source-spoofing feature — 0.5.12 (#136) shipped IPv4 only. IPv6 kill targets now also get a forged victim `ip:port` instead of the ephemeral fallback.

## Changes

- **`kill_packet::build_ipv6_udp`** — pure IPv6 + UDP datagram builder with the mandatory UDP checksum over the IPv6 pseudo-header. Unit-tested against golden bytes and an independent checksum, including empty / NUL-binary / oversize cases.
- **`RawKillSocket`** now opens both an `AF_INET` and an `AF_INET6` raw socket (`IPPROTO_RAW`, best-effort per family), so a host with only one stack still spoofs that family. `send_to_v6` sets **`sin6_port = 0`** — raw IPv6 sockets reject a nonzero port with `EINVAL`; the real dest port lives in our own UDP header. `IPV6_HDRINCL` is set best-effort (`IPPROTO_RAW` already includes the header).
- **`process_send`** spoofs v4 or v6 by address family, falling back to the ephemeral send on any failure. Mixed families never occur (src and dst come from one sniffed packet).

## Tests

- v6 builder unit tests (3): header fields + checksum validity, empty/adversarial, oversize.
- **`CAP_NET_RAW`-gated v6 integration test**: asserts a `::1` listener receives the datagram with the **forged source port** (an ephemeral send would show a random port). Skipped (not failed) when unprivileged or without IPv6 loopback.
- **Live e2e**: `-K '[::1]:5094-5094' --kill-spoof raw` → the scanner at `[::1]:5094` receives `SIP/2.0 200 OK` from source `::1:5060`.
- Full suite 2514 green; clippy `-Dwarnings` clean on default + `--all-features`; feature matrix (default/all-features/no-default/wasm) builds.

Both address families now spoof; the `KILL-TARGET-SPOOFING-SPEC.md` open item is closed.