### PR TITLE
Fix spurious "Unknown config key" warnings for [sip] and capture.promisc

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ fn known_keys() -> HashMap<&'static str, &'static [&'static str]> {
             "capture",
             "display",
             "filter",
+            "sip",
             "security",
             "limits",
             "privilege",
@@ -43,6 +44,7 @@ fn known_keys() -> HashMap<&'static str, &'static [&'static str]> {
             "buffer",
             "buffer_budget_mb",
             "no_rtp",
+            "promisc",
         ]
         .as_slice(),
     );
@@ -58,6 +60,7 @@ fn known_keys() -> HashMap<&'static str, &'static [&'static str]> {
         .as_slice(),
     );
     m.insert("filter", ["from", "to", "expression"].as_slice());
+    m.insert("sip", ["xcid_headers"].as_slice());
     m.insert(
         "security",
         [
@@ -1159,6 +1162,35 @@ filter = "/"
             collect_unknown_keys(&value),
             vec!["crash.bogus".to_string()]
         );
+    }
+
+    /// The `[sip]` section and the `[capture] promisc` key are valid config the
+    /// code actually reads; neither may be flagged as unknown, or the warning
+    /// trains users to ignore it.
+    #[test]
+    fn sip_section_and_capture_promisc_are_known() {
+        let toml_str = "[sip]\nxcid_headers = [\"X-CID\"]\n[capture]\npromisc = false\n";
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            collect_unknown_keys(&value),
+            Vec::<String>::new(),
+            "valid [sip] section and [capture] promisc must not be flagged"
+        );
+        // And they actually parse into the config.
+        let config = Config::parse_toml(toml_str, None).unwrap();
+        assert_eq!(
+            config.sip.xcid_headers.as_deref(),
+            Some(["X-CID".to_string()].as_slice())
+        );
+        assert_eq!(config.capture.promisc, Some(false));
+    }
+
+    /// With `[sip]` now a known section, a typo inside it must still be flagged
+    /// (the fix must not turn the section into a wildcard).
+    #[test]
+    fn sip_section_typo_is_flagged() {
+        let value: toml::Value = toml::from_str("[sip]\nbogus = 1\n").unwrap();
+        assert_eq!(collect_unknown_keys(&value), vec!["sip.bogus".to_string()]);
     }
 
     #[test]

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -155,7 +155,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2514 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2516 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -226,7 +226,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2514" data-suffix="">2514</span>
+        <span class="arch-stat" data-count="2516" data-suffix="">2516</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
`known_keys()` omitted the valid `[sip]` section and the `[capture] promisc` key, so a config using `[sip] xcid_headers` or `[capture] promisc = …` — both read by the code — emitted `Unknown config key` warnings at load. A valid key that warns trains users to ignore the warning entirely (defeating the point of the check).

## Fix
- Register `sip` as a known root section with its `xcid_headers` key.
- Add `promisc` to the `capture` key list.

Detection still reaches typos inside `[sip]` (`sip.bogus` is still flagged) — the section is now *known*, not wildcarded.

## Tests (TDD, red→green)
- `sip_section_and_capture_promisc_are_known` — `collect_unknown_keys()` is empty for a valid `[sip]` + `[capture] promisc` config, and both parse into `Config`.
- `sip_section_typo_is_flagged` — a `[sip]` typo is still flagged.

Verified end-to-end on the built binary: a valid `[sip]`/`promisc` config loads with **no** warning; `[sip] bogus` still warns `Unknown config key: sip.bogus`. Full suite 2516 green; clippy `-Dwarnings` clean on default + `--all-features`; homepage count 2514 → 2516.