### PR TITLE
docs: per-parameter examples, RFC 5737 sweep, and two coverage gates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ mimalloc = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 bytes = "1"
+unicode-width = "0.2"
 parking_lot = "0.12"
 proptest = "1"
 trycmd = "1"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -30,6 +30,32 @@ CLI flags always override config file values (see [config-reference.md](config-r
 | `--pcapng` | -- | off | Use pcapng format for output files |
 | `<BPF_FILTER>...` | positional | -- | BPF display filter expression (trailing positional args) |
 
+**Examples**
+
+```bash
+# Record up to 10000 packets from eth0 into a pcap, watching a widened SIP port range
+sudo sipnab --device eth0 --output capture.pcap --portrange 5060-5080 --count 10000
+# Live-capture a busy link with bigger kernel and queue buffers, a capped snapshot length, and parse-error notices silenced (sipgrep -x)
+sudo sipnab --device eth0 --buffer 16 --buffer-budget 128 --snaplen 2048 --quiet-bad-parse
+# Capture on all available interfaces headlessly, stopping once the output file reaches 100 MiB
+sudo sipnab -N --multi-device --output capture.pcap --autostop filesize:100
+# Replay a pcap at its original timing with RTP capture and analysis disabled
+sipnab -N --input capture.pcap --replay --no-rtp
+# Scan a pcap sipgrep-style: parse only the first 512 bytes of each packet, every packet standalone (no reassembly), without parse-error noise
+sipnab -N --input capture.pcap --limitlen 512 --no-reassembly --quiet-bad-parse
+# Capture for 5 minutes using a BPF filter read from sip.bpf, without putting the interface into promiscuous mode (sipgrep -p)
+sudo sipnab --device eth0 --bpf-file sip.bpf --no-promisc --duration 5m
+# Monitor an hour of traffic across a wide SIP port range with enlarged capture buffers
+sudo sipnab --device eth0 --portrange 5060-5090 --buffer 8 --buffer-budget 256 --duration 1h
+# Replay signaling only from a pcap, parsing at most 1500 bytes of each packet
+sipnab -N --input capture.pcap --replay --limitlen 1500 --no-rtp
+# Stop after 500 packets that pass the sip.bpf filter, non-promiscuous, with the snapshot length sized for jumbo frames
+sudo sipnab --device eth0 --bpf-file sip.bpf --no-promisc --snaplen 9000 --count 500
+# Write a one-minute capture that treats every packet standalone (IP-fragment and TCP-segment reassembly off)
+sudo sipnab -N --device eth0 --output capture.pcap --autostop duration:60 --no-reassembly
+```
+
+
 ## Mode
 
 | Flag | Value | Default | Description |
@@ -38,6 +64,18 @@ CLI flags always override config file values (see [config-reference.md](config-r
 | `-c`, `--calls-only` | -- | off | Show only SIP dialogs (calls), not standalone messages |
 | `-t`, `--telephone-event` | -- | off | Capture and display telephone-event (DTMF) RTP payloads |
 | `-q`, `--quiet` | -- | off | Suppress informational output; only show results |
+
+**Examples**
+
+```bash
+# Analyze a pcap headlessly, showing only complete SIP dialogs (calls), not standalone messages
+sipnab --no-tui -I capture.pcap --calls-only
+# Watch live calls in the TUI with telephone-event (DTMF) RTP payloads captured and displayed
+sudo sipnab -d eth0 --calls-only --telephone-event
+# Headless live capture that decodes DTMF and suppresses informational output
+sudo sipnab --no-tui -d eth0 --telephone-event --quiet
+```
+
 
 ## Matching
 
@@ -54,6 +92,24 @@ CLI flags always override config file values (see [config-reference.md](config-r
 | `--ua` | `<PATTERN>` | -- | Filter by User-Agent header (regex pattern) |
 | `--filter` | `<EXPR>` | -- | Filter DSL expression OR a diagnostic alias name (`codec-asym`, `late-media`, etc.) — see [filter-dsl.md](filter-dsl.md) |
 
+**Examples**
+
+```bash
+# Show every dialog that mentions alice@example.com, case-insensitively (dialog-following payload match)
+sipnab -N -I capture.pcap --match "alice@example.com" --ignore-case
+# Whole-word match for 486 rejections, folding multi-line headers into one line before matching
+sipnab -N -I capture.pcap --match "486 Busy Here" --word --single-line
+# Live view of everything except REGISTER traffic (inverted match)
+sudo sipnab -d eth0 --match "REGISTER" --invert
+# Flag scanner traffic live: a known scanner User-Agent (any case) with a Contact pointing into 203.0.113.0/24
+sudo sipnab -d eth0 --ua "friendly-scanner" --contact "203\.0\.113\." --ignore-case
+# Filter a pcap by User-Agent and a Contact in 192.0.2.0/24, matching even when headers span folded lines
+sipnab -N -I capture.pcap --ua "sipcli" --contact "192\.0\.2\." --single-line
+# Suppress keep-alive noise: show messages that do not contain the whole word OPTIONS
+sipnab -N -I capture.pcap --match "OPTIONS" --word --invert
+```
+
+
 ## Name Resolution
 
 | Flag | Value | Default | Description |
@@ -63,6 +119,20 @@ CLI flags always override config file values (see [config-reference.md](config-r
 | `--names` | `<FILE>` | -- | Preload IP → name mappings from an `/etc/hosts`-format file. Repeatable |
 
 See the [Name Resolution](keybindings.md#name-resolution) keys for in-TUI naming (`N`) and persistence.
+
+**Examples**
+
+```bash
+# Live capture with name resolution from a static hosts-format mapping file
+sudo sipnab -d eth0 --resolve --names /etc/sipnab/hosts.map
+# Annotate an offline pcap with names, preloading two mapping files on top of /etc/hosts
+sipnab -N -I capture.pcap --resolve --names /etc/sipnab/hosts.map --names ~/.config/sipnab/lab-names
+# Live capture that also resolves captured IPs via reverse DNS (PTR) lookups
+sudo sipnab -d eth0 --reverse-dns
+# Replay an offline pcap and resolve its addresses with reverse DNS, supplemented by a local mapping file
+sipnab -N -I capture.pcap --reverse-dns --names ~/.config/sipnab/lab-names
+```
+
 
 ## pcapng Metadata
 
@@ -79,6 +149,16 @@ capture source as the interface name. Embedded NRB names / DSB TLS secrets are
 read back (and used for decryption) when a pcapng is opened. See
 [the design doc](design/pcapng-metadata.md).
 
+**Examples**
+
+```bash
+# Write a sanitized copy of a pcapng with every Decryption Secrets Block removed
+sipnab -N -I capture.pcapng --strip-secrets clean.pcapng
+# Strip embedded TLS secrets from a decrypted-session capture before sharing it in a support ticket
+sipnab -N -I tls-call.pcapng --strip-secrets tls-call-clean.pcapng
+```
+
+
 ## Diagnostic Aliases
 
 Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl.md](filter-dsl.md) for the exact expansion of each alias.
@@ -90,6 +170,18 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--short-calls` | -- | off | Show completed calls shorter than 5 seconds |
 | `--one-way` | -- | off | Show calls with potential one-way audio issues |
 | `--nat-issues` | -- | off | Show calls with Contact/Via NAT mismatch |
+
+**Examples**
+
+```bash
+# Flag completed calls under 5 seconds and calls with suspected one-way audio in a capture
+sipnab -N -I capture.pcap --short-calls --one-way
+# Live-monitor for one-way audio and Contact/Via NAT mismatches
+sudo sipnab -d eth0 -N --one-way --nat-issues
+# Summarize short completed calls from a capture in a post-run report
+sipnab -N -I capture.pcap --short-calls --report
+```
+
 
 ## Output
 
@@ -116,6 +208,30 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--fail2ban` | -- | off | Output in fail2ban-compatible format for SIP security events. Requires `-N` |
 | `--group-by` | `<FIELD>` | -- | Group output by field (e.g., `call-id`, `from`, `method`) |
 
+**Examples**
+
+```bash
+# Export every SIP message from a capture as pretty-printed JSON, truncating displayed payloads to 1000 bytes
+sipnab -N -I capture.pcap --json-pretty --payload-limit 1000 > messages.json
+# Stream live SIP traffic as pretty-printed JSON grouped by method, flushing after each line for downstream tooling
+sudo sipnab -d eth0 -N --json-pretty --group-by method --line-buffer > live.json
+# Dump raw SIP text with hex payloads and IANA protocol numbers, uncolored for log archiving
+sipnab -N -I capture.pcap --text-dump --hexdump --proto-number --color never
+# Follow live REGISTER traffic in real time, printing raw text plus 2 messages of context after each match
+sudo sipnab -d eth0 -N --match REGISTER --after 2 --text-dump --line-buffer --color always
+# Review a capture with per-message delta times, empty-bodied messages included, and hex dumps grouped per call
+sipnab -N -I capture.pcap --show-empty --delta-time --hexdump --group-by call-id
+# Inspect OPTIONS keepalives with 5 messages of trailing context, empty bodies shown, and display capped at 256 payload bytes
+sudo sipnab -d eth0 -N --match OPTIONS --after 5 --show-empty --proto-number --payload-limit 256
+# Watch the live TUI with host:port From/To columns and hand the capture to Wireshark with a matching display filter
+sudo sipnab -d eth0 --from-to-mode host-port --wireshark
+# Browse an existing capture in the TUI with full user@host:port From/To columns
+sipnab -I capture.pcap --from-to-mode user-host-port
+# Print a tshark-compatible display filter for the INVITE traffic in a capture
+sipnab -N -I capture.pcap --tshark-filter "method=INVITE"
+```
+
+
 ## Dialog
 
 | Flag | Value | Default | Description |
@@ -127,6 +243,24 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--no-dialog` | -- | off | Disable dialog tracking entirely (message-only mode) |
 | `--tag` | `<TAG>` | -- | Filter dialogs by tag value |
 
+**Examples**
+
+```bash
+# Monitor a busy proxy with a tight 5000-dialog memory bound, explicitly evicting the oldest dialog at capacity
+sudo sipnab -d eth0 --limit 5000 --rotate --dialog-track call-id
+# Analyze a capture keyed by Via branch, dropping new dialogs (instead of evicting old ones) past 20000 tracked
+sipnab -N -I capture.pcap --limit 20000 --no-rotate --dialog-track branch
+# Show only dialogs carrying a specific From/To tag, with explicit LRU rotation
+sipnab -N -I capture.pcap --tag 1928301774 --rotate
+# Live-follow dialogs matching a tag while refusing new dialogs once the tracker is full
+sudo sipnab -d eth0 --tag as7d60e14a --no-rotate
+# Scan a capture message-by-message with dialog tracking disabled entirely
+sipnab -N -I capture.pcap --no-dialog
+# Watch raw live SIP messages on an interface without keeping any per-dialog state
+sudo sipnab -d eth0 -N --no-dialog
+```
+
+
 ## RTP
 
 | Flag | Value | Default | Description |
@@ -135,6 +269,16 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--max-streams` | `<N>` | `50000` | Maximum number of RTP streams to track simultaneously |
 | `--quality-threshold` | `<MOS>` | `3.0` | MOS quality threshold for alerts (1.0-5.0 scale) |
 
+**Examples**
+
+```bash
+# Monitor live RTP with 5-second statistics reports and MOS alerts below 3.5
+sudo sipnab -d eth0 --rtp-interval 5 --quality-threshold 3.5 --max-streams 10000
+# Batch-analyze RTP streams in a capture, reporting stats every 2 seconds with a raised stream cap
+sipnab -N -I capture.pcap --rtp-interval 2 --max-streams 100000
+```
+
+
 ## Security
 
 | Flag | Value | Default | Description |
@@ -142,7 +286,7 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--kill-scanner` | -- | off | Detect SIP scanning (known UA signatures + behavioral rate/enumeration) and send the kill response back to the scanner (sipgrep `-J`/`-j`) |
 | `--kill-ua` | `<PATTERN>` | -- | Add a custom scanner User-Agent pattern (regex) to `--kill-scanner` detection |
 | `--kill-response` | `<CODE>` | `200` | SIP response code for the kill response (100-699) |
-| `-K`, `--kill-target` | `<ADDR[:PORT-RANGE]>` | -- | Targeted kill (sipgrep `-K`): send the kill response to any SIP request whose source matches ADDR and an optional port range (`10.0.0.1:5060-5090`, `[::1]:5060`), regardless of UA/behavioral detection. Repeatable; spawns the kill worker on its own (no `--kill-scanner` needed) |
+| `-K`, `--kill-target` | `<ADDR[:PORT-RANGE]>` | -- | Targeted kill (sipgrep `-K`): send the kill response to any SIP request whose source matches ADDR and an optional port range (`192.0.2.1:5060-5090`, `[::1]:5060`), regardless of UA/behavioral detection. Repeatable; spawns the kill worker on its own (no `--kill-scanner` needed) |
 | `--kill-spoof` | `<MODE>` | `auto` | Source-address strategy for the kill response (Linux only; other platforms always `ephemeral`). `auto` forges the victim's ip:port via a raw socket when `CAP_NET_RAW` is available (so the reply appears to come from the targeted SIP port), falling back to an ephemeral source otherwise; `raw` requires the spoof and errors if the raw socket can't be opened; `ephemeral` never spoofs |
 | `--fraud-detect` | -- | off | Enable fraud detection heuristics |
 | `--reg-flood` | -- | off | Detect registration flood attacks |
@@ -151,6 +295,22 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--alert-exec` | `<CMD>` | -- | Execute this command when an alert fires |
 | `--alert-json` | -- | off | Emit each security alert as a structured JSON line on stderr (in addition to the human `[ALERT]` line) |
 | `--stir-shaken` | -- | off | Validate STIR/SHAKEN identity headers |
+
+**Examples**
+
+```bash
+# Detect SIP scanners (plus a custom UA pattern) and reply 486 with the victim's spoofed source
+sudo sipnab -d eth0 --kill-scanner --kill-ua 'friendly-scanner' --kill-response 486 --kill-spoof auto
+# Targeted kill of a scanning host across a port range, plus a second scanner UA, replying 480 via raw-socket spoof
+sudo sipnab -d eth0 --kill-target 192.0.2.66:5060-5090 --kill-ua 'sipvicious' --kill-response 480 --kill-spoof raw
+# Kill requests from one more source port using a non-spoofed ephemeral reply
+sudo sipnab -d eth0 --kill-target 198.51.100.77:5060 --kill-spoof ephemeral
+# Live security monitoring: registration floods, digest leaks, fraud, STIR/SHAKEN, with JSON alerts and an exec hook
+sudo sipnab -N -d eth0 --reg-flood --digest-leak --fraud-detect --stir-shaken --alert json --alert-json --alert-exec '/usr/local/bin/notify.sh'
+# Offline audit of a pcap for digest leaks and STIR/SHAKEN validity, emitting structured JSON alerts
+sipnab -N -I capture.pcap --stir-shaken --digest-leak --alert-json
+```
+
 
 ## Event Execution
 
@@ -196,6 +356,28 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--mint-token` | -- | off | Mint a signed bearer token from the first configured signing key, print it to stdout, and exit (no capture/servers). See [`auth.md`](./auth.md). |
 | `--token-id` | `<ID>` | -- | Token id (`jti`) for `--mint-token`, used for revocation. Defaults to a generated id. |
 
+**Examples**
+
+```bash
+# Live capture serving a TLS REST API (cert+key) with signed tokens, a revocation list, and a Basic-auth'd Prometheus endpoint
+sudo sipnab -d eth0 --api 127.0.0.1:8080 --api-tls-cert /etc/sipnab/api.pem --api-tls-key /etc/sipnab/api.key --api-signing-key-file /etc/sipnab/signing.key --api-revoked-file /etc/sipnab/revoked.txt --api-token-ttl 7200 --api-max-conn 200 --metrics 127.0.0.1:9090 --metrics-auth alice:s3cret
+# Public-facing TLS API tuned to 100 connections and 1h token TTL, with its own auth'd metrics endpoint
+sudo sipnab -d eth0 --api 0.0.0.0:8080 --api-tls-cert /etc/sipnab/api.pem --api-tls-key /etc/sipnab/api.key --api-signing-key-file /etc/sipnab/signing.key --api-token-ttl 3600 --api-max-conn 100 --metrics 127.0.0.1:9090 --metrics-auth bob:hunter2
+# Loopback HTTP MCP server with a bearer token, file-loaded signing key, revocation denylist, and a 30-minute mint TTL
+sudo sipnab -N -d eth0 --mcp --mcp-transport http --mcp-bind 127.0.0.1:8731 --mcp-token t0ken-alice --mcp-signing-key-file /etc/sipnab/mcp-signing.key --mcp-revoked-file /etc/sipnab/mcp-revoked.txt --mcp-token-ttl 1800
+# Non-loopback HTTP MCP server (token required) accepting an extra Host header for named clients
+sudo sipnab -N -d eth0 --mcp --mcp-transport http --mcp-bind 0.0.0.0:8731 --mcp-token t0ken-bob --mcp-signing-key-file /etc/sipnab/mcp-signing.key --mcp-revoked-file /etc/sipnab/mcp-revoked.txt --mcp-allowed-host mcp.example.com
+# Forward captured packets to a Homer collector, stamping capture-agent id 42 and an authenticate key
+sudo sipnab -N -d eth0 --hep-send 192.0.2.10:9060 --hep-id 42 --hep-auth s3cr3t-homer-key
+# Forward to a second collector under a different agent id and auth key
+sudo sipnab -N -d eth0 --hep-send 198.51.100.20:9060 --hep-id 7 --hep-auth homerkey2
+# Run a HEP collector that parses incoming packets, only from two allowed CIDRs, capped at 20k pkts/sec
+sipnab -N -L 0.0.0.0:9060 --hep-parse --hep-allow 192.0.2.0/24 --hep-allow 198.51.100.20/32 --hep-rate-limit 20000
+# Mint a signed bearer token with a fixed id (for later revocation) and a 1-hour TTL, then exit
+sipnab --mint-token --token-id alice-2026 --api-signing-key-file /etc/sipnab/signing.key --api-token-ttl 3600
+```
+
+
 ## TLS / Decryption
 
 | Flag | Value | Default | Description |
@@ -208,6 +390,18 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--pcap-export-mode` | `<MODE>` | `decrypted` | Pcap export mode for encrypted traffic: `decrypted`, `encrypted+dsb`, or `raw` |
 | `--allow-coredump` | -- | off | Allow core dumps (do not call `prctl` to disable them) |
 
+**Examples**
+
+```bash
+# Decrypt TLS 1.2 RSA-key-exchange SIP from a pcap using an RSA private key, with core dumps left enabled
+sipnab -N -I capture.pcap --tls-key /etc/sipnab/tls-rsa.key --keylog /etc/sipnab/keys.log --allow-coredump
+# Decrypt SRTP media in an offline pcap from an SRTP master-keys file plus DTLS-SRTP handshake keys
+sipnab -N -I capture.pcap --srtp-keys /etc/sipnab/srtp.keys --dtls-keylog /etc/sipnab/dtls.log
+# Live decrypt both SIP (RSA key) and SRTP media, watching the key log for new PFS session keys
+sudo sipnab -d eth0 --tls-key /etc/sipnab/tls-rsa.key --srtp-keys /etc/sipnab/srtp.keys --keylog /etc/sipnab/keys.log --keylog-watch --allow-coredump
+```
+
+
 ## Privilege
 
 | Flag | Value | Default | Description |
@@ -217,12 +411,36 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `--chroot` | `<DIR>` | -- | Chroot to this directory after initialization |
 | `--setup-caps` | -- | off | Grant this binary the Linux capabilities for live capture (`cap_net_raw,cap_net_admin+ep` via `setcap`) so it runs without `sudo`, then exit. Re-invokes through `sudo` when not already root. Linux only. |
 
+**Examples**
+
+```bash
+# Live capture that drops root to the sipnab service user once the capture device is open
+sudo sipnab -d eth0 --user sipnab
+# Long-running monitor that drops to nobody and confines itself to an empty chroot
+sudo sipnab -d eth0 --user nobody --chroot /var/empty
+# Chrooted capture that keeps root privileges for the whole run
+sudo sipnab -d eth0 --chroot /var/empty --no-priv-drop
+# Grant the binary the capture capabilities (cap_net_raw,cap_net_admin) so future runs work without sudo, then exit
+sudo sipnab --setup-caps
+```
+
+
 ## Resource Limits
 
 | Flag | Value | Default | Description |
 |------|-------|---------|-------------|
 | `--max-reassembly` | `<N>` | `10000` | Maximum concurrent TCP/TLS reassembly sessions |
 | `--cores` | `<N>` | `1` | CPU cores for offline pcap reconstruction (`-I`). 1 = single-threaded; >1 shards by host pair for multi-core throughput (dialog+RTP reconstruction, `--report`/`--json`) |
+
+**Examples**
+
+```bash
+# Live capture on a busy TCP/TLS trunk with a raised reassembly-session ceiling
+sudo sipnab -d eth0 --max-reassembly 50000
+# Offline reconstruction sharded across 4 cores, with a tight reassembly bound for an untrusted capture
+sipnab -N -I capture.pcap --cores 4 --max-reassembly 2000
+```
+
 
 ## Config
 
@@ -232,6 +450,24 @@ Shortcut flags that expand to predefined filter DSL expressions. See [filter-dsl
 | `-F`, `--no-config` | -- | off | Skip loading any configuration file |
 | `-D`, `--dump-config` | -- | off | Dump effective configuration and exit |
 | `--completions` | `<SHELL>` | -- | Print a shell completion script (bash, zsh, fish, elvish, powershell) to stdout and exit |
+
+**Examples**
+
+```bash
+# Dump the effective configuration produced by a specific config file, then exit
+sipnab --config /etc/sipnab/sipnab.toml --dump-config
+# Dump the built-in defaults, skipping any configuration file, then exit
+sipnab --no-config --dump-config
+# Live capture using a per-user configuration file
+sudo sipnab -d eth0 --config ~/.config/sipnab/config.toml
+# Analyze an offline pcap with all configuration files ignored
+sipnab -N -I capture.pcap --no-config
+# Print a bash completion script into a file suitable for /etc/bash_completion.d
+sipnab --completions bash > sipnab.bash
+# Print a zsh completion script into a file suitable for the zsh fpath
+sipnab --completions zsh > _sipnab
+```
+
 
 ## Validation Rules
 
@@ -261,7 +497,7 @@ sipnab --kill-scanner -d eth0
 sipnab --from alice --to bob
 
 # BPF display filter
-sipnab 'host 10.0.0.1 and port 5060'
+sipnab 'host 192.0.2.1 and port 5060'
 
 # Advanced filter DSL
 sipnab --filter "method == 'INVITE' AND rtp.mos < 3.0"
@@ -270,7 +506,7 @@ sipnab --filter "method == 'INVITE' AND rtp.mos < 3.0"
 sipnab -I capture.pcap --call-report "abc123@host" --markdown
 
 # Capture with HEP mirror
-sipnab -d eth0 -H 10.0.0.50:9060
+sipnab -d eth0 -H 192.0.2.50:9060
 
 # Live TLS decryption
 sipnab -d eth0 --keylog /tmp/sslkeys.log --keylog-watch

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -181,7 +181,7 @@ persist_to_config = true
 
 # Inline mappings (also written here when persist_to_config = true):
 [names.manual]
-"10.0.0.1" = "sbc-edge"
+"192.0.2.1" = "sbc-edge"
 "2001:db8::1" = "core6"
 ```
 
@@ -289,12 +289,14 @@ device = "eth0"
 portrange = "5060-5080"
 snaplen = 65535
 buffer = 16
+buffer_budget_mb = 128
 no_rtp = false
 
 [display]
 color = "always"
 payload_limit = 4096
 delta_time = true
+from_to = "host-port"
 
 [filter]
 from = "^1001@"
@@ -324,7 +326,7 @@ enabled = true
 hosts_file = "/etc/sipnab/hosts"
 
 [names.manual]
-"10.0.0.1" = "sbc-edge"
+"192.0.2.1" = "sbc-edge"
 
 [crash]
 reports = true

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -18,10 +18,10 @@ sudo sipnab -d eth0
 sipnab -N -I capture.pcap --problems
 
 # 3. Deep-dive one call: ladder, timing, SDP, RTP quality, diagnosis
-sipnab -N -I capture.pcap --call-report 'abc123@10.0.0.1'
+sipnab -N -I capture.pcap --call-report 'abc123@192.0.2.1'
 
 # 4. The same as a Markdown report for a ticket
-sipnab -N -I capture.pcap --call-report 'abc123@10.0.0.1' --markdown > call.md
+sipnab -N -I capture.pcap --call-report 'abc123@192.0.2.1' --markdown > call.md
 
 # 5. Post-capture aggregate summary only (no per-message noise)
 sipnab -N -I capture.pcap --report --no-cli-print

--- a/docs/filter-dsl.md
+++ b/docs/filter-dsl.md
@@ -29,8 +29,8 @@ All 31 addressable fields, organized by type.
 | `ua` | User-Agent header (first non-empty across dialog messages) | `"Olle"`, `"friendly-scanner"` |
 | `call_id` | SIP Call-ID header | `"abc123@host"` |
 | `payload` | Raw message content — matches when ANY message in the dialog contains/matches the value (sngrep-style payload grep) | `"X-Custom-Header"`, `"sipsak"` |
-| `src.ip` | Source IP address (first message) | `"10.0.0.1"` |
-| `dst.ip` | Destination IP address (first message) | `"10.0.0.2"` |
+| `src.ip` | Source IP address (first message) | `"192.0.2.1"` |
+| `dst.ip` | Destination IP address (first message) | `"192.0.2.2"` |
 | `state` | Dialog state machine value | `"Trying"`, `"InCall"`, `"Failed"` |
 | `rtp.codec` | RTP codec name (first stream) | `"PCMU"`, `"opus"` |
 | `rtp.ssrc` | RTP SSRC in hex format (first stream) | `"0x12345678"` |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -317,7 +317,7 @@ sections are preserved). You can also pre-declare mappings there by hand:
 
 ```toml
 [names.manual]
-"10.0.0.1" = "sbc-edge"
+"192.0.2.1" = "sbc-edge"
 ```
 
 When saving a capture as **PCAP-NG** with resolution active, the mappings are

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -20,14 +20,14 @@ Message record (fields with no value are omitted, not null):
 {
   "schema_version": 1,
   "timestamp": "2026-06-12T14:03:21.412345+00:00",
-  "src": "10.0.0.1",
+  "src": "192.0.2.1",
   "src_port": 5060,
-  "dst": "10.0.0.2",
+  "dst": "192.0.2.2",
   "dst_port": 5060,
   "transport": "UDP",
   "is_request": true,
   "method": "INVITE",
-  "call_id": "abc123@10.0.0.1",
+  "call_id": "abc123@192.0.2.1",
   "cseq": { "number": 1, "method": "INVITE" },
   "from": "1001",
   "to": "1002",
@@ -93,7 +93,7 @@ per-message stream but not the report):
 sipnab -N -I capture.pcap --report --no-cli-print
 
 # Single-call deep dive only
-sipnab -N -I capture.pcap --call-report 'abc123@10.0.0.1' --no-cli-print
+sipnab -N -I capture.pcap --call-report 'abc123@192.0.2.1' --no-cli-print
 ```
 
 ## Dialog / stream JSON

--- a/man/sipnab.1
+++ b/man/sipnab.1
@@ -92,7 +92,7 @@ Targeted scanner kill: send the kill response to any request whose source
 matches
 .I addr
 and an optional port range (e.g.
-.IR 10.0.0.1:5060\-5090 ).
+.IR 192.0.2.1:5060\-5090 ).
 Repeatable.
 .TP
 .BI \-l " N"

--- a/tasks/docs-website-improvements-2026-07-18.md
+++ b/tasks/docs-website-improvements-2026-07-18.md
@@ -3,6 +3,17 @@
 > Created 2026-07-18. Source: three parallel audits (repo docs vs 0.5.14 code;
 > website tree; live sipnab.com). crates.io publish explicitly **out of scope**
 > (deferred by owner). Attribution/credit "gaps" not applicable.
+>
+> **STATUS: COMPLETE (2026-07-18).** All Tier A + Tier B items shipped in
+> PR #142 (`6152144`) and verified on the live site. The Cloudflare email
+> obfuscation was disabled the same day via the zone-settings API (no
+> dashboard needed — `CLOUDFLARE_DNS_TOKEN` has Zone Settings Edit).
+> Follow-up hardening landed after the merge: mockup alignment is now gated
+> by `tests/mockup_alignment_test.rs`, and the deferred search-quality
+> validation was run (zola 0.19.2 + node replay of the elasticlunr index:
+> all 10 representative queries return relevant top-3 results, no tuning
+> needed). Still deferred: re-benchmark on 0.5.x, full RFC 5737 sweep,
+> crates.io publish (owner).
 
 ## External / owner action (cannot fix in repo)
 
@@ -56,12 +67,36 @@
     (`05-file-open.gif`, `06-rtp-quality.gif`); `-1` duplicate-slug anchor
     fragility in output-formats.md/mcp.md (low, optional).
 
-## Deferred (not this pass)
+## Follow-up pass — 2026-07-18 (completeness sweep)
+
+Closing the remaining gaps after the maintainer asked for full per-parameter
+example coverage and "every gap closed":
+
+- **Per-parameter examples — DONE.** A coverage audit found 80 CLI flags with
+  zero runnable examples and 17 with only one (in the doc corpus = `docs/*.md`
+  + README + `website/content/docs/*.md`). Added grouped `**Examples**` bash
+  blocks after every flag table in `docs/cli-reference.md` (15 groups) and
+  mirrored 14 to `website/content/docs/cli.md`. Now **135/135 flags and 56/56
+  config keys have ≥2 example occurrences**. Every drafted command was executed
+  against the installed 0.5.14 binary and proven to clear clap parsing (241
+  commands across the four example docs, 0 clap-rejected; harness detects
+  clap-rejection signatures, not just exit-2, so missing-file/root runtime
+  errors don't false-positive). Two config keys (`buffer_budget_mb`,
+  `from_to`) gained a second toml occurrence. One real doc bug found+fixed:
+  `--hep-allow` needs CIDR (`192.0.2.0/24`), not a bare host.
+- **Full RFC 5737 sweep — DONE** (was deferred as "large churn"). All example
+  IPs converted to TEST-NET ranges (`10.0.0.x`→`192.0.2.x`,
+  `192.168.1.x`→`198.51.100.x`) across docs, website content, and the man
+  page — including the width-sensitive terminal mockups in `keybindings.md` /
+  `install.md`, done with a column-preserving replacer (each +1 delta absorbed
+  from the next padding run) and verified: rendered call-list/RTP/ladder
+  columns still align and `mockup_alignment_test` stays green. Zero private
+  IPs remain in any doc.
+
+## Deferred (owner action / genuinely blocked)
 
 - Re-benchmark on 0.5.x (Tier A #6 adds provenance instead).
-- Search 10-query quality validation (zola not installed on this box).
-- Full RFC 5737 sweep of all example IPs (large churn, only .40 was real).
-- crates.io publish (owner deferred).
+- crates.io publish (owner deferred — needs `cargo login`).
 
 ## Test/gate notes
 

--- a/tasks/website-fixes.md
+++ b/tasks/website-fixes.md
@@ -1,119 +1,38 @@
 # Website Remaining Issues Plan
 
-> Created: 2026-04-14
-> Status: Pending
+> Created: 2026-04-14 · **Reconciled: 2026-07-18** (post July site overhaul +
+> PR #142). Original effort estimates removed; per-issue status below.
 
-## Issue 1: Terminal Mockup Pipe Alignment
+## Issue 1: Terminal Mockup Pipe Alignment — RESOLVED
 
-**Problem:** Terminal mockups in doc pages have pipe characters (`│`) that may not align vertically because each line wasn't manually character-counted. The monospace font fix helps but doesn't guarantee alignment if the source Markdown has inconsistent spacing.
+The specific misaligned mockups (keybindings call-flow ladder, Save/Settings
+dialogs) were rebuilt to exact column widths in PR #142. The CI validation
+script this issue asked for now exists as `tests/mockup_alignment_test.rs`:
+it extracts every `<pre class="terminal-body">` block from the website
+sources, strips tags/entities, and enforces box-outline and ladder-lifeline
+alignment by display column (Unicode-width aware). Runs in the normal
+`cargo test` CI lane. The `theme.md` mockups this plan listed no longer
+exist — the July overhaul replaced them with `toml` theme-definition blocks.
 
-**Fix approach:**
-- Write a validation script that parses every `<pre class="terminal-body">` block from the built HTML
-- Strip HTML tags, find pipe positions on each line, verify they match across lines
-- For any misaligned mockup, fix the source Markdown by padding/trimming to exact column widths
-- Add the validation script to CI so future changes don't break alignment
+## Issue 2: Publish to crates.io — DEFERRED (owner action)
 
-**Files:** `website/content/docs/keybindings.md` (8 mockups), `website/content/docs/theme.md` (7 mockups), `website/templates/index.html` (2 mockups)
+Blocked on the owner's `cargo login` token; explicitly deferred. The metadata
+prep steps remain valid when picked up.
 
-**Effort:** 2-3 hours (script + manual fixes)
+## Issue 3: Real PNG Screenshots — SUPERSEDED
 
----
+The July 2026 site overhaul kept the styled `<pre>` mockups deliberately
+(searchable, theme-consistent) and added animated demo GIFs
+(`website/static/demos/`), which cover the "show the real TUI" goal.
+Revisit only if a decision is made to replace mockups with static PNGs;
+the VHS capture recipe in the git history of this file is a good start.
 
-## Issue 2: Publish to crates.io
+## Issue 4: Search Quality Validation — DONE (2026-07-18)
 
-**Problem:** The install page says "build from source" because sipnab isn't on crates.io. `cargo install sipnab` would be the ideal user experience.
-
-**Fix approach:**
-- Verify `Cargo.toml` metadata is complete (description, license, repository, homepage, keywords, categories, readme, exclude)
-- Add `exclude` patterns for test pcaps, website, tasks, and other non-essential files to keep the crate size under 1MB
-- Run `cargo publish --dry-run` to validate
-- Publish with `cargo publish`
-- Update website: landing page install command back to `cargo install sipnab`, install page adds crates.io as primary method
-- Add crates.io badge to README
-
-**Prereqs:** Repository owner (you) needs a crates.io API token. Run `cargo login` first.
-
-**Files:** `Cargo.toml` (metadata + exclude), `website/templates/index.html`, `website/content/docs/install.md`, `README.md`
-
-**Effort:** 30 minutes (metadata) + your action (cargo login + publish)
-
----
-
-## Issue 3: Real PNG Screenshots
-
-**Problem:** All "screenshots" are styled `<pre>` blocks that depend on monospace fonts loading correctly. Real PNG/WebP screenshots would be font-independent and show the actual TUI pixel-perfect.
-
-**Fix approach:**
-- Use `vhs` (VHS by Charmbracelet) to record terminal GIFs/PNGs programmatically:
-  ```
-  # tape.vhs
-  Set Shell bash
-  Set FontSize 14
-  Set Width 1200
-  Set Height 800
-  Type "sipnab -I tests/pcap-samples/SIP_CALL_RTP_G711"
-  Enter
-  Sleep 2s
-  Screenshot screenshots/call-list.png
-  Type "j"
-  Sleep 500ms
-  Enter
-  Sleep 1s
-  Screenshot screenshots/call-flow.png
-  ```
-- Alternatively, use `ttyd` + Playwright to render the TUI in a browser and screenshot
-- Or simplest: manually run sipnab, take macOS screenshots, crop and optimize
-- Store screenshots in `website/static/img/` (WebP format, ~50-100KB each)
-- Replace `<pre>` mockups on the landing page with `<img>` tags
-- Keep `<pre>` mockups on doc pages as fallback (they're searchable)
-
-**Screenshots needed:**
-1. Call list view (full terminal, shows multiple dialogs with state colors)
-2. Call flow ladder (3-participant, Unicode arrows, auth collapse)
-3. Raw message view (syntax highlighted SIP INVITE)
-4. RTP streams view (quality metrics table)
-5. F2 save dialog (vertical format picker)
-6. F7 filter dialog
-7. F8 settings dialog
-
-**Files:** `website/static/img/` (new), `website/templates/index.html`, `website/content/docs/keybindings.md`
-
-**Effort:** 1-2 hours (capture + optimize + integrate)
-
----
-
-## Issue 4: Search Quality Validation
-
-**Problem:** The elasticlunr search index builds correctly but search result quality hasn't been tested. Users searching for specific topics (e.g., "MOS", "retransmit", "filter method") may not find relevant results.
-
-**Fix approach:**
-- Test 10 representative search queries against the built index:
-  1. "MOS" → should find RTP quality docs
-  2. "retransmit" → should find filter DSL + keybindings (fold)
-  3. "filter method" → should find filter DSL
-  4. "theme dark" → should find theme guide
-  5. "REGISTER" → should find keybindings + CLI
-  6. "TLS decrypt" → should find CLI + install
-  7. "save pcap" → should find keybindings + CLI
-  8. "API endpoint" → should find API docs
-  9. "jitter loss" → should find filter DSL + CLI
-  10. "F7" → should find keybindings
-- If results are poor, tune Zola's search config (boost title vs body, adjust `include_content`)
-- Add a "search tips" note to the search overlay: "Try: MOS, retransmit, filter, theme"
-
-**Files:** `website/config.toml` (search config), `website/templates/base.html` (search UI)
-
-**Effort:** 1 hour
-
----
-
-## Priority Order
-
-1. **Issue 1 (alignment)** — users see this immediately, embarrassing
-2. **Issue 3 (PNG screenshots)** — makes the site look professional vs. amateur
-3. **Issue 2 (crates.io)** — improves install experience significantly
-4. **Issue 4 (search)** — nice-to-have, affects repeat visitors
-
-## Total Effort
-
-~5-6 hours for all four issues.
+Built the site with zola 0.19.2 and replayed the shipped elasticlunr index
+under node with the 10 representative queries from this plan (MOS,
+retransmit, filter method, theme dark, REGISTER, TLS decrypt, save pcap,
+API endpoint, jitter loss, F7). All 10 return relevant top-3 results —
+no search-config tuning needed. Replay harness: session scratchpad
+`search_check.js` (trivial to recreate: `elasticlunr.Index.load` +
+`idx.search(q, {bool:'OR', expand:true})`).

--- a/tests/doc_example_coverage_test.rs
+++ b/tests/doc_example_coverage_test.rs
@@ -1,0 +1,149 @@
+//! Ratchet guard: every user-facing CLI flag must appear in at least two
+//! runnable example commands in the documentation.
+//!
+//! Companion to `docs_drift_test` (which proves documented flags EXIST) and
+//! `flag_coverage_test` (which proves flags are TESTED). This one proves flags
+//! are DEMONSTRATED — the maintainer's "every parameter gets multiple
+//! examples" requirement (tasks/docs-website-improvements-2026-07-18.md).
+//!
+//! Regression history: an audit on 2026-07-18 found 80 flags with zero
+//! examples and 17 with one; grouped `**Examples**` blocks in
+//! `docs/cli-reference.md` (+ website mirror) closed the gap to 135/135. This
+//! test keeps it closed — a new flag added without two examples fails CI.
+#![cfg(feature = "native")]
+
+use clap::CommandFactory;
+use std::collections::BTreeMap;
+
+/// Minimum example occurrences required per user-facing flag.
+const MIN_EXAMPLES: usize = 2;
+
+/// Flags that legitimately cannot carry a runnable example (none today).
+/// Each entry MUST carry a written justification, mirroring the
+/// `KNOWN_UNTESTED` ratchet convention in `flag_coverage_test.rs`.
+const WAIVED: &[(&str, &str)] = &[
+    // Hidden internal flag (clap `hide = true`, absent from --help): it
+    // deliberately triggers a panic to exercise the crash-report hook. Not a
+    // user-facing feature; documenting a "crash on purpose" flag with runnable
+    // examples would be actively misleading.
+    (
+        "panic-selftest",
+        "hidden internal panic-hook self-test, not user-facing",
+    ),
+];
+
+/// Every markdown doc that carries user-facing command examples. Read at
+/// runtime from CARGO_MANIFEST_DIR so new docs are covered automatically.
+fn doc_corpus() -> Vec<(String, String)> {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let mut docs = Vec::new();
+    for dir in ["docs", "website/content/docs"] {
+        let path = std::path::Path::new(root).join(dir);
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.extension().and_then(|s| s.to_str()) == Some("md")
+                && let Ok(text) = std::fs::read_to_string(&p)
+            {
+                docs.push((
+                    format!("{dir}/{}", p.file_name().unwrap().to_string_lossy()),
+                    text,
+                ));
+            }
+        }
+    }
+    let readme = std::path::Path::new(root).join("README.md");
+    if let Ok(text) = std::fs::read_to_string(&readme) {
+        docs.push(("README.md".into(), text));
+    }
+    assert!(
+        docs.len() > 15,
+        "doc corpus suspiciously small ({}) — path resolution broken?",
+        docs.len()
+    );
+    docs
+}
+
+/// Concatenated text of every ```bash fenced block in the corpus.
+fn all_bash_blocks(corpus: &[(String, String)]) -> String {
+    let re = regex::Regex::new(r"(?s)```bash\n(.*?)```").unwrap();
+    let mut out = String::new();
+    for (_, text) in corpus {
+        for cap in re.captures_iter(text) {
+            out.push_str(&cap[1]);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Primary long name of every user-facing flag (aliases and auto
+/// help/version excluded — we count the canonical spelling only).
+fn user_facing_long_flags() -> Vec<String> {
+    let cmd = sipnab::cli::Cli::command();
+    let mut flags = Vec::new();
+    for arg in cmd.get_arguments() {
+        if let Some(long) = arg.get_long()
+            && long != "help"
+            && long != "version"
+        {
+            flags.push(long.to_string());
+        }
+    }
+    flags
+}
+
+#[test]
+fn every_flag_has_at_least_two_examples() {
+    let corpus = doc_corpus();
+    let blocks = all_bash_blocks(&corpus);
+    let waived: BTreeMap<&str, &str> = WAIVED.iter().copied().collect();
+
+    let mut under = Vec::new();
+    for flag in user_facing_long_flags() {
+        if waived.contains_key(flag.as_str()) {
+            continue;
+        }
+        // Count occurrences of `--flag` not followed by a flag char, so
+        // `--api` doesn't match inside `--api-token-ttl`. The `regex` crate
+        // has no look-ahead, so check the trailing byte by hand.
+        let needle = format!("--{flag}");
+        let n = blocks
+            .match_indices(&needle)
+            .filter(|(i, _)| {
+                let after = i + needle.len();
+                blocks[after..]
+                    .chars()
+                    .next()
+                    .map(|c| !(c.is_ascii_alphanumeric() || c == '-'))
+                    .unwrap_or(true)
+            })
+            .count();
+        if n < MIN_EXAMPLES {
+            under.push(format!("--{flag}: {n} example(s)"));
+        }
+    }
+    under.sort();
+    assert!(
+        under.is_empty(),
+        "{} flag(s) below the {MIN_EXAMPLES}-example minimum — add runnable \
+         `**Examples**` blocks in docs/cli-reference.md (and mirror to the \
+         website), or waive with justification:\n{}",
+        under.len(),
+        under.join("\n")
+    );
+}
+
+#[test]
+fn waived_flags_still_exist() {
+    // A waiver for a removed flag is dead weight — fail so it gets cleaned up.
+    let real: std::collections::BTreeSet<String> = user_facing_long_flags().into_iter().collect();
+    let stale: Vec<&str> = WAIVED
+        .iter()
+        .map(|(f, _)| *f)
+        .filter(|f| !real.contains(*f))
+        .collect();
+    assert!(stale.is_empty(), "waivers for nonexistent flags: {stale:?}");
+}

--- a/tests/mockup_alignment_test.rs
+++ b/tests/mockup_alignment_test.rs
@@ -1,0 +1,368 @@
+//! Guards the terminal mockups (`<pre class="terminal-body">` blocks) in the
+//! website content against box-drawing/ladder misalignment.
+//!
+//! Regression context: the keybindings-page call-flow ladder and the
+//! Save/Settings dialogs shipped measurably misaligned for months because
+//! nothing gated them; they were realigned by hand in #142. This test makes
+//! that class of drift impossible to reintroduce.
+//!
+//! Invariants per mockup block (display columns, after stripping HTML tags
+//! and unescaping entities):
+//! - Unicode box outlines: `┌`/`┐` corner columns must equal `└`/`┘`, and
+//!   every interior line must carry `│` at exactly both border columns.
+//!   Interior `│` (e.g. `PCAP │ PCAP-NG │ TXT` separators) are ignored.
+//! - ASCII-pipe ladders: every `|` must sit on a lifeline column — the
+//!   column set of the line with the most pipes.
+
+use std::fmt::Write as _;
+use unicode_width::UnicodeWidthChar;
+
+/// Strip HTML tags and unescape the entities the mockups use, so column
+/// positions reflect what the browser renders.
+fn strip_html(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '<' => {
+                for t in chars.by_ref() {
+                    if t == '>' {
+                        break;
+                    }
+                }
+            }
+            '&' => {
+                let mut ent = String::new();
+                let mut terminated = false;
+                while let Some(&e) = chars.peek() {
+                    if e == ';' {
+                        chars.next();
+                        terminated = true;
+                        break;
+                    }
+                    if !e.is_ascii_alphanumeric() && e != '#' {
+                        break;
+                    }
+                    ent.push(e);
+                    chars.next();
+                }
+                if terminated {
+                    match ent.as_str() {
+                        "lt" => out.push('<'),
+                        "gt" => out.push('>'),
+                        "amp" => out.push('&'),
+                        "quot" => out.push('"'),
+                        "#39" | "apos" => out.push('\''),
+                        _ => {
+                            // Unknown entity: keep verbatim so drift is visible.
+                            let _ = write!(out, "&{ent};");
+                        }
+                    }
+                } else {
+                    out.push('&');
+                    out.push_str(&ent);
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Extract every `<pre class="terminal-body">...</pre>` block as
+/// (1-based start line, rendered lines).
+fn extract_terminal_blocks(text: &str) -> Vec<(usize, Vec<String>)> {
+    let re = regex::Regex::new(r#"(?s)<pre class="terminal-body">(.*?)</pre>"#).unwrap();
+    re.captures_iter(text)
+        .map(|cap| {
+            let m = cap.get(0).unwrap();
+            let start_line = text[..m.start()].lines().count() + 1;
+            let lines = cap[1].lines().map(strip_html).collect();
+            (start_line, lines)
+        })
+        .collect()
+}
+
+/// Display-column positions of `needles` occurrences in a rendered line.
+fn columns_of(line: &str, needles: &[char]) -> Vec<(char, usize)> {
+    let mut col = 0;
+    let mut hits = Vec::new();
+    for c in line.chars() {
+        if needles.contains(&c) {
+            hits.push((c, col));
+        }
+        col += c.width().unwrap_or(0);
+    }
+    hits
+}
+
+const BOX_CHARS: &[char] = &['┌', '┐', '└', '┘', '│', '├', '┤'];
+
+/// Check one rendered mockup block; returns human-readable violations.
+fn check_block(lines: &[String]) -> Vec<String> {
+    let mut violations = Vec::new();
+    let hits: Vec<Vec<(char, usize)>> = lines.iter().map(|l| columns_of(l, BOX_CHARS)).collect();
+
+    // --- Unicode box outlines -------------------------------------------
+    let mut i = 0;
+    while i < lines.len() {
+        let top: Vec<_> = hits[i]
+            .iter()
+            .filter(|(c, _)| *c == '┌' || *c == '┐')
+            .collect();
+        let (left, right) = match (
+            top.iter().find(|(c, _)| *c == '┌'),
+            top.iter().rev().find(|(c, _)| *c == '┐'),
+        ) {
+            (Some(&&(_, l)), Some(&&(_, r))) => (l, r),
+            _ => {
+                i += 1;
+                continue;
+            }
+        };
+        // Find the matching bottom border.
+        let Some(bottom) = (i + 1..lines.len()).find(|&j| hits[j].iter().any(|(c, _)| *c == '└'))
+        else {
+            violations.push(format!("line {}: box has no bottom border", i + 1));
+            i += 1;
+            continue;
+        };
+        for (j, line_hits) in hits.iter().enumerate().take(bottom).skip(i + 1) {
+            let verticals: Vec<usize> = line_hits
+                .iter()
+                .filter(|(c, _)| *c == '│' || *c == '├' || *c == '┤')
+                .map(|&(_, col)| col)
+                .collect();
+            if !verticals.contains(&left) || !verticals.contains(&right) {
+                violations.push(format!(
+                    "line {}: interior line lacks '│' at box borders (cols {left}/{right}), has {verticals:?}",
+                    j + 1
+                ));
+            }
+        }
+        let bl = hits[bottom]
+            .iter()
+            .find(|(c, _)| *c == '└')
+            .map(|&(_, c)| c);
+        let br = hits[bottom]
+            .iter()
+            .rev()
+            .find(|(c, _)| *c == '┘')
+            .map(|&(_, c)| c);
+        if bl != Some(left) || br != Some(right) {
+            violations.push(format!(
+                "line {}: bottom corners at {bl:?}/{br:?} but top at {left}/{right}",
+                bottom + 1
+            ));
+        }
+        i = bottom + 1;
+    }
+
+    // --- ASCII-pipe ladders ---------------------------------------------
+    // Only blocks that are pipe-ladders (>=3 lines with '|', no Unicode box
+    // art — dialogs use '│' interior separators that are not lifelines).
+    let has_box_art = hits.iter().any(|h| !h.is_empty());
+    let pipe_cols: Vec<Vec<usize>> = lines
+        .iter()
+        .map(|l| columns_of(l, &['|']).into_iter().map(|(_, c)| c).collect())
+        .collect();
+    let pipe_lines = pipe_cols.iter().filter(|c| !c.is_empty()).count();
+    if !has_box_art && pipe_lines >= 3 {
+        let reference = pipe_cols
+            .iter()
+            .max_by_key(|c| c.len())
+            .cloned()
+            .unwrap_or_default();
+        for (j, cols) in pipe_cols.iter().enumerate() {
+            for col in cols {
+                if !reference.contains(col) {
+                    violations.push(format!(
+                        "line {}: '|' at col {col} is off the lifeline columns {reference:?}",
+                        j + 1
+                    ));
+                }
+            }
+        }
+    }
+    violations
+}
+
+// ---------------------------------------------------------------------------
+// Fixture tests — the checker must accept aligned art and reject misaligned.
+// ---------------------------------------------------------------------------
+
+fn render(block: &str) -> Vec<String> {
+    block.lines().map(strip_html).collect()
+}
+
+#[test]
+fn strip_html_removes_tags_and_unescapes_entities() {
+    assert_eq!(
+        strip_html(r#"<span class="t-good">|--- INVITE ---&gt;|</span>"#),
+        "|--- INVITE --->|"
+    );
+    assert_eq!(
+        strip_html("&lt;sip:bob&gt; &amp; &quot;x&quot;"),
+        "<sip:bob> & \"x\""
+    );
+    // Adversarial: bare '&', unterminated entity, empty line.
+    assert_eq!(strip_html("a & b &incomplete"), "a & b &incomplete");
+    assert_eq!(strip_html(""), "");
+    // Unknown-but-terminated entity survives verbatim.
+    assert_eq!(strip_html("&nbsp;"), "&nbsp;");
+}
+
+// NOTE: fixtures are flush-left because Rust's `"\` continuation strips the
+// following line's leading whitespace (only the first line is affected —
+// which silently shifts a box's top border).
+
+#[test]
+fn aligned_box_passes() {
+    let block = "\
+┌───── Title ─────┐
+│  content        │
+│ x │ pipes │  yy │
+│ <span>zz</span>              │
+└─────────────────┘";
+    let v = check_block(&render(block));
+    assert!(v.is_empty(), "expected no violations, got: {v:?}");
+}
+
+#[test]
+fn box_with_shifted_right_border_fails() {
+    let block = "\
+┌───── Title ─────┐
+│  content         │
+└─────────────────┘";
+    assert!(
+        !check_block(&render(block)).is_empty(),
+        "shifted right border must be reported"
+    );
+}
+
+#[test]
+fn box_with_mismatched_bottom_corner_fails() {
+    let block = "\
+┌───── Title ─────┐
+│  content        │
+ └─────────────────┘";
+    assert!(
+        !check_block(&render(block)).is_empty(),
+        "shifted bottom-left corner must be reported"
+    );
+}
+
+#[test]
+fn box_interior_line_missing_border_fails() {
+    let block = "\
+┌───── Title ─────┐
+│  content        │
+   no borders here
+└─────────────────┘";
+    assert!(
+        !check_block(&render(block)).is_empty(),
+        "interior line without borders must be reported"
+    );
+}
+
+#[test]
+fn entity_width_counts_one_column() {
+    // `&gt;` renders as one column; treating it as 4 shifts the border.
+    let block = "\
+┌───────┐
+│ ---&gt;  │
+└───────┘";
+    let v = check_block(&render(block));
+    assert!(v.is_empty(), "entity must count 1 column, got: {v:?}");
+}
+
+#[test]
+fn aligned_ladder_passes() {
+    let block = "\
+a               b               c
+|               |               |
+|--- INVITE --->|               |
+|               |--- INVITE --->|
+|               |               |";
+    let v = check_block(&render(block));
+    assert!(v.is_empty(), "expected no violations, got: {v:?}");
+}
+
+#[test]
+fn ladder_with_off_column_pipe_fails() {
+    let block = "\
+a               b               c
+|               |               |
+|--- INVITE ---> |              |
+|               |               |";
+    assert!(
+        !check_block(&render(block)).is_empty(),
+        "off-lifeline pipe must be reported"
+    );
+}
+
+#[test]
+fn wide_glyphs_count_two_columns() {
+    // CJK '実' is width 2 — a line using it must still land borders on the
+    // same display columns as an all-ASCII line.
+    let block = "\
+┌──────┐
+│ 実実 │
+│ xxxx │
+└──────┘";
+    let v = check_block(&render(block));
+    assert!(v.is_empty(), "wide glyphs must count 2 columns, got: {v:?}");
+}
+
+#[test]
+fn plain_text_block_has_no_violations() {
+    // Blocks with no box chars and <3 pipe lines (tables, raw SIP) pass.
+    let block = "\
+INVITE sip:bob@10.0.0.2:5060 SIP/2.0
+Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK
+ #  SSRC        Codec   MOS";
+    assert!(check_block(&render(block)).is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Real content — every terminal-body mockup shipped on the site.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn website_terminal_mockups_are_aligned() {
+    let sources: &[(&str, &str)] = &[
+        (
+            "website/content/docs/keybindings.md",
+            include_str!("../website/content/docs/keybindings.md"),
+        ),
+        (
+            "website/content/docs/theme.md",
+            include_str!("../website/content/docs/theme.md"),
+        ),
+        (
+            "website/templates/index.html",
+            include_str!("../website/templates/index.html"),
+        ),
+    ];
+    let mut violations = Vec::new();
+    let mut blocks_seen = 0;
+    for (path, text) in sources {
+        for (start, lines) in extract_terminal_blocks(text) {
+            blocks_seen += 1;
+            for v in check_block(&lines) {
+                violations.push(format!("{path}:{start}: {v}"));
+            }
+        }
+    }
+    // The keybindings page alone ships 8 mockups; if extraction ever finds
+    // none, the gate is silently dead — fail loudly instead.
+    assert!(
+        blocks_seen >= 8,
+        "expected >=8 terminal-body blocks, found {blocks_seen} — extractor broken?"
+    );
+    assert!(
+        violations.is_empty(),
+        "misaligned terminal mockups:\n{}",
+        violations.join("\n")
+    );
+}

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -298,7 +298,7 @@ console.log(`State: ${dialog.state}`);
       "timestamp": "2026-04-13T10:30:00Z",
       "direction": "offer",
       "codecs": ["PCMU", "PCMA", "telephone-event"],
-      "media_addr": "10.0.0.1",
+      "media_addr": "192.0.2.1",
       "media_port": 10000,
       "mode": "sendrecv"
     },
@@ -306,7 +306,7 @@ console.log(`State: ${dialog.state}`);
       "timestamp": "2026-04-13T10:30:02Z",
       "direction": "answer",
       "codecs": ["PCMU", "telephone-event"],
-      "media_addr": "10.0.0.2",
+      "media_addr": "192.0.2.2",
       "media_port": 20000,
       "mode": "sendrecv"
     }
@@ -325,8 +325,8 @@ console.log(`State: ${dialog.state}`);
       "ssrc": "0x1a2b3c4d",
       "codec": "PCMU",
       "payload_type": 0,
-      "src": "10.0.0.1:10000",
-      "dst": "10.0.0.2:20000",
+      "src": "192.0.2.1:10000",
+      "dst": "192.0.2.2:20000",
       "packets": 4820,
       "octets": 771200,
       "jitter_ms": 2.1,
@@ -532,8 +532,8 @@ streams.forEach(s =>
     {
       "ssrc": "0x1a2b3c4d",
       "codec": "PCMU",
-      "src": "10.0.0.1:10000",
-      "dst": "10.0.0.2:20000",
+      "src": "192.0.2.1:10000",
+      "dst": "192.0.2.2:20000",
       "packets": 4820,
       "jitter_ms": 2.1,
       "loss_pct": 0.0,
@@ -1455,7 +1455,7 @@ sipnab -L 0.0.0.0:9060 -E
 Restrict sources with `--hep-allow` and rate-limit with `--hep-rate-limit`:
 
 ```bash
-sipnab -L 0.0.0.0:9060 -E --hep-allow 10.0.0.0/24 --hep-rate-limit 25000
+sipnab -L 0.0.0.0:9060 -E --hep-allow 192.0.2.0/24 --hep-rate-limit 25000
 ```
 
 ### Sending HEP
@@ -1463,7 +1463,7 @@ sipnab -L 0.0.0.0:9060 -E --hep-allow 10.0.0.0/24 --hep-rate-limit 25000
 Mirror captured traffic to a Homer collector:
 
 ```bash
-sipnab -d eth0 -H 10.0.0.50:9060
+sipnab -d eth0 -H 192.0.2.50:9060
 ```
 
 ## Security Model

--- a/website/content/docs/cli.md
+++ b/website/content/docs/cli.md
@@ -131,6 +131,32 @@ sipnab -d any --multi-device --delta-time
 | `--strip-secrets` | `<OUTPUT>` | -- | With `-I <input>`, write a copy of the input pcapng to `<OUTPUT>` with all Decryption Secrets Blocks removed (the `editcap --discard-all-secrets` analog), then exit. The input is never modified; the output is written atomically |
 | `<BPF_FILTER>...` | positional | -- | BPF display filter expression (trailing positional args) |
 
+**Examples**
+
+```bash
+# Record up to 10000 packets from eth0 into a pcap, watching a widened SIP port range
+sudo sipnab --device eth0 --output capture.pcap --portrange 5060-5080 --count 10000
+# Live-capture a busy link with bigger kernel and queue buffers, a capped snapshot length, and parse-error notices silenced (sipgrep -x)
+sudo sipnab --device eth0 --buffer 16 --buffer-budget 128 --snaplen 2048 --quiet-bad-parse
+# Capture on all available interfaces headlessly, stopping once the output file reaches 100 MiB
+sudo sipnab -N --multi-device --output capture.pcap --autostop filesize:100
+# Replay a pcap at its original timing with RTP capture and analysis disabled
+sipnab -N --input capture.pcap --replay --no-rtp
+# Scan a pcap sipgrep-style: parse only the first 512 bytes of each packet, every packet standalone (no reassembly), without parse-error noise
+sipnab -N --input capture.pcap --limitlen 512 --no-reassembly --quiet-bad-parse
+# Capture for 5 minutes using a BPF filter read from sip.bpf, without putting the interface into promiscuous mode (sipgrep -p)
+sudo sipnab --device eth0 --bpf-file sip.bpf --no-promisc --duration 5m
+# Monitor an hour of traffic across a wide SIP port range with enlarged capture buffers
+sudo sipnab --device eth0 --portrange 5060-5090 --buffer 8 --buffer-budget 256 --duration 1h
+# Replay signaling only from a pcap, parsing at most 1500 bytes of each packet
+sipnab -N --input capture.pcap --replay --limitlen 1500 --no-rtp
+# Stop after 500 packets that pass the sip.bpf filter, non-promiscuous, with the snapshot length sized for jumbo frames
+sudo sipnab --device eth0 --bpf-file sip.bpf --no-promisc --snaplen 9000 --count 500
+# Write a one-minute capture that treats every packet standalone (IP-fragment and TCP-segment reassembly off)
+sudo sipnab -N --device eth0 --output capture.pcap --autostop duration:60 --no-reassembly
+```
+
+
 ## Mode
 
 | Flag | Value | Default | Description |
@@ -139,6 +165,18 @@ sipnab -d any --multi-device --delta-time
 | `-c`, `--calls-only` | -- | off | Show only SIP dialogs (calls), not standalone messages |
 | `-t`, `--telephone-event` | -- | off | Capture and display telephone-event (DTMF) RTP payloads |
 | `-q`, `--quiet` | -- | off | Suppress informational output; only show results |
+
+**Examples**
+
+```bash
+# Analyze a pcap headlessly, showing only complete SIP dialogs (calls), not standalone messages
+sipnab --no-tui -I capture.pcap --calls-only
+# Watch live calls in the TUI with telephone-event (DTMF) RTP payloads captured and displayed
+sudo sipnab -d eth0 --calls-only --telephone-event
+# Headless live capture that decodes DTMF and suppresses informational output
+sudo sipnab --no-tui -d eth0 --telephone-event --quiet
+```
+
 
 ## Matching
 
@@ -154,6 +192,24 @@ sipnab -d any --multi-device --delta-time
 | `--ua` | `<PATTERN>` | -- | Filter by User-Agent header (regex pattern) |
 | `--filter` | `<EXPR>` | -- | Advanced filter DSL expression (see [Filter DSL](@/docs/filter-dsl.md)) |
 
+**Examples**
+
+```bash
+# Show every dialog that mentions alice@example.com, case-insensitively (dialog-following payload match)
+sipnab -N -I capture.pcap --match "alice@example.com" --ignore-case
+# Whole-word match for 486 rejections, folding multi-line headers into one line before matching
+sipnab -N -I capture.pcap --match "486 Busy Here" --word --single-line
+# Live view of everything except REGISTER traffic (inverted match)
+sudo sipnab -d eth0 --match "REGISTER" --invert
+# Flag scanner traffic live: a known scanner User-Agent (any case) with a Contact pointing into 203.0.113.0/24
+sudo sipnab -d eth0 --ua "friendly-scanner" --contact "203\.0\.113\." --ignore-case
+# Filter a pcap by User-Agent and a Contact in 192.0.2.0/24, matching even when headers span folded lines
+sipnab -N -I capture.pcap --ua "sipcli" --contact "192\.0\.2\." --single-line
+# Suppress keep-alive noise: show messages that do not contain the whole word OPTIONS
+sipnab -N -I capture.pcap --match "OPTIONS" --word --invert
+```
+
+
 ## Diagnostic Aliases
 
 Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL](@/docs/filter-dsl.md) for the exact expansion of each alias.
@@ -165,6 +221,18 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | `--short-calls` | Show completed calls shorter than 5 seconds |
 | `--one-way` | Show calls with potential one-way audio issues |
 | `--nat-issues` | Show calls with Contact/Via NAT mismatch |
+
+**Examples**
+
+```bash
+# Flag completed calls under 5 seconds and calls with suspected one-way audio in a capture
+sipnab -N -I capture.pcap --short-calls --one-way
+# Live-monitor for one-way audio and Contact/Via NAT mismatches
+sudo sipnab -d eth0 -N --one-way --nat-issues
+# Summarize short completed calls from a capture in a post-run report
+sipnab -N -I capture.pcap --short-calls --report
+```
+
 
 ## Output
 
@@ -190,6 +258,30 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | `--fail2ban` | -- | off | Output in fail2ban-compatible format for SIP security events. Requires `-N` |
 | `--group-by` | `<FIELD>` | -- | Group output by field (e.g., `call-id`, `from`, `method`) |
 
+**Examples**
+
+```bash
+# Export every SIP message from a capture as pretty-printed JSON, truncating displayed payloads to 1000 bytes
+sipnab -N -I capture.pcap --json-pretty --payload-limit 1000 > messages.json
+# Stream live SIP traffic as pretty-printed JSON grouped by method, flushing after each line for downstream tooling
+sudo sipnab -d eth0 -N --json-pretty --group-by method --line-buffer > live.json
+# Dump raw SIP text with hex payloads and IANA protocol numbers, uncolored for log archiving
+sipnab -N -I capture.pcap --text-dump --hexdump --proto-number --color never
+# Follow live REGISTER traffic in real time, printing raw text plus 2 messages of context after each match
+sudo sipnab -d eth0 -N --match REGISTER --after 2 --text-dump --line-buffer --color always
+# Review a capture with per-message delta times, empty-bodied messages included, and hex dumps grouped per call
+sipnab -N -I capture.pcap --show-empty --delta-time --hexdump --group-by call-id
+# Inspect OPTIONS keepalives with 5 messages of trailing context, empty bodies shown, and display capped at 256 payload bytes
+sudo sipnab -d eth0 -N --match OPTIONS --after 5 --show-empty --proto-number --payload-limit 256
+# Watch the live TUI with host:port From/To columns and hand the capture to Wireshark with a matching display filter
+sudo sipnab -d eth0 --from-to-mode host-port --wireshark
+# Browse an existing capture in the TUI with full user@host:port From/To columns
+sipnab -I capture.pcap --from-to-mode user-host-port
+# Print a tshark-compatible display filter for the INVITE traffic in a capture
+sipnab -N -I capture.pcap --tshark-filter "method=INVITE"
+```
+
+
 ## Name Resolution
 
 | Flag | Value | Default | Description |
@@ -197,6 +289,20 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | `--resolve` | -- | off | Start with name resolution enabled (manual mappings + hosts file) |
 | `--reverse-dns` | -- | off | Also resolve via reverse DNS (PTR); implies `--resolve` |
 | `--names` | `<FILE>` | -- | Preload an `/etc/hosts`-format mapping file (repeatable) |
+
+**Examples**
+
+```bash
+# Live capture with name resolution from a static hosts-format mapping file
+sudo sipnab -d eth0 --resolve --names /etc/sipnab/hosts.map
+# Annotate an offline pcap with names, preloading two mapping files on top of /etc/hosts
+sipnab -N -I capture.pcap --resolve --names /etc/sipnab/hosts.map --names ~/.config/sipnab/lab-names
+# Live capture that also resolves captured IPs via reverse DNS (PTR) lookups
+sudo sipnab -d eth0 --reverse-dns
+# Replay an offline pcap and resolve its addresses with reverse DNS, supplemented by a local mapping file
+sipnab -N -I capture.pcap --reverse-dns --names ~/.config/sipnab/lab-names
+```
+
 
 ## Dialog
 
@@ -209,6 +315,24 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | `--no-dialog` | -- | off | Disable dialog tracking entirely (message-only mode) |
 | `--tag` | `<TAG>` | -- | Filter dialogs by tag value |
 
+**Examples**
+
+```bash
+# Monitor a busy proxy with a tight 5000-dialog memory bound, explicitly evicting the oldest dialog at capacity
+sudo sipnab -d eth0 --limit 5000 --rotate --dialog-track call-id
+# Analyze a capture keyed by Via branch, dropping new dialogs (instead of evicting old ones) past 20000 tracked
+sipnab -N -I capture.pcap --limit 20000 --no-rotate --dialog-track branch
+# Show only dialogs carrying a specific From/To tag, with explicit LRU rotation
+sipnab -N -I capture.pcap --tag 1928301774 --rotate
+# Live-follow dialogs matching a tag while refusing new dialogs once the tracker is full
+sudo sipnab -d eth0 --tag as7d60e14a --no-rotate
+# Scan a capture message-by-message with dialog tracking disabled entirely
+sipnab -N -I capture.pcap --no-dialog
+# Watch raw live SIP messages on an interface without keeping any per-dialog state
+sudo sipnab -d eth0 -N --no-dialog
+```
+
+
 ## RTP
 
 | Flag | Value | Default | Description |
@@ -216,6 +340,16 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | `--rtp-interval` | `<SECS>` | `1` | RTP statistics reporting interval in seconds |
 | `--max-streams` | `<N>` | `50000` | Maximum number of RTP streams to track simultaneously |
 | `--quality-threshold` | `<MOS>` | `3.0` | MOS quality threshold for alerts (1.0-5.0 scale) |
+
+**Examples**
+
+```bash
+# Monitor live RTP with 5-second statistics reports and MOS alerts below 3.5
+sudo sipnab -d eth0 --rtp-interval 5 --quality-threshold 3.5 --max-streams 10000
+# Batch-analyze RTP streams in a capture, reporting stats every 2 seconds with a raised stream cap
+sipnab -N -I capture.pcap --rtp-interval 2 --max-streams 100000
+```
+
 
 ## Security
 
@@ -231,6 +365,22 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | `--alert-exec` | `<CMD>` | -- | Execute this command when an alert fires |
 | `--alert-json` | -- | off | Emit each security alert as a structured JSON line on stderr (in addition to the human `[ALERT]` line) |
 | `--stir-shaken` | -- | off | Validate STIR/SHAKEN identity headers |
+
+**Examples**
+
+```bash
+# Detect SIP scanners (plus a custom UA pattern) and reply 486 with the victim's spoofed source
+sudo sipnab -d eth0 --kill-scanner --kill-ua 'friendly-scanner' --kill-response 486 --kill-spoof auto
+# Targeted kill of a scanning host across a port range, plus a second scanner UA, replying 480 via raw-socket spoof
+sudo sipnab -d eth0 --kill-target 192.0.2.66:5060-5090 --kill-ua 'sipvicious' --kill-response 480 --kill-spoof raw
+# Kill requests from one more source port using a non-spoofed ephemeral reply
+sudo sipnab -d eth0 --kill-target 198.51.100.77:5060 --kill-spoof ephemeral
+# Live security monitoring: registration floods, digest leaks, fraud, STIR/SHAKEN, with JSON alerts and an exec hook
+sudo sipnab -N -d eth0 --reg-flood --digest-leak --fraud-detect --stir-shaken --alert json --alert-json --alert-exec '/usr/local/bin/notify.sh'
+# Offline audit of a pcap for digest leaks and STIR/SHAKEN validity, emitting structured JSON alerts
+sipnab -N -I capture.pcap --stir-shaken --digest-leak --alert-json
+```
+
 
 ## Event Execution
 
@@ -261,6 +411,28 @@ Shortcut flags that expand to predefined filter DSL expressions. See [Filter DSL
 | `--hep-allow` | `<ADDR>` | -- | Allowed source addresses for HEP input (repeatable) Feature: `hep` |
 | `--hep-rate-limit` | `<N>` | `50000` | Maximum HEP packets per second Feature: `hep` |
 | `--syslog` | -- | off | Send alerts to syslog |
+
+**Examples**
+
+```bash
+# Live capture serving a TLS REST API (cert+key) with signed tokens, a revocation list, and a Basic-auth'd Prometheus endpoint
+sudo sipnab -d eth0 --api 127.0.0.1:8080 --api-tls-cert /etc/sipnab/api.pem --api-tls-key /etc/sipnab/api.key --api-signing-key-file /etc/sipnab/signing.key --api-revoked-file /etc/sipnab/revoked.txt --api-token-ttl 7200 --api-max-conn 200 --metrics 127.0.0.1:9090 --metrics-auth alice:s3cret
+# Public-facing TLS API tuned to 100 connections and 1h token TTL, with its own auth'd metrics endpoint
+sudo sipnab -d eth0 --api 0.0.0.0:8080 --api-tls-cert /etc/sipnab/api.pem --api-tls-key /etc/sipnab/api.key --api-signing-key-file /etc/sipnab/signing.key --api-token-ttl 3600 --api-max-conn 100 --metrics 127.0.0.1:9090 --metrics-auth bob:hunter2
+# Loopback HTTP MCP server with a bearer token, file-loaded signing key, revocation denylist, and a 30-minute mint TTL
+sudo sipnab -N -d eth0 --mcp --mcp-transport http --mcp-bind 127.0.0.1:8731 --mcp-token t0ken-alice --mcp-signing-key-file /etc/sipnab/mcp-signing.key --mcp-revoked-file /etc/sipnab/mcp-revoked.txt --mcp-token-ttl 1800
+# Non-loopback HTTP MCP server (token required) accepting an extra Host header for named clients
+sudo sipnab -N -d eth0 --mcp --mcp-transport http --mcp-bind 0.0.0.0:8731 --mcp-token t0ken-bob --mcp-signing-key-file /etc/sipnab/mcp-signing.key --mcp-revoked-file /etc/sipnab/mcp-revoked.txt --mcp-allowed-host mcp.example.com
+# Forward captured packets to a Homer collector, stamping capture-agent id 42 and an authenticate key
+sudo sipnab -N -d eth0 --hep-send 192.0.2.10:9060 --hep-id 42 --hep-auth s3cr3t-homer-key
+# Forward to a second collector under a different agent id and auth key
+sudo sipnab -N -d eth0 --hep-send 198.51.100.20:9060 --hep-id 7 --hep-auth homerkey2
+# Run a HEP collector that parses incoming packets, only from two allowed CIDRs, capped at 20k pkts/sec
+sipnab -N -L 0.0.0.0:9060 --hep-parse --hep-allow 192.0.2.0/24 --hep-allow 198.51.100.20/32 --hep-rate-limit 20000
+# Mint a signed bearer token with a fixed id (for later revocation) and a 1-hour TTL, then exit
+sipnab --mint-token --token-id alice-2026 --api-signing-key-file /etc/sipnab/signing.key --api-token-ttl 3600
+```
+
 
 ## MCP Server
 
@@ -294,6 +466,18 @@ it. See [MCP Server](@/docs/mcp.md) for the full guide.
 | `--pcap-export-mode` | `<MODE>` | `decrypted` | Pcap export mode for encrypted traffic: `decrypted` (plaintext payloads, no DSB), `raw` (original encrypted bytes, no DSB), `encrypted+dsb` (original encrypted bytes + Decryption Secrets Block so Wireshark can decrypt) |
 | `--allow-coredump` | -- | off | Allow core dumps (do not call `prctl` to disable them) |
 
+**Examples**
+
+```bash
+# Decrypt TLS 1.2 RSA-key-exchange SIP from a pcap using an RSA private key, with core dumps left enabled
+sipnab -N -I capture.pcap --tls-key /etc/sipnab/tls-rsa.key --keylog /etc/sipnab/keys.log --allow-coredump
+# Decrypt SRTP media in an offline pcap from an SRTP master-keys file plus DTLS-SRTP handshake keys
+sipnab -N -I capture.pcap --srtp-keys /etc/sipnab/srtp.keys --dtls-keylog /etc/sipnab/dtls.log
+# Live decrypt both SIP (RSA key) and SRTP media, watching the key log for new PFS session keys
+sudo sipnab -d eth0 --tls-key /etc/sipnab/tls-rsa.key --srtp-keys /etc/sipnab/srtp.keys --keylog /etc/sipnab/keys.log --keylog-watch --allow-coredump
+```
+
+
 ## Privilege
 
 | Flag | Value | Default | Description |
@@ -303,12 +487,36 @@ it. See [MCP Server](@/docs/mcp.md) for the full guide.
 | `--chroot` | `<DIR>` | -- | Chroot to this directory after initialization |
 | `--setup-caps` | -- | off | Grant the binary `CAP_NET_RAW`/`CAP_NET_ADMIN` via setcap (one-time, needs sudo) and exit |
 
+**Examples**
+
+```bash
+# Live capture that drops root to the sipnab service user once the capture device is open
+sudo sipnab -d eth0 --user sipnab
+# Long-running monitor that drops to nobody and confines itself to an empty chroot
+sudo sipnab -d eth0 --user nobody --chroot /var/empty
+# Chrooted capture that keeps root privileges for the whole run
+sudo sipnab -d eth0 --chroot /var/empty --no-priv-drop
+# Grant the binary the capture capabilities (cap_net_raw,cap_net_admin) so future runs work without sudo, then exit
+sudo sipnab --setup-caps
+```
+
+
 ## Resource Limits
 
 | Flag | Value | Default | Description |
 |------|-------|---------|-------------|
 | `--max-reassembly` | `<N>` | `10000` | Maximum concurrent TCP/TLS reassembly sessions |
 | `--cores` | `<N>` | `1` | CPU cores for offline pcap reconstruction (`-I`). 1 = single-threaded; >1 shards by host pair for multi-core throughput (dialog+RTP reconstruction, `--report`/`--json`) |
+
+**Examples**
+
+```bash
+# Live capture on a busy TCP/TLS trunk with a raised reassembly-session ceiling
+sudo sipnab -d eth0 --max-reassembly 50000
+# Offline reconstruction sharded across 4 cores, with a tight reassembly bound for an untrusted capture
+sipnab -N -I capture.pcap --cores 4 --max-reassembly 2000
+```
+
 
 ## Config
 
@@ -318,6 +526,24 @@ it. See [MCP Server](@/docs/mcp.md) for the full guide.
 | `-F`, `--no-config` | -- | off | Skip loading any configuration file |
 | `-D`, `--dump-config` | -- | off | Dump effective configuration and exit |
 | `--completions` | `<SHELL>` | -- | Print a shell completion script (bash, zsh, fish, elvish, powershell) to stdout and exit |
+
+**Examples**
+
+```bash
+# Dump the effective configuration produced by a specific config file, then exit
+sipnab --config /etc/sipnab/sipnab.toml --dump-config
+# Dump the built-in defaults, skipping any configuration file, then exit
+sipnab --no-config --dump-config
+# Live capture using a per-user configuration file
+sudo sipnab -d eth0 --config ~/.config/sipnab/config.toml
+# Analyze an offline pcap with all configuration files ignored
+sipnab -N -I capture.pcap --no-config
+# Print a bash completion script into a file suitable for /etc/bash_completion.d
+sipnab --completions bash > sipnab.bash
+# Print a zsh completion script into a file suitable for the zsh fpath
+sipnab --completions zsh > _sipnab
+```
+
 
 ## Validation Rules
 

--- a/website/content/docs/config.md
+++ b/website/content/docs/config.md
@@ -226,7 +226,7 @@ persist_to_config = true
 
 # Inline mappings (also written here when persist_to_config = true):
 [names.manual]
-"10.0.0.1" = "sbc-edge"
+"192.0.2.1" = "sbc-edge"
 "2001:db8::1" = "core6"
 ```
 

--- a/website/content/docs/cookbook.md
+++ b/website/content/docs/cookbook.md
@@ -31,7 +31,7 @@ sipnab -N -I capture.pcap --problems --json
 The `--problems` sweep prints one line per SIP message of each flagged call, then the end-of-capture summary. You should see something like (abridged):
 
 ```
-INVITE +15551234 -> +15559876  10.0.0.6:5060 -> 10.0.0.7:5060  Failed  408 Request Timeout
+INVITE +15551234 -> +15559876  192.0.2.6:5060 -> 192.0.2.7:5060  Failed  408 Request Timeout
 ...
 852 packets captured, 10 SIP messages, 839 RTP packets across 2 streams
 ```
@@ -151,8 +151,8 @@ Step 1 should print a diagnosis object like:
     "nat_mismatch": true,
     "no_media": false,
     "hints": [
-      "RTP from 203.0.113.7 -> 10.0.0.5 only. No reverse media flow detected.",
-      "SDP c= address (192.168.1.20) differs from actual RTP source (203.0.113.7) — likely NAT issue.",
+      "RTP from 203.0.113.7 -> 192.0.2.5 only. No reverse media flow detected.",
+      "SDP c= address (198.51.100.20) differs from actual RTP source (203.0.113.7) — likely NAT issue.",
       "One-way audio combined with NAT mismatch — media likely being sent to the wrong address."
     ]
   }
@@ -286,7 +286,7 @@ watch -n 1 'curl -s http://localhost:9100/v1/dialogs?limit=5 | jq ".dialogs[] | 
 **Pitfalls:**
 
 - HEP is UDP — silently drops if the listener can't keep up. The `--hep-rate-limit 50000` default lets you tune.
-- The default HEP listener accepts from any source. Add `--hep-allow 10.0.0.0/24` (repeatable) to lock it down to your SIP-server subnet.
+- The default HEP listener accepts from any source. Add `--hep-allow 192.0.2.0/24` (repeatable) to lock it down to your SIP-server subnet.
 - If your central host is reachable by hostname only, set `--mcp-allowed-host` for the MCP transport too (see Recipe 8).
 
 ---

--- a/website/content/docs/filter-dsl.md
+++ b/website/content/docs/filter-dsl.md
@@ -35,8 +35,8 @@ All addressable fields, organized by type.
 | `ua` | User-Agent header (first non-empty across dialog messages) | `"Olle"`, `"friendly-scanner"` |
 | `call_id` | SIP Call-ID header | `"abc123@host"` |
 | `payload` | Raw message content — matches when ANY message in the dialog contains/matches the value (sngrep-style payload grep) | `"X-Custom-Header"`, `"sipsak"` |
-| `src.ip` | Source IP address (first message) | `"10.0.0.1"` |
-| `dst.ip` | Destination IP address (first message) | `"10.0.0.2"` |
+| `src.ip` | Source IP address (first message) | `"192.0.2.1"` |
+| `dst.ip` | Destination IP address (first message) | `"192.0.2.2"` |
 | `state` | Dialog state machine value | `"Trying"`, `"InCall"`, `"Failed"` |
 | `rtp.codec` | RTP codec name (first stream) | `"PCMU"`, `"opus"` |
 | `rtp.ssrc` | RTP SSRC in hex format (first stream) | `"0x12345678"` |
@@ -237,7 +237,7 @@ The `^\+` regex matches E.164 formatted numbers (international prefix).
 sipnab -N -I capture.pcap --filter "method == 'REGISTER' AND retransmits > 5" --report
 ```
 
-High retransmit counts on REGISTER indicate network issues, DNS failures, or server overload. Append `AND src.ip == '10.0.0.50'` to isolate a specific endpoint.
+High retransmit counts on REGISTER indicate network issues, DNS failures, or server overload. Append `AND src.ip == '192.0.2.50'` to isolate a specific endpoint.
 
 ### Scanner activity
 
@@ -254,7 +254,7 @@ sipnab -N -I capture.pcap --filter "duration < 5.0 AND state == 'Completed' AND 
 ### SIP trunk failures
 
 ```bash
-sipnab -N -I capture.pcap --filter "dst.ip == '192.168.1.100' AND state == 'Failed' AND method == 'INVITE'" --report
+sipnab -N -I capture.pcap --filter "dst.ip == '198.51.100.100' AND state == 'Failed' AND method == 'INVITE'" --report
 ```
 
 Filter for failures targeting a specific SIP trunk IP.

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -347,9 +347,9 @@ sipnab -D
 sipnab 0.5.14 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 
 <span class="t-muted">$</span> sipnab -N -I demo.pcap | head -3
-<span class="t-accent">INVITE</span> alice -> bob  10.0.0.1:5060 -> 10.0.0.2:5060  <span class="t-good">InCall</span>  PDD=847ms
-<span class="t-accent">REGISTER</span> admin -> --  10.0.0.5:5060 -> 10.0.0.1:5060  <span class="t-good">Registered</span>
-<span class="t-accent">INVITE</span> +15551234 -> +15559876  10.0.0.6:5060 -> 10.0.0.7:5060  <span class="t-bad">Failed</span>  408 Request Timeout</pre>
+<span class="t-accent">INVITE</span> alice -> bob  192.0.2.1:5060 -> 192.0.2.2:5060 <span class="t-good">InCall</span> PDD=847ms
+<span class="t-accent">REGISTER</span> admin -> --  192.0.2.5:5060 -> 192.0.2.1:5060 <span class="t-good">Registered</span>
+<span class="t-accent">INVITE</span> +15551234 -> +15559876  192.0.2.6:5060 -> 192.0.2.7:5060 <span class="t-bad">Failed</span> 408 Request Timeout</pre>
 </div>
 
 > **Tip:** sipnab requires libpcap for live capture. For pcap file analysis, no special permissions are needed. For live capture, run with `sudo` or set capabilities:

--- a/website/content/docs/keybindings.md
+++ b/website/content/docs/keybindings.md
@@ -291,13 +291,13 @@ The call list is the main view when sipnab starts. It shows all tracked SIP dial
 <span class="t-muted"> Match Expression:             BPF Filter: port 5060</span>
 <span class="t-muted"> Time: Delta-prev</span>
 <span class="t-muted">  #  Method     From           To             Src IP         Dst IP         State        Msgs  Date        PDD</span>
-<span class="t-selected">▸</span><span class="t-accent"> 1  INVITE     alice          bob            10.0.0.1       10.0.0.2       </span><span class="t-good">InCall</span><span class="t-accent">         12  +0.000s     847ms</span>
-  <span class="t-accent">2  INVITE     charlie        dave           10.0.0.3       10.0.0.4       </span><span class="t-warn">Ringing</span><span class="t-accent">         6  +1.234s     --</span>
-  <span class="t-accent">3  REGISTER   admin          --             10.0.0.5       10.0.0.1       </span><span class="t-good">Registered</span><span class="t-accent">      4  +0.012s     --</span>
-  <span class="t-accent">4  INVITE     +15551234      +15559876      10.0.0.6       10.0.0.7       </span><span class="t-bad">Failed</span><span class="t-accent">          8  +3.456s     --</span>
-  <span class="t-accent">5  INVITE     1005           1006           10.0.0.1       10.0.0.2       </span><span class="t-good">Completed</span><span class="t-accent">      14  +0.003s     923ms</span>
-  <span class="t-accent">6  OPTIONS    monitor        --             10.0.0.8       10.0.0.1       </span><span class="t-good">Completed</span><span class="t-accent">       2  +0.001s     --</span>
-  <span class="t-accent">7  INVITE     1010           +441234567     10.0.0.9       10.0.0.7       </span><span class="t-good">InCall</span><span class="t-accent">         10  +0.215s     1.2s</span>
+<span class="t-selected">▸</span><span class="t-accent"> 1  INVITE     alice          bob            192.0.2.1      192.0.2.2      </span><span class="t-good">InCall</span><span class="t-accent">         12  +0.000s     847ms</span>
+  <span class="t-accent">2  INVITE     charlie        dave           192.0.2.3      192.0.2.4      </span><span class="t-warn">Ringing</span><span class="t-accent">         6  +1.234s     --</span>
+  <span class="t-accent">3  REGISTER   admin          --             192.0.2.5      192.0.2.1      </span><span class="t-good">Registered</span><span class="t-accent">      4  +0.012s     --</span>
+  <span class="t-accent">4  INVITE     +15551234      +15559876      192.0.2.6      192.0.2.7      </span><span class="t-bad">Failed</span><span class="t-accent">          8  +3.456s     --</span>
+  <span class="t-accent">5  INVITE     1005           1006           192.0.2.1      192.0.2.2      </span><span class="t-good">Completed</span><span class="t-accent">      14  +0.003s     923ms</span>
+  <span class="t-accent">6  OPTIONS    monitor        --             192.0.2.8      192.0.2.1      </span><span class="t-good">Completed</span><span class="t-accent">       2  +0.001s     --</span>
+  <span class="t-accent">7  INVITE     1010           +441234567     192.0.2.9      192.0.2.7      </span><span class="t-good">InCall</span><span class="t-accent">         10  +0.215s     1.2s</span>
 <span class="t-muted">  Esc Quit  Enter Show  F2 Save  F7 Filter  F8 Settings  F10 Columns  Tab Streams</span></pre>
 </div>
 
@@ -312,7 +312,7 @@ The call flow shows a ladder diagram for a selected dialog, with timing, SDP, an
 <span class="terminal-dot red"></span><span class="terminal-dot yellow"></span><span class="terminal-dot green"></span>
 <span class="terminal-title">sipnab -- Call Flow</span>
 </div>
-<pre class="terminal-body"><span class="t-header">    10.0.0.1:5060            10.0.0.3:5060            10.0.0.2:5060</span>
+<pre class="terminal-body"><span class="t-header">    192.0.2.1:5060           192.0.2.3:5060           192.0.2.2:5060</span>
 <span class="t-header">     (alice UAC)           (OpenSIPS proxy)             (bob UAS)</span>
 <span class="t-muted">          |                        |                        |</span>
 <span class="t-accent"> +0.000s  </span><span class="t-good">|------- INVITE --------&gt;|</span><span class="t-muted">                        |</span>
@@ -345,22 +345,22 @@ Full SIP message with optional syntax highlighting, searchable.
 <span class="terminal-dot red"></span><span class="terminal-dot yellow"></span><span class="terminal-dot green"></span>
 <span class="terminal-title">sipnab -- Raw Message</span>
 </div>
-<pre class="terminal-body"><span class="t-good">INVITE</span> sip:bob@10.0.0.2:5060 SIP/2.0
-<span class="t-header">Via:</span> SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-524287-1
+<pre class="terminal-body"><span class="t-good">INVITE</span> sip:bob@192.0.2.2:5060 SIP/2.0
+<span class="t-header">Via:</span> SIP/2.0/UDP 192.0.2.1:5060;branch=z9hG4bK-524287-1
 <span class="t-header">Max-Forwards:</span> 70
-<span class="t-header">From:</span> "alice" &lt;sip:alice@10.0.0.1&gt;;tag=as6e4f2c8b
-<span class="t-header">To:</span> &lt;sip:bob@10.0.0.2&gt;
-<span class="t-header">Contact:</span> &lt;sip:alice@10.0.0.1:5060&gt;
-<span class="t-header">Call-ID:</span> 3c9a82f1e7b4@10.0.0.1
+<span class="t-header">From:</span> "alice" &lt;sip:alice@192.0.2.1&gt;;tag=as6e4f2c8b
+<span class="t-header">To:</span> &lt;sip:bob@192.0.2.2&gt;
+<span class="t-header">Contact:</span> &lt;sip:alice@192.0.2.1:5060&gt;
+<span class="t-header">Call-ID:</span> 3c9a82f1e7b4@192.0.2.1
 <span class="t-header">CSeq:</span> 102 INVITE
 <span class="t-header">User-Agent:</span> Olle/1.0
 <span class="t-header">Content-Type:</span> application/sdp
 <span class="t-header">Content-Length:</span> 263
 
 <span class="t-accent">v=</span>0
-<span class="t-accent">o=</span>alice 2890844526 2890844526 IN IP4 10.0.0.1
+<span class="t-accent">o=</span>alice 2890844526 2890844526 IN IP4 192.0.2.1
 <span class="t-accent">s=</span>-
-<span class="t-accent">c=</span>IN IP4 10.0.0.1
+<span class="t-accent">c=</span>IN IP4 192.0.2.1
 <span class="t-accent">t=</span>0 0
 <span class="t-accent">m=</span>audio 10000 RTP/AVP 0 8 101
 <span class="t-accent">a=</span>rtpmap:0 PCMU/8000
@@ -381,13 +381,13 @@ Shows all tracked RTP streams with quality metrics. Switch here from the Call Li
 </div>
 <pre class="terminal-body"><span class="t-header"> RTP Streams: 14 tracked                                                         </span>
 <span class="t-muted">  #  SSRC        Src IP:Port          Dst IP:Port          Codec   Pkts    Jitter  Loss%   MOS</span>
-<span class="t-selected">▸</span><span class="t-accent"> 1  0x1a2b3c4d  10.0.0.1:10000       10.0.0.2:20000       PCMU    4820    </span><span class="t-good">2.1ms</span><span class="t-accent">   </span><span class="t-good">0.0%</span><span class="t-accent">    </span><span class="t-good">4.2</span>
-  <span class="t-accent">2  0x5e6f7a8b  10.0.0.2:20000       10.0.0.1:10000       PCMU    4815    </span><span class="t-good">1.8ms</span><span class="t-accent">   </span><span class="t-good">0.0%</span><span class="t-accent">    </span><span class="t-good">4.3</span>
-  <span class="t-accent">3  0x9c0d1e2f  10.0.0.6:12000       10.0.0.7:22000       PCMA    1205    </span><span class="t-warn">18.3ms</span><span class="t-accent">  </span><span class="t-warn">1.2%</span><span class="t-accent">    </span><span class="t-warn">3.4</span>
-  <span class="t-accent">4  0xa1b2c3d4  10.0.0.7:22000       10.0.0.6:12000       PCMA    1198    </span><span class="t-bad">45.7ms</span><span class="t-accent">  </span><span class="t-bad">3.8%</span><span class="t-accent">    </span><span class="t-bad">2.1</span>
-  <span class="t-accent">5  0xe5f60718  10.0.0.9:14000       10.0.0.7:24000       opus    9612    </span><span class="t-good">3.2ms</span><span class="t-accent">   </span><span class="t-good">0.1%</span><span class="t-accent">    </span><span class="t-good">4.1</span>
-  <span class="t-accent">6  0x29304150  10.0.0.7:24000       10.0.0.9:14000       opus    9608    </span><span class="t-good">2.9ms</span><span class="t-accent">   </span><span class="t-good">0.0%</span><span class="t-accent">    </span><span class="t-good">4.2</span>
-  <span class="t-muted">7  0xdeadbeef  10.0.0.3:16000       --                   PCMU    340     </span><span class="t-bad">--</span><span class="t-muted">      </span><span class="t-bad">--</span><span class="t-muted">      </span><span class="t-bad">orphan</span>
+<span class="t-selected">▸</span><span class="t-accent"> 1  0x1a2b3c4d  192.0.2.1:10000      192.0.2.2:20000      PCMU    4820    </span><span class="t-good">2.1ms</span><span class="t-accent">   </span><span class="t-good">0.0%</span><span class="t-accent">    </span><span class="t-good">4.2</span>
+  <span class="t-accent">2  0x5e6f7a8b  192.0.2.2:20000      192.0.2.1:10000      PCMU    4815    </span><span class="t-good">1.8ms</span><span class="t-accent">   </span><span class="t-good">0.0%</span><span class="t-accent">    </span><span class="t-good">4.3</span>
+  <span class="t-accent">3  0x9c0d1e2f  192.0.2.6:12000      192.0.2.7:22000      PCMA    1205    </span><span class="t-warn">18.3ms</span><span class="t-accent">  </span><span class="t-warn">1.2%</span><span class="t-accent">    </span><span class="t-warn">3.4</span>
+  <span class="t-accent">4  0xa1b2c3d4  192.0.2.7:22000      192.0.2.6:12000      PCMA    1198    </span><span class="t-bad">45.7ms</span><span class="t-accent">  </span><span class="t-bad">3.8%</span><span class="t-accent">    </span><span class="t-bad">2.1</span>
+  <span class="t-accent">5  0xe5f60718  192.0.2.9:14000      192.0.2.7:24000      opus    9612    </span><span class="t-good">3.2ms</span><span class="t-accent">   </span><span class="t-good">0.1%</span><span class="t-accent">    </span><span class="t-good">4.1</span>
+  <span class="t-accent">6  0x29304150  192.0.2.7:24000      192.0.2.9:14000      opus    9608    </span><span class="t-good">2.9ms</span><span class="t-accent">   </span><span class="t-good">0.0%</span><span class="t-accent">    </span><span class="t-good">4.2</span>
+  <span class="t-muted">7  0xdeadbeef  192.0.2.3:16000      --                   PCMU    340     </span><span class="t-bad">--</span><span class="t-muted">      </span><span class="t-bad">--</span><span class="t-muted">      </span><span class="t-bad">orphan</span>
 <span class="t-muted">  Tab Call List  Esc Back  F7 Filter</span></pre>
 </div>
 

--- a/website/content/docs/output-formats.md
+++ b/website/content/docs/output-formats.md
@@ -29,14 +29,14 @@ Message record (fields with no value are omitted, not null):
 {
   "schema_version": 1,
   "timestamp": "2026-06-12T14:03:21.412345+00:00",
-  "src": "10.0.0.1",
+  "src": "192.0.2.1",
   "src_port": 5060,
-  "dst": "10.0.0.2",
+  "dst": "192.0.2.2",
   "dst_port": 5060,
   "transport": "UDP",
   "is_request": true,
   "method": "INVITE",
-  "call_id": "abc123@10.0.0.1",
+  "call_id": "abc123@192.0.2.1",
   "from": "1001",
   "to": "1002",
   "cseq": { "number": 1, "method": "INVITE" },
@@ -51,15 +51,15 @@ A response record carries `is_request: false` plus `status_code`,
 {
   "schema_version": 1,
   "timestamp": "2026-06-12T14:03:21.598204+00:00",
-  "src": "10.0.0.2",
+  "src": "192.0.2.2",
   "src_port": 5060,
-  "dst": "10.0.0.1",
+  "dst": "192.0.2.1",
   "dst_port": 5060,
   "transport": "UDP",
   "is_request": false,
   "status_code": 180,
   "reason": "Ringing",
-  "call_id": "abc123@10.0.0.1",
+  "call_id": "abc123@192.0.2.1",
   "from": "1001",
   "to": "1002",
   "cseq": { "number": 1, "method": "INVITE" },
@@ -116,7 +116,7 @@ per-message stream but not the report):
 sipnab -N -I capture.pcap --report --no-cli-print
 
 # Single-call deep dive only
-sipnab -N -I capture.pcap --call-report 'abc123@10.0.0.1' --no-cli-print
+sipnab -N -I capture.pcap --call-report 'abc123@192.0.2.1' --no-cli-print
 ```
 
 ## Dialog / stream JSON

--- a/website/content/docs/troubleshooting.md
+++ b/website/content/docs/troubleshooting.md
@@ -110,7 +110,7 @@ sipnab -N -I capture.pcap --filter "one_way == true" --report
 You should see one NDJSON record per SIP message of each flagged call (abridged -- real records carry the full field set):
 
 ```json
-{"is_request":true,"method":"INVITE","call_id":"7f3a9c@10.0.0.5","from":"...","to":"...", "...":"..."}
+{"is_request":true,"method":"INVITE","call_id":"7f3a9c@192.0.2.5","from":"...","to":"...", "...":"..."}
 ```
 
 Get the diagnosis detail (`one_way_audio`, `nat_mismatch`, hints) per call with `--call-report <call-id>`.

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -155,7 +155,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2516 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2529 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -226,7 +226,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.4.16)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2516" data-suffix="">2516</span>
+        <span class="arch-stat" data-count="2529" data-suffix="">2529</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Closes the per-parameter example mandate from `verification-spec.md` §15/§17:
every user-facing CLI flag must carry multiple runnable examples, and every
example must be proven against the real binary.

An audit of the doc corpus (`docs/`, `README.md`, `website/content/docs/`)
found the mandate was **not** met: of 135 user-facing flags, **80 had zero
runnable examples and 17 had only one** — only 38 met the bar. This PR closes
the gap.

## What changed

- **135/135 flags and 56/56 config keys now have ≥2 example occurrences.**
  Grouped `**Examples**` bash blocks added after every flag table in
  `docs/cli-reference.md` (15 groups), mirrored to the website `cli.md`.
- **Every command proven against the installed 0.5.14 binary** — 241 commands
  across the four example docs, **0 clap-rejected** (harness detects
  clap-rejection signatures, so missing-file / needs-root runtime errors don't
  false-pass). Found and fixed one real doc bug: `--hep-allow` needs CIDR
  (`192.0.2.0/24`), not a bare host.
- **Full RFC 5737 IP sweep** (the other deferred audit item): every
  `10.0.0.x` / `192.168.x.x` example IP → TEST-NET ranges across docs, website,
  and the man page — including the width-sensitive terminal mockups, done with
  a column-preserving replacer and verified aligned. No private IPs remain.

## Regression guards (new, TDD)

- `tests/doc_example_coverage_test.rs` — ratchet: every flag must keep ≥2
  examples or CI fails. One justified waiver (`--panic-selftest`, hidden
  internal flag).
- `tests/mockup_alignment_test.rs` — enforces box/ladder alignment of the
  terminal mockups the sweep touched.

## Verification

Gates green: `docs_drift`, `keybinding_drift`, `mockup_alignment`,
`doc_example_coverage`; clippy `-Dwarnings` clean; Zola site rebuilds with
internal links checked; search validated 10/10 representative queries.

## Not included (owner-blocked / deferred)

- crates.io publish (needs `cargo login`).
- 0.5.x re-benchmark (homepage stats keep the "measured v0.4.16" caveat).
