### PR TITLE
site: fix hidden nav, reorder learning path, mirror TLS note

### DIFF
--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -1,6 +1,6 @@
 +++
 title = "REST API & Metrics"
-weight = 7
+weight = 10
 description = "REST API endpoints, Prometheus metrics, and HEP protocol integration."
 +++
 

--- a/website/content/docs/benchmarks.md
+++ b/website/content/docs/benchmarks.md
@@ -1,6 +1,6 @@
 +++
 title = "Benchmarks"
-weight = 11
+weight = 12
 description = "Reproducible throughput and memory benchmarks: sipnab multi-core scaling, and honest comparisons against sngrep and voipmonitor."
 +++
 

--- a/website/content/docs/cli.md
+++ b/website/content/docs/cli.md
@@ -1,6 +1,6 @@
 +++
 title = "CLI Reference"
-weight = 2
+weight = 6
 description = "Complete flag reference for sipnab, organized by functional group."
 +++
 
@@ -398,8 +398,8 @@ sipnab -N -I capture.pcap --stir-shaken --digest-leak --alert-json
 | `--metrics-auth` | `<USER:PASS>` | -- | HTTP Basic auth credentials (`user:pass`) required by the metrics endpoint; requests must send `Authorization: Basic <base64>` Feature: `api` |
 | `--api` | `<ADDR>` | -- | REST API endpoint (e.g., `0.0.0.0:8080`). Feature: `api` |
 | `--api-key` | `<KEY>` | -- | API key for REST API authentication. Also reads `$SIPNAB_API_KEY` Feature: `api` |
-| `--api-tls-cert` | `<FILE>` | -- | TLS certificate file for API endpoint Feature: `api` |
-| `--api-tls-key` | `<FILE>` | -- | TLS private key file for API endpoint Feature: `api` |
+| `--api-tls-cert` | `<FILE>` | -- | **Not yet implemented** — built-in API TLS is not wired up, and sipnab exits if this is set. Terminate TLS at a reverse proxy instead. Feature: `api` |
+| `--api-tls-key` | `<FILE>` | -- | **Not yet implemented** — see `--api-tls-cert`; terminate TLS at a reverse proxy. Feature: `api` |
 | `--api-max-conn` | `<N>` | `100` | Maximum concurrent API connections Feature: `api` |
 | `--api-signing-key` | `<HEX>` | -- | HMAC signing key (hex) for revocable API tokens |
 | `--api-signing-key-file` | `<FILE>` | -- | Read the API HMAC signing key from a file |
@@ -415,10 +415,10 @@ sipnab -N -I capture.pcap --stir-shaken --digest-leak --alert-json
 **Examples**
 
 ```bash
-# Live capture serving a TLS REST API (cert+key) with signed tokens, a revocation list, and a Basic-auth'd Prometheus endpoint
-sudo sipnab -d eth0 --api 127.0.0.1:8080 --api-tls-cert /etc/sipnab/api.pem --api-tls-key /etc/sipnab/api.key --api-signing-key-file /etc/sipnab/signing.key --api-revoked-file /etc/sipnab/revoked.txt --api-token-ttl 7200 --api-max-conn 200 --metrics 127.0.0.1:9090 --metrics-auth alice:s3cret
-# Public-facing TLS API tuned to 100 connections and 1h token TTL, with its own auth'd metrics endpoint
-sudo sipnab -d eth0 --api 0.0.0.0:8080 --api-tls-cert /etc/sipnab/api.pem --api-tls-key /etc/sipnab/api.key --api-signing-key-file /etc/sipnab/signing.key --api-token-ttl 3600 --api-max-conn 100 --metrics 127.0.0.1:9090 --metrics-auth bob:hunter2
+# Live capture serving a signed-token REST API, a revocation list, and a Basic-auth'd Prometheus endpoint (terminate TLS at a reverse proxy)
+sudo sipnab -d eth0 --api 127.0.0.1:8080 --api-signing-key-file /etc/sipnab/signing.key --api-revoked-file /etc/sipnab/revoked.txt --api-token-ttl 7200 --api-max-conn 200 --metrics 127.0.0.1:9090 --metrics-auth alice:s3cret
+# Public-facing API tuned to 100 connections and 1h token TTL, with its own auth'd metrics endpoint
+sudo sipnab -d eth0 --api 0.0.0.0:8080 --api-signing-key-file /etc/sipnab/signing.key --api-token-ttl 3600 --api-max-conn 100 --metrics 127.0.0.1:9090 --metrics-auth bob:hunter2
 # Loopback HTTP MCP server with a bearer token, file-loaded signing key, revocation denylist, and a 30-minute mint TTL
 sudo sipnab -N -d eth0 --mcp --mcp-transport http --mcp-bind 127.0.0.1:8731 --mcp-token t0ken-alice --mcp-signing-key-file /etc/sipnab/mcp-signing.key --mcp-revoked-file /etc/sipnab/mcp-revoked.txt --mcp-token-ttl 1800
 # Non-loopback HTTP MCP server (token required) accepting an extra Host header for named clients

--- a/website/content/docs/config.md
+++ b/website/content/docs/config.md
@@ -1,6 +1,6 @@
 +++
 title = "Config Reference"
-weight = 3
+weight = 9
 description = "TOML configuration file format and all configurable sections."
 +++
 

--- a/website/content/docs/cookbook.md
+++ b/website/content/docs/cookbook.md
@@ -1,6 +1,6 @@
 +++
 title = "Cookbook"
-weight = 10
+weight = 2
 description = "Step-by-step recipes for every major sipnab feature: triage, filtering, HEP, TLS decryption, MCP, observability, security, audio export."
 +++
 

--- a/website/content/docs/filter-dsl.md
+++ b/website/content/docs/filter-dsl.md
@@ -1,6 +1,6 @@
 +++
 title = "Filter DSL"
-weight = 5
+weight = 7
 description = "Declarative filter language for matching SIP dialogs and RTP streams."
 +++
 

--- a/website/content/docs/mcp.md
+++ b/website/content/docs/mcp.md
@@ -1,6 +1,7 @@
 +++
 title = "MCP Server"
-weight = 9
+description = "Run sipnab as a Model Context Protocol server, exposing its read-only analysis surface as tools for an AI agent."
+weight = 11
 +++
 
 sipnab can run as a **Model Context Protocol** server, exposing its

--- a/website/content/docs/theme.md
+++ b/website/content/docs/theme.md
@@ -1,6 +1,6 @@
 +++
 title = "Theme Guide"
-weight = 6
+weight = 5
 description = "Customize sipnab's TUI colors with 10 semantic color slots and preset themes."
 +++
 

--- a/website/content/docs/troubleshooting.md
+++ b/website/content/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 +++
 title = "Troubleshooting"
-weight = 12
+weight = 3
 description = "Real-world VoIP diagnostic workflows with exact commands."
 +++
 

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -95,12 +95,16 @@
           <div class="nav-drop-menu" role="menu">
             <a href="{{ get_url(path='@/docs/_index.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/" %}class="active"{% endif %}>Overview</a>
             <a href="{{ get_url(path='@/docs/install.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/install/" %}class="active"{% endif %}>Install</a>
+            <a href="{{ get_url(path='@/docs/cookbook.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/cookbook/" %}class="active"{% endif %}>Cookbook</a>
+            <a href="{{ get_url(path='@/docs/troubleshooting.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/troubleshooting/" %}class="active"{% endif %}>Troubleshooting</a>
             <a href="{{ get_url(path='@/docs/cli.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/cli/" %}class="active"{% endif %}>CLI</a>
+            <a href="{{ get_url(path='@/docs/filter-dsl.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/filter-dsl/" %}class="active"{% endif %}>Filter DSL</a>
+            <a href="{{ get_url(path='@/docs/output-formats.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/output-formats/" %}class="active"{% endif %}>Output Formats</a>
             <a href="{{ get_url(path='@/docs/config.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/config/" %}class="active"{% endif %}>Config</a>
             <a href="{{ get_url(path='@/docs/keybindings.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/keybindings/" %}class="active"{% endif %}>Keybindings</a>
-            <a href="{{ get_url(path='@/docs/filter-dsl.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/filter-dsl/" %}class="active"{% endif %}>Filter DSL</a>
             <a href="{{ get_url(path='@/docs/theme.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/theme/" %}class="active"{% endif %}>Theme</a>
             <a href="{{ get_url(path='@/docs/api.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/api/" %}class="active"{% endif %}>API</a>
+            <a href="{{ get_url(path='@/docs/mcp.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/mcp/" %}class="active"{% endif %}>MCP</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Workstream C of the site overhaul — the high-value, low-risk information-architecture fixes from the audit. (The larger structural page-splits are deferred to a focused follow-up; see below.)

- **Fix the biggest nav defect:** the Docs dropdown hid 5 of 12 pages, including **Cookbook** and **Troubleshooting** — the two pages the docs landing page itself routes newcomers to. Now surfaces Cookbook, Troubleshooting, Output Formats, and MCP.
- **Reorder the learning path** (Zola `weight`) so task pages precede deep reference: install → cookbook → troubleshooting → TUI (keybindings, theme) → CLI/automation → config → integrations (api, mcp) → benchmarks. Previously Cookbook was weight 10 and Troubleshooting 12, below the 1539-line API reference.
- **Add the missing `description`** to `mcp.md` (the only docs page without one — its index card and meta tags were falling back to defaults).
- **Mirror the TLS-not-implemented fix** onto the website: `cli.md` presented `--api-tls-cert/key` as working while `api.md` already said they're not implemented (sipnab exits if set). Rows marked not-implemented; dropped from the runnable examples.

Site builds clean (0 orphans, internal links checked); doc-example ratchet green.

## Deferred — large structural work, best as a focused follow-up PR

- Split the 1539-line `api.md` (move the 5-language client programs / HEP / event-exec / fail2ban to their own pages).
- Split `install.md` (user-install vs build-from-source).
- Collapse the duplicated key-tables vs "TUI Views" prose in `keybindings.md` (the mockups there are worth keeping, so this needs care, not a bulk delete).
- De-duplicate the recipe sections repeated across `cli.md` / `filter-dsl.md` / `cookbook.md` / `troubleshooting.md` into the two canonical task pages.
