### PR TITLE
site: split api.md and install.md, de-dup recipes

### DIFF
--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -125,6 +125,18 @@ fn readme_long_flags_exist_in_cli() {
             include_str!("../website/content/docs/api.md"),
         ),
         (
+            "website/api-clients.md",
+            include_str!("../website/content/docs/api-clients.md"),
+        ),
+        (
+            "website/integrations.md",
+            include_str!("../website/content/docs/integrations.md"),
+        ),
+        (
+            "website/build.md",
+            include_str!("../website/content/docs/build.md"),
+        ),
+        (
             "website/mcp.md",
             include_str!("../website/content/docs/mcp.md"),
         ),

--- a/website/content/docs/api-clients.md
+++ b/website/content/docs/api-clients.md
@@ -1,0 +1,695 @@
++++
+title = "API Client Examples"
+weight = 11
+description = "Client code for the sipnab REST API in curl, Python, Node/TypeScript, Rust, and Go."
++++
+
+Ready-to-adapt clients for the [REST API](@/docs/api.md) in curl, Python, Node/TypeScript, Rust, and Go.
+
+## Client Examples
+
+End-to-end examples in five languages. Each one covers: bearer-token auth, listing dialogs filtered by state, fetching a single dialog with pagination, scraping `/metrics`, and error handling. Adapt to your environment.
+
+> **Filter parameters:** the REST API accepts `state` (e.g. `Failed`, `Completed`, `InCall`) and `from` (regex on the From header) as query parameters on `/v1/dialogs`, plus `orphaned` and `mos_below` on `/v1/streams`. Full DSL filtering — anything more complex than a single state/from match — is **not** available over REST. For arbitrary DSL queries, use the [MCP server](@/docs/mcp.md)'s `list_dialogs` tool, which accepts a `filter` argument that runs through the same evaluator as `sipnab --filter`.
+
+> **Status codes:** the REST API returns **503 Service Unavailable** when a request is rejected by the rate limiter or the connection cap (not 429). 401 on bad/missing token, 404 on unknown call_id.
+
+> **Per-call response code / per-message data is not on REST.** The REST API aggregates each dialog into a summary (`call_id`, `state`, `from`, `to`, `duration_sec`, `msg_count`, `timing`, `diagnosis`, `sdp_timeline`, `streams`) — individual SIP messages and per-response status codes are **not** exposed by `/v1/dialogs` or `/v1/dialogs/{id}`. To work with per-message data programmatically, use either: (a) the CLI `sipnab -N --json ...` mode, which emits one JSON object per SIP message with `is_request`, `status_code`, `reason`, etc. (field reference: [Output Formats](@/docs/output-formats.md); see also [cookbook Recipe 3](@/docs/cookbook.md#3-find-every-failed-call-grouped-by-response-code)), or (b) the MCP `get_dialog` tool, which returns paginated `messages[]` (see [MCP](@/docs/mcp.md)).
+
+### curl + jq one-liners
+
+```bash
+# Setup
+API="http://localhost:8080"
+KEY="my-secret-token"
+H="-H 'Authorization: Bearer $KEY'"
+
+# Health check (no auth required)
+curl -fsS $API/health
+
+# List failed dialogs (state= query param)
+curl -fsS "$API/v1/dialogs?state=Failed&limit=20" $H | jq
+
+# List dialogs from a specific user (from= regex)
+curl -fsS "$API/v1/dialogs?from=alice&limit=20" $H | jq
+
+# Get one full (aggregated) dialog — no per-message data over REST
+curl -fsS "$API/v1/dialogs/abc123@host" $H | jq
+
+# Get a call report (JSON — this endpoint is JSON-only)
+curl -fsS "$API/v1/dialogs/abc123@host/report" $H | jq
+
+# Non-orphaned streams (orphaned=false)
+curl -fsS "$API/v1/streams?orphaned=false" $H | jq
+
+# Streams below a MOS threshold
+curl -fsS "$API/v1/streams?mos_below=3.5" $H | jq
+
+# Aggregate counters
+curl -fsS "$API/v1/stats" $H | jq
+
+# Count failed calls (aggregated — REST exposes no per-message data)
+curl -fsS "$API/v1/dialogs?state=Failed&limit=1000" $H \
+  | jq '.total'
+
+# For per-call response-code histograms, use the CLI NDJSON mode —
+# sipnab -N --json emits one record per message (see Output Formats docs):
+#   sipnab -N -I capture.pcap --filter "state == 'Failed'" --json \
+#     | jq -r 'select(.is_request == false) | .status_code' \
+#     | sort | uniq -c | sort -rn
+
+# Prometheus metrics
+curl -fsS "$API/metrics" $H | grep '^sipnab_'
+
+# Error handling — server returns 503 (not 429) on rate-limit + conn-cap
+http_code=$(curl -s -o /dev/null -w '%{http_code}' \
+            "$API/v1/dialogs/no-such-call" $H)
+case "$http_code" in
+  200) echo "found" ;;
+  401) echo "auth failed — check --api-key" ;;
+  404) echo "dialog not found" ;;
+  503) echo "rate-limited or connection cap reached" ;;
+  *)   echo "unexpected $http_code" ;;
+esac
+```
+
+> The per-message NDJSON records referenced above (`is_request`, `status_code`, `reason`, `cseq`, ...) are documented in [Output Formats](@/docs/output-formats.md).
+
+---
+
+### Python (sync, `requests`)
+
+```python
+"""sipnab REST client — sync version using requests."""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+import requests
+
+API = os.environ.get("SIPNAB_API", "http://localhost:8080")
+KEY = os.environ["SIPNAB_API_KEY"]  # raises KeyError if unset
+
+
+class SipnabError(Exception):
+    pass
+
+
+class SipnabClient:
+    def __init__(self, base_url: str = API, token: str = KEY,
+                 timeout: float = 10.0) -> None:
+        self.base = base_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = f"Bearer {token}"
+        self.timeout = timeout
+
+    def _get(self, path: str, **params: Any) -> Any:
+        r = self.session.get(f"{self.base}{path}", params=params,
+                             timeout=self.timeout)
+        if r.status_code == 401:
+            raise SipnabError("authentication failed")
+        if r.status_code == 503:
+            raise SipnabError("rate-limited or connection cap reached")
+        r.raise_for_status()
+        return r.json()
+
+    def health(self) -> bool:
+        r = self.session.get(f"{self.base}/health", timeout=self.timeout)
+        return r.ok
+
+    def list_dialogs(self, *, state: str | None = None,
+                     from_regex: str | None = None,
+                     limit: int = 50, offset: int = 0) -> list[dict]:
+        """List dialog summaries.
+
+        The REST API supports filtering by `state` (exact match against
+        DialogState e.g. 'Failed', 'Completed', 'InCall') and `from` (regex).
+        For full DSL filtering use the MCP server's list_dialogs tool.
+        """
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if state:
+            params["state"] = state
+        if from_regex:
+            params["from"] = from_regex
+        return self._get("/v1/dialogs", **params)["dialogs"]
+
+    def get_dialog(self, call_id: str) -> dict:
+        from urllib.parse import quote
+        return self._get(f"/v1/dialogs/{quote(call_id, safe='')}")
+
+    def call_report(self, call_id: str) -> dict:
+        from urllib.parse import quote
+        return self._get(f"/v1/dialogs/{quote(call_id, safe='')}/report")
+
+    def stats(self) -> dict:
+        return self._get("/v1/stats")
+
+    def metrics(self) -> str:
+        r = self.session.get(f"{self.base}/metrics", timeout=self.timeout)
+        if r.status_code == 401:
+            raise SipnabError("authentication failed")
+        if r.status_code == 503:
+            raise SipnabError("rate-limited")
+        r.raise_for_status()
+        return r.text
+
+
+# ── Usage ─────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    c = SipnabClient()
+
+    if not c.health():
+        sys.exit("sipnab not reachable")
+
+    print("Stats:", c.stats())
+
+    # Pull every failed call, page through
+    failed: list[dict] = []
+    offset = 0
+    while True:
+        page = c.list_dialogs(state="Failed", limit=100, offset=offset)
+        if not page:
+            break
+        failed.extend(page)
+        offset += len(page)
+    print(f"{len(failed)} failed dialogs")
+
+    # Show the first few — note the REST shape doesn't expose
+    # per-message status_code. See module-level note above for how to
+    # build a response-code histogram via CLI or MCP.
+    for d in failed[:5]:
+        full = c.get_dialog(d["call_id"])
+        diag = full.get("diagnosis", {})
+        print(f"  {d['call_id']:30s}  state={d['state']:10s}  "
+              f"diagnosis={ {k: v for k, v in diag.items() if v} }")
+```
+
+Run it:
+
+```bash
+SIPNAB_API_KEY=my-secret-token python3 sipnab_client.py
+```
+
+---
+
+### Python (async, `httpx`)
+
+For tailing dialogs in near-real-time without blocking:
+
+```python
+"""sipnab REST client — async, periodic polling."""
+import asyncio
+import os
+from datetime import datetime, timezone
+
+import httpx
+
+API = os.environ.get("SIPNAB_API", "http://localhost:8080")
+KEY = os.environ["SIPNAB_API_KEY"]
+
+
+async def tail_dialogs(poll_interval: float = 2.0) -> None:
+    """Poll /v1/dialogs every `poll_interval` and print newly-completed calls."""
+    seen: set[str] = set()
+    headers = {"Authorization": f"Bearer {KEY}"}
+
+    async with httpx.AsyncClient(base_url=API, headers=headers,
+                                  timeout=10.0) as client:
+        while True:
+            try:
+                r = await client.get("/v1/dialogs",
+                                     params={"limit": 100})
+                r.raise_for_status()
+                for d in r.json()["dialogs"]:
+                    if d["call_id"] in seen:
+                        continue
+                    seen.add(d["call_id"])
+                    if d["state"] in ("Completed", "Failed", "Cancelled"):
+                        print(f"{datetime.now(timezone.utc).isoformat()}  "
+                              f"{d['state']:10s}  {d['call_id']}  "
+                              f"{d.get('from')} → {d.get('to')}")
+            except httpx.HTTPError as e:
+                print(f"warning: {e}")
+            await asyncio.sleep(poll_interval)
+
+
+if __name__ == "__main__":
+    asyncio.run(tail_dialogs())
+```
+
+---
+
+### Node.js / TypeScript
+
+```typescript
+// sipnab-client.ts — runs on Node 18+ (built-in fetch)
+const API = process.env.SIPNAB_API ?? "http://localhost:8080";
+const KEY = process.env.SIPNAB_API_KEY;
+if (!KEY) throw new Error("SIPNAB_API_KEY not set");
+
+interface DialogSummary {
+  call_id: string;
+  state: string;
+  method: string;
+  from: string;
+  to: string;
+  duration_sec: number;
+  msg_count: number;
+}
+
+interface DialogsPage {
+  dialogs: DialogSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+async function api<T>(
+  path: string,
+  params: Record<string, string | number> = {},
+): Promise<T> {
+  const url = new URL(`${API}${path}`);
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, String(v));
+  }
+  const r = await fetch(url, {
+    headers: { Authorization: `Bearer ${KEY}` },
+  });
+  if (r.status === 401) throw new Error("auth failed");
+  if (r.status === 503) throw new Error("rate-limited or conn cap reached");
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return (await r.json()) as T;
+}
+
+async function listDialogs(
+  state: string | null = null,
+  limit = 50,
+): Promise<DialogSummary[]> {
+  const all: DialogSummary[] = [];
+  let offset = 0;
+  for (;;) {
+    const params: Record<string, string | number> = { limit, offset };
+    if (state) params.state = state;
+    const page = await api<DialogsPage>("/v1/dialogs", params);
+    if (page.dialogs.length === 0) break;
+    all.push(...page.dialogs);
+    if (all.length >= page.total) break;
+    offset += page.dialogs.length;
+  }
+  return all;
+}
+
+// REST API doesn't expose per-message data — see the note at the top of
+// "Client Examples" for how to build per-call response-code histograms
+// via the CLI or MCP. Here we just summarize what REST exposes:
+interface FullDialog {
+  call_id: string;
+  state: string;
+  msg_count: number;
+  timing: { pdd_ms: number | null; setup_ms: number | null; retransmits: number };
+  diagnosis: { one_way_audio: boolean; nat_mismatch: boolean; no_media: boolean };
+}
+
+// ── Demo ──────────────────────────────────────────────────────────
+const failed = await listDialogs("Failed");
+console.log(`${failed.length} failed dialogs`);
+
+for (const d of failed.slice(0, 5)) {
+  const full = await api<FullDialog>(`/v1/dialogs/${encodeURIComponent(d.call_id)}`);
+  console.log(`  ${d.call_id}  state=${d.state}  ` +
+              `pdd=${full.timing.pdd_ms ?? "—"}ms  ` +
+              `nat_mismatch=${full.diagnosis.nat_mismatch}`);
+}
+```
+
+Run:
+
+```bash
+SIPNAB_API_KEY=my-secret-token npx tsx sipnab-client.ts
+```
+
+---
+
+### Rust (`reqwest`)
+
+```rust
+// Cargo.toml deps:
+//   reqwest = { version = "0.12", features = ["json", "blocking"] }
+//   serde   = { version = "1", features = ["derive"] }
+//   anyhow  = "1"
+
+use anyhow::{anyhow, Result};
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use std::env;
+
+#[derive(Debug, Deserialize)]
+struct DialogSummary {
+    call_id: String,
+    state: String,
+    from: String,
+    to: String,
+    duration_sec: f64,
+    msg_count: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct DialogsPage {
+    dialogs: Vec<DialogSummary>,
+    total: usize,
+    limit: usize,
+    offset: usize,
+}
+
+struct Sipnab {
+    base: String,
+    client: Client,
+}
+
+impl Sipnab {
+    fn new() -> Result<Self> {
+        let base = env::var("SIPNAB_API")
+            .unwrap_or_else(|_| "http://localhost:8080".into());
+        let key = env::var("SIPNAB_API_KEY")?;
+        let client = Client::builder()
+            .default_headers({
+                let mut h = reqwest::header::HeaderMap::new();
+                h.insert(reqwest::header::AUTHORIZATION,
+                    format!("Bearer {key}").parse()?);
+                h
+            })
+            .timeout(std::time::Duration::from_secs(10))
+            .build()?;
+        Ok(Self { base, client })
+    }
+
+    fn list_dialogs(&self, state: Option<&str>) -> Result<Vec<DialogSummary>> {
+        let mut all = Vec::new();
+        let mut offset = 0usize;
+        loop {
+            let mut req = self.client
+                .get(format!("{}/v1/dialogs", self.base))
+                .query(&[("limit", "100"), ("offset", &offset.to_string())]);
+            if let Some(s) = state {
+                req = req.query(&[("state", s)]);
+            }
+            let resp = req.send()?;
+            match resp.status().as_u16() {
+                401 => return Err(anyhow!("auth failed")),
+                503 => return Err(anyhow!("rate-limited or conn cap reached")),
+                code if code >= 400 => return Err(anyhow!("HTTP {code}")),
+                _ => {}
+            }
+            let page: DialogsPage = resp.json()?;
+            if page.dialogs.is_empty() { break; }
+            offset += page.dialogs.len();
+            let total = page.total;
+            all.extend(page.dialogs);
+            if all.len() >= total { break; }
+        }
+        Ok(all)
+    }
+
+    /// Fetch one full dialog (aggregated; no per-message data).
+    /// REST does not expose individual messages — for that, use the
+    /// CLI `sipnab -N --json` mode or the MCP `get_dialog` tool.
+    fn get_dialog(&self, call_id: &str) -> Result<serde_json::Value> {
+        let cid = urlencoding::encode(call_id);
+        let resp = self.client
+            .get(format!("{}/v1/dialogs/{}", self.base, cid))
+            .send()?;
+        Ok(resp.json()?)
+    }
+}
+
+fn main() -> Result<()> {
+    let s = Sipnab::new()?;
+    let failed = s.list_dialogs(Some("Failed"))?;
+    println!("{} failed dialogs", failed.len());
+
+    for d in failed.iter().take(5) {
+        let full = s.get_dialog(&d.call_id)?;
+        let pdd = full["timing"]["pdd_ms"].as_i64();
+        let nat_mismatch = full["diagnosis"]["nat_mismatch"].as_bool().unwrap_or(false);
+        println!("  {}  state={}  pdd={:?}ms  nat_mismatch={}",
+                 d.call_id, d.state, pdd, nat_mismatch);
+    }
+    Ok(())
+}
+```
+
+> The per-message `sipnab -N --json` records mentioned in `get_dialog`'s doc comment are documented in [Output Formats](@/docs/output-formats.md).
+
+---
+
+### Go (`net/http` + `encoding/json`)
+
+```go
+// sipnab-client.go
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "net/url"
+    "os"
+    "sort"
+    "time"
+)
+
+type DialogSummary struct {
+    CallID      string  `json:"call_id"`
+    State       string  `json:"state"`
+    From        string  `json:"from"`
+    To          string  `json:"to"`
+    DurationSec float64 `json:"duration_sec"`
+    MsgCount    int     `json:"msg_count"`
+}
+
+type DialogTiming struct {
+    PddMs      *int64 `json:"pdd_ms"`
+    SetupMs    *int64 `json:"setup_ms"`
+    Retransmits int   `json:"retransmits"`
+}
+
+type DialogDiagnosis struct {
+    OneWayAudio  bool `json:"one_way_audio"`
+    NatMismatch  bool `json:"nat_mismatch"`
+    NoMedia      bool `json:"no_media"`
+}
+
+type FullDialog struct {
+    CallID    string          `json:"call_id"`
+    State     string          `json:"state"`
+    Timing    DialogTiming    `json:"timing"`
+    Diagnosis DialogDiagnosis `json:"diagnosis"`
+}
+
+type DialogsPage struct {
+    Dialogs []DialogSummary `json:"dialogs"`
+    Total   int             `json:"total"`
+    Limit   int             `json:"limit"`
+    Offset  int             `json:"offset"`
+}
+
+type Sipnab struct {
+    Base   string
+    Token  string
+    Client *http.Client
+}
+
+func newSipnab() (*Sipnab, error) {
+    base := os.Getenv("SIPNAB_API")
+    if base == "" {
+        base = "http://localhost:8080"
+    }
+    token := os.Getenv("SIPNAB_API_KEY")
+    if token == "" {
+        return nil, fmt.Errorf("SIPNAB_API_KEY not set")
+    }
+    return &Sipnab{
+        Base:   base,
+        Token:  token,
+        Client: &http.Client{Timeout: 10 * time.Second},
+    }, nil
+}
+
+func (s *Sipnab) get(path string, params url.Values, out any) error {
+    u, _ := url.Parse(s.Base + path)
+    u.RawQuery = params.Encode()
+    req, _ := http.NewRequest(http.MethodGet, u.String(), nil)
+    req.Header.Set("Authorization", "Bearer "+s.Token)
+    resp, err := s.Client.Do(req)
+    if err != nil {
+        return err
+    }
+    defer resp.Body.Close()
+    switch resp.StatusCode {
+    case 401:
+        return fmt.Errorf("auth failed")
+    case 503:
+        return fmt.Errorf("rate-limited or conn cap reached")
+    }
+    if resp.StatusCode >= 400 {
+        return fmt.Errorf("HTTP %d", resp.StatusCode)
+    }
+    return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func (s *Sipnab) ListDialogs(state string) ([]DialogSummary, error) {
+    var all []DialogSummary
+    offset := 0
+    for {
+        params := url.Values{"limit": {"100"}, "offset": {fmt.Sprint(offset)}}
+        if state != "" {
+            params.Set("state", state)
+        }
+        var page DialogsPage
+        if err := s.get("/v1/dialogs", params, &page); err != nil {
+            return nil, err
+        }
+        if len(page.Dialogs) == 0 {
+            break
+        }
+        all = append(all, page.Dialogs...)
+        offset += len(page.Dialogs)
+        if len(all) >= page.Total {
+            break
+        }
+    }
+    return all, nil
+}
+
+// GetDialog fetches the full (aggregated) dialog. REST has no
+// per-message detail — for that, use the CLI --json mode or the
+// MCP get_dialog tool.
+func (s *Sipnab) GetDialog(callID string) (*FullDialog, error) {
+    var full FullDialog
+    if err := s.get("/v1/dialogs/"+url.PathEscape(callID), nil, &full); err != nil {
+        return nil, err
+    }
+    return &full, nil
+}
+
+func main() {
+    s, err := newSipnab()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    failed, err := s.ListDialogs("Failed")
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    fmt.Printf("%d failed dialogs\n", len(failed))
+
+    for i, d := range failed {
+        if i >= 5 {
+            break
+        }
+        full, err := s.GetDialog(d.CallID)
+        if err != nil {
+            continue
+        }
+        pdd := "—"
+        if full.Timing.PddMs != nil {
+            pdd = fmt.Sprintf("%dms", *full.Timing.PddMs)
+        }
+        fmt.Printf("  %s  state=%s  pdd=%s  nat_mismatch=%t\n",
+            d.CallID, d.State, pdd, full.Diagnosis.NatMismatch)
+    }
+    // sort import no longer needed
+    _ = sort.Strings
+}
+```
+
+Run:
+
+```bash
+SIPNAB_API_KEY=my-secret-token go run sipnab-client.go
+```
+
+---
+
+## Common Patterns
+
+### Monitor failed calls in real-time (Python)
+
+```python
+import time
+import requests
+
+API = "http://127.0.0.1:8080"
+KEY = "my-secret-token"
+HEADERS = {"Authorization": f"Bearer {KEY}"}
+
+seen = set()
+while True:
+    resp = requests.get(f"{API}/v1/dialogs", headers=HEADERS,
+                        params={"state": "Failed"})
+    for d in resp.json()["dialogs"]:
+        cid = d["call_id"]
+        if cid not in seen:
+            seen.add(cid)
+            print(f"FAILED: {cid} from={d.get('from')} to={d.get('to')}")
+    time.sleep(5)
+```
+
+### Export all dialogs to CSV (bash)
+
+```bash
+curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
+  "http://127.0.0.1:8080/v1/dialogs?limit=1000" | \
+  jq -r '.dialogs[] | [.call_id, .method, .state, .from, .to, .duration_sec] | @csv'
+```
+
+### Alert on poor MOS (bash)
+
+```bash
+curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
+  "http://127.0.0.1:8080/v1/streams?mos_below=3.0" | \
+  jq -r '.streams[] | "LOW MOS: SSRC=\(.ssrc) MOS=\(.mos) call=\(.associated_dialog)"'
+```
+
+### Grafana dashboard via Prometheus
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: sipnab
+    bearer_token: your-api-key
+    static_configs:
+      - targets: ['127.0.0.1:8080']
+    scrape_interval: 15s
+```
+
+> **Tip:** The metrics endpoint is lightweight and suitable for 5-15 second scrape intervals. A sample Grafana dashboard JSON is included in the repository at `contrib/grafana-dashboard.json`.
+
+### Paginate through all dialogs (Python)
+
+```python
+import requests
+
+API = "http://127.0.0.1:8080"
+HEADERS = {"Authorization": "Bearer my-secret-token"}
+
+offset = 0
+limit = 100
+all_dialogs = []
+
+while True:
+    resp = requests.get(f"{API}/v1/dialogs",
+                        headers=HEADERS,
+                        params={"limit": limit, "offset": offset})
+    data = resp.json()
+    all_dialogs.extend(data["dialogs"])
+    if offset + limit >= data["total"]:
+        break
+    offset += limit
+
+print(f"Fetched {len(all_dialogs)} dialogs")
+```

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -1,7 +1,7 @@
 +++
 title = "REST API & Metrics"
 weight = 10
-description = "REST API endpoints, Prometheus metrics, and HEP protocol integration."
+description = "REST API endpoints and Prometheus metrics."
 +++
 
 sipnab includes an optional REST API and Prometheus metrics endpoint, enabled with the `api` feature flag. The API runs as a thread inside the sipnab process, reading the same in-memory dialog/stream stores as the capture pipeline (read-only — it never mutates capture state).
@@ -51,6 +51,8 @@ The process stays alive serving the API until you press Ctrl-C.
 ```bash
 curl -H "Authorization: Bearer $SIPNAB_API_KEY" http://127.0.0.1:8080/v1/dialogs
 ```
+
+> **More client code and integrations:** ready-to-adapt clients in several languages live in [API Client Examples](@/docs/api-clients.md); HEP forwarding, event hooks, fail2ban, and syslog live in [Integrations](@/docs/integrations.md).
 
 ## Authentication
 
@@ -196,7 +198,7 @@ dialogs.forEach(d => console.log(`${d.call_id}: ${d.state}`));
   "limit": 10,
   "dialogs": [
     {
-      "call_id": "12013223@200.57.7.195",
+      "call_id": "12013223@203.0.113.195",
       "from": "alice",
       "to": "bob",
       "state": "Failed",
@@ -225,7 +227,7 @@ Get full details for a single dialog by Call-ID, including associated RTP stream
 
 ```bash
 curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
-  "http://127.0.0.1:8080/v1/dialogs/12013223@200.57.7.195" | jq .
+  "http://127.0.0.1:8080/v1/dialogs/12013223@203.0.113.195" | jq .
 ```
 
 **Python:**
@@ -234,7 +236,7 @@ curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
 import requests
 from urllib.parse import quote
 
-call_id = "12013223@200.57.7.195"
+call_id = "12013223@203.0.113.195"
 resp = requests.get(
     f"http://127.0.0.1:8080/v1/dialogs/{quote(call_id, safe='')}",
     headers={"Authorization": "Bearer my-secret-token"},
@@ -246,7 +248,7 @@ print(f"State: {dialog['state']}, Messages: {len(dialog.get('messages', []))}")
 **Go:**
 
 ```go
-callID := url.PathEscape("12013223@200.57.7.195")
+callID := url.PathEscape("12013223@203.0.113.195")
 req, _ := http.NewRequest("GET",
     "http://127.0.0.1:8080/v1/dialogs/"+callID, nil)
 req.Header.Set("Authorization", "Bearer my-secret-token")
@@ -261,7 +263,7 @@ fmt.Printf("State: %s\n", dialog["state"])
 **JavaScript (Node.js):**
 
 ```javascript
-const callId = encodeURIComponent("12013223@200.57.7.195");
+const callId = encodeURIComponent("12013223@203.0.113.195");
 const resp = await fetch(
   `http://127.0.0.1:8080/v1/dialogs/${callId}`,
   { headers: { Authorization: "Bearer my-secret-token" } }
@@ -275,7 +277,7 @@ console.log(`State: ${dialog.state}`);
 ```json
 {
   "schema_version": 1,
-  "call_id": "12013223@200.57.7.195",
+  "call_id": "12013223@203.0.113.195",
   "from": "alice",
   "to": "bob",
   "from_display": "Alice Smith",
@@ -332,7 +334,7 @@ console.log(`State: ${dialog.state}`);
       "jitter_ms": 2.1,
       "loss_pct": 0.0,
       "orphaned": false,
-      "associated_dialog": "12013223@200.57.7.195",
+      "associated_dialog": "12013223@203.0.113.195",
       "first_seen": "2026-04-13T10:30:02Z",
       "last_seen": "2026-04-13T10:30:47Z",
       "quality_intervals": []
@@ -358,7 +360,7 @@ Get a structured call diagnosis report for a dialog in JSON format. Includes tra
 
 ```bash
 curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
-  "http://127.0.0.1:8080/v1/dialogs/12013223@200.57.7.195/report" | jq .
+  "http://127.0.0.1:8080/v1/dialogs/12013223@203.0.113.195/report" | jq .
 ```
 
 **Python:**
@@ -367,7 +369,7 @@ curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
 import requests
 from urllib.parse import quote
 
-call_id = "12013223@200.57.7.195"
+call_id = "12013223@203.0.113.195"
 resp = requests.get(
     f"http://127.0.0.1:8080/v1/dialogs/{quote(call_id, safe='')}/report",
     headers={"Authorization": "Bearer my-secret-token"},
@@ -379,7 +381,7 @@ print(f"Diagnosis: {report.get('diagnosis', {}).get('summary', 'N/A')}")
 **Go:**
 
 ```go
-callID := url.PathEscape("12013223@200.57.7.195")
+callID := url.PathEscape("12013223@203.0.113.195")
 req, _ := http.NewRequest("GET",
     "http://127.0.0.1:8080/v1/dialogs/"+callID+"/report", nil)
 req.Header.Set("Authorization", "Bearer my-secret-token")
@@ -393,7 +395,7 @@ json.NewDecoder(resp.Body).Decode(&report)
 **JavaScript (Node.js):**
 
 ```javascript
-const callId = encodeURIComponent("12013223@200.57.7.195");
+const callId = encodeURIComponent("12013223@203.0.113.195");
 const resp = await fetch(
   `http://127.0.0.1:8080/v1/dialogs/${callId}/report`,
   { headers: { Authorization: "Bearer my-secret-token" } }
@@ -413,7 +415,7 @@ available via the MCP `get_dialog_report` tool and the CLI `--call-report`.
 ```json
 {
   "schema_version": 1,
-  "call_id": "12013223@200.57.7.195",
+  "call_id": "12013223@203.0.113.195",
   "from": "alice",
   "to": "bob",
   "state": "Completed",
@@ -538,7 +540,7 @@ streams.forEach(s =>
       "jitter_ms": 2.1,
       "loss_pct": 0.0,
       "orphaned": false,
-      "associated_dialog": "12013223@200.57.7.195",
+      "associated_dialog": "12013223@203.0.113.195",
       "mos": 4.2
     }
   ]
@@ -754,718 +756,6 @@ Metric names emitted by `src/output/prometheus.rs`:
 
 The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.14 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
 
-## Client Examples
-
-End-to-end examples in five languages. Each one covers: bearer-token auth, listing dialogs filtered by state, fetching a single dialog with pagination, scraping `/metrics`, and error handling. Adapt to your environment.
-
-> **Filter parameters:** the REST API accepts `state` (e.g. `Failed`, `Completed`, `InCall`) and `from` (regex on the From header) as query parameters on `/v1/dialogs`, plus `orphaned` and `mos_below` on `/v1/streams`. Full DSL filtering — anything more complex than a single state/from match — is **not** available over REST. For arbitrary DSL queries, use the [MCP server](@/docs/mcp.md)'s `list_dialogs` tool, which accepts a `filter` argument that runs through the same evaluator as `sipnab --filter`.
-
-> **Status codes:** the REST API returns **503 Service Unavailable** when a request is rejected by the rate limiter or the connection cap (not 429). 401 on bad/missing token, 404 on unknown call_id.
-
-> **Per-call response code / per-message data is not on REST.** The REST API aggregates each dialog into a summary (`call_id`, `state`, `from`, `to`, `duration_sec`, `msg_count`, `timing`, `diagnosis`, `sdp_timeline`, `streams`) — individual SIP messages and per-response status codes are **not** exposed by `/v1/dialogs` or `/v1/dialogs/{id}`. To work with per-message data programmatically, use either: (a) the CLI `sipnab -N --json ...` mode, which emits one JSON object per SIP message with `is_request`, `status_code`, `reason`, etc. (field reference: [Output Formats](@/docs/output-formats.md); see also [cookbook Recipe 3](@/docs/cookbook.md#3-find-every-failed-call-grouped-by-response-code)), or (b) the MCP `get_dialog` tool, which returns paginated `messages[]` (see [MCP](@/docs/mcp.md)).
-
-### curl + jq one-liners
-
-```bash
-# Setup
-API="http://localhost:8080"
-KEY="my-secret-token"
-H="-H 'Authorization: Bearer $KEY'"
-
-# Health check (no auth required)
-curl -fsS $API/health
-
-# List failed dialogs (state= query param)
-curl -fsS "$API/v1/dialogs?state=Failed&limit=20" $H | jq
-
-# List dialogs from a specific user (from= regex)
-curl -fsS "$API/v1/dialogs?from=alice&limit=20" $H | jq
-
-# Get one full (aggregated) dialog — no per-message data over REST
-curl -fsS "$API/v1/dialogs/abc123@host" $H | jq
-
-# Get a call report (JSON — this endpoint is JSON-only)
-curl -fsS "$API/v1/dialogs/abc123@host/report" $H | jq
-
-# Non-orphaned streams (orphaned=false)
-curl -fsS "$API/v1/streams?orphaned=false" $H | jq
-
-# Streams below a MOS threshold
-curl -fsS "$API/v1/streams?mos_below=3.5" $H | jq
-
-# Aggregate counters
-curl -fsS "$API/v1/stats" $H | jq
-
-# Count failed calls (aggregated — REST exposes no per-message data)
-curl -fsS "$API/v1/dialogs?state=Failed&limit=1000" $H \
-  | jq '.total'
-
-# For per-call response-code histograms, use the CLI NDJSON mode —
-# sipnab -N --json emits one record per message (see Output Formats docs):
-#   sipnab -N -I capture.pcap --filter "state == 'Failed'" --json \
-#     | jq -r 'select(.is_request == false) | .status_code' \
-#     | sort | uniq -c | sort -rn
-
-# Prometheus metrics
-curl -fsS "$API/metrics" $H | grep '^sipnab_'
-
-# Error handling — server returns 503 (not 429) on rate-limit + conn-cap
-http_code=$(curl -s -o /dev/null -w '%{http_code}' \
-            "$API/v1/dialogs/no-such-call" $H)
-case "$http_code" in
-  200) echo "found" ;;
-  401) echo "auth failed — check --api-key" ;;
-  404) echo "dialog not found" ;;
-  503) echo "rate-limited or connection cap reached" ;;
-  *)   echo "unexpected $http_code" ;;
-esac
-```
-
-> The per-message NDJSON records referenced above (`is_request`, `status_code`, `reason`, `cseq`, ...) are documented in [Output Formats](@/docs/output-formats.md).
-
----
-
-### Python (sync, `requests`)
-
-```python
-"""sipnab REST client — sync version using requests."""
-from __future__ import annotations
-
-import os
-import sys
-from typing import Any
-
-import requests
-
-API = os.environ.get("SIPNAB_API", "http://localhost:8080")
-KEY = os.environ["SIPNAB_API_KEY"]  # raises KeyError if unset
-
-
-class SipnabError(Exception):
-    pass
-
-
-class SipnabClient:
-    def __init__(self, base_url: str = API, token: str = KEY,
-                 timeout: float = 10.0) -> None:
-        self.base = base_url.rstrip("/")
-        self.session = requests.Session()
-        self.session.headers["Authorization"] = f"Bearer {token}"
-        self.timeout = timeout
-
-    def _get(self, path: str, **params: Any) -> Any:
-        r = self.session.get(f"{self.base}{path}", params=params,
-                             timeout=self.timeout)
-        if r.status_code == 401:
-            raise SipnabError("authentication failed")
-        if r.status_code == 503:
-            raise SipnabError("rate-limited or connection cap reached")
-        r.raise_for_status()
-        return r.json()
-
-    def health(self) -> bool:
-        r = self.session.get(f"{self.base}/health", timeout=self.timeout)
-        return r.ok
-
-    def list_dialogs(self, *, state: str | None = None,
-                     from_regex: str | None = None,
-                     limit: int = 50, offset: int = 0) -> list[dict]:
-        """List dialog summaries.
-
-        The REST API supports filtering by `state` (exact match against
-        DialogState e.g. 'Failed', 'Completed', 'InCall') and `from` (regex).
-        For full DSL filtering use the MCP server's list_dialogs tool.
-        """
-        params: dict[str, Any] = {"limit": limit, "offset": offset}
-        if state:
-            params["state"] = state
-        if from_regex:
-            params["from"] = from_regex
-        return self._get("/v1/dialogs", **params)["dialogs"]
-
-    def get_dialog(self, call_id: str) -> dict:
-        from urllib.parse import quote
-        return self._get(f"/v1/dialogs/{quote(call_id, safe='')}")
-
-    def call_report(self, call_id: str) -> dict:
-        from urllib.parse import quote
-        return self._get(f"/v1/dialogs/{quote(call_id, safe='')}/report")
-
-    def stats(self) -> dict:
-        return self._get("/v1/stats")
-
-    def metrics(self) -> str:
-        r = self.session.get(f"{self.base}/metrics", timeout=self.timeout)
-        if r.status_code == 401:
-            raise SipnabError("authentication failed")
-        if r.status_code == 503:
-            raise SipnabError("rate-limited")
-        r.raise_for_status()
-        return r.text
-
-
-# ── Usage ─────────────────────────────────────────────────────────
-if __name__ == "__main__":
-    c = SipnabClient()
-
-    if not c.health():
-        sys.exit("sipnab not reachable")
-
-    print("Stats:", c.stats())
-
-    # Pull every failed call, page through
-    failed: list[dict] = []
-    offset = 0
-    while True:
-        page = c.list_dialogs(state="Failed", limit=100, offset=offset)
-        if not page:
-            break
-        failed.extend(page)
-        offset += len(page)
-    print(f"{len(failed)} failed dialogs")
-
-    # Show the first few — note the REST shape doesn't expose
-    # per-message status_code. See module-level note above for how to
-    # build a response-code histogram via CLI or MCP.
-    for d in failed[:5]:
-        full = c.get_dialog(d["call_id"])
-        diag = full.get("diagnosis", {})
-        print(f"  {d['call_id']:30s}  state={d['state']:10s}  "
-              f"diagnosis={ {k: v for k, v in diag.items() if v} }")
-```
-
-Run it:
-
-```bash
-SIPNAB_API_KEY=my-secret-token python3 sipnab_client.py
-```
-
----
-
-### Python (async, `httpx`)
-
-For tailing dialogs in near-real-time without blocking:
-
-```python
-"""sipnab REST client — async, periodic polling."""
-import asyncio
-import os
-from datetime import datetime, timezone
-
-import httpx
-
-API = os.environ.get("SIPNAB_API", "http://localhost:8080")
-KEY = os.environ["SIPNAB_API_KEY"]
-
-
-async def tail_dialogs(poll_interval: float = 2.0) -> None:
-    """Poll /v1/dialogs every `poll_interval` and print newly-completed calls."""
-    seen: set[str] = set()
-    headers = {"Authorization": f"Bearer {KEY}"}
-
-    async with httpx.AsyncClient(base_url=API, headers=headers,
-                                  timeout=10.0) as client:
-        while True:
-            try:
-                r = await client.get("/v1/dialogs",
-                                     params={"limit": 100})
-                r.raise_for_status()
-                for d in r.json()["dialogs"]:
-                    if d["call_id"] in seen:
-                        continue
-                    seen.add(d["call_id"])
-                    if d["state"] in ("Completed", "Failed", "Cancelled"):
-                        print(f"{datetime.now(timezone.utc).isoformat()}  "
-                              f"{d['state']:10s}  {d['call_id']}  "
-                              f"{d.get('from')} → {d.get('to')}")
-            except httpx.HTTPError as e:
-                print(f"warning: {e}")
-            await asyncio.sleep(poll_interval)
-
-
-if __name__ == "__main__":
-    asyncio.run(tail_dialogs())
-```
-
----
-
-### Node.js / TypeScript
-
-```typescript
-// sipnab-client.ts — runs on Node 18+ (built-in fetch)
-const API = process.env.SIPNAB_API ?? "http://localhost:8080";
-const KEY = process.env.SIPNAB_API_KEY;
-if (!KEY) throw new Error("SIPNAB_API_KEY not set");
-
-interface DialogSummary {
-  call_id: string;
-  state: string;
-  method: string;
-  from: string;
-  to: string;
-  duration_sec: number;
-  msg_count: number;
-}
-
-interface DialogsPage {
-  dialogs: DialogSummary[];
-  total: number;
-  limit: number;
-  offset: number;
-}
-
-async function api<T>(
-  path: string,
-  params: Record<string, string | number> = {},
-): Promise<T> {
-  const url = new URL(`${API}${path}`);
-  for (const [k, v] of Object.entries(params)) {
-    url.searchParams.set(k, String(v));
-  }
-  const r = await fetch(url, {
-    headers: { Authorization: `Bearer ${KEY}` },
-  });
-  if (r.status === 401) throw new Error("auth failed");
-  if (r.status === 503) throw new Error("rate-limited or conn cap reached");
-  if (!r.ok) throw new Error(`HTTP ${r.status}`);
-  return (await r.json()) as T;
-}
-
-async function listDialogs(
-  state: string | null = null,
-  limit = 50,
-): Promise<DialogSummary[]> {
-  const all: DialogSummary[] = [];
-  let offset = 0;
-  for (;;) {
-    const params: Record<string, string | number> = { limit, offset };
-    if (state) params.state = state;
-    const page = await api<DialogsPage>("/v1/dialogs", params);
-    if (page.dialogs.length === 0) break;
-    all.push(...page.dialogs);
-    if (all.length >= page.total) break;
-    offset += page.dialogs.length;
-  }
-  return all;
-}
-
-// REST API doesn't expose per-message data — see the note at the top of
-// "Client Examples" for how to build per-call response-code histograms
-// via the CLI or MCP. Here we just summarize what REST exposes:
-interface FullDialog {
-  call_id: string;
-  state: string;
-  msg_count: number;
-  timing: { pdd_ms: number | null; setup_ms: number | null; retransmits: number };
-  diagnosis: { one_way_audio: boolean; nat_mismatch: boolean; no_media: boolean };
-}
-
-// ── Demo ──────────────────────────────────────────────────────────
-const failed = await listDialogs("Failed");
-console.log(`${failed.length} failed dialogs`);
-
-for (const d of failed.slice(0, 5)) {
-  const full = await api<FullDialog>(`/v1/dialogs/${encodeURIComponent(d.call_id)}`);
-  console.log(`  ${d.call_id}  state=${d.state}  ` +
-              `pdd=${full.timing.pdd_ms ?? "—"}ms  ` +
-              `nat_mismatch=${full.diagnosis.nat_mismatch}`);
-}
-```
-
-Run:
-
-```bash
-SIPNAB_API_KEY=my-secret-token npx tsx sipnab-client.ts
-```
-
----
-
-### Rust (`reqwest`)
-
-```rust
-// Cargo.toml deps:
-//   reqwest = { version = "0.12", features = ["json", "blocking"] }
-//   serde   = { version = "1", features = ["derive"] }
-//   anyhow  = "1"
-
-use anyhow::{anyhow, Result};
-use reqwest::blocking::Client;
-use serde::Deserialize;
-use std::env;
-
-#[derive(Debug, Deserialize)]
-struct DialogSummary {
-    call_id: String,
-    state: String,
-    from: String,
-    to: String,
-    duration_sec: f64,
-    msg_count: u32,
-}
-
-#[derive(Debug, Deserialize)]
-struct DialogsPage {
-    dialogs: Vec<DialogSummary>,
-    total: usize,
-    limit: usize,
-    offset: usize,
-}
-
-struct Sipnab {
-    base: String,
-    client: Client,
-}
-
-impl Sipnab {
-    fn new() -> Result<Self> {
-        let base = env::var("SIPNAB_API")
-            .unwrap_or_else(|_| "http://localhost:8080".into());
-        let key = env::var("SIPNAB_API_KEY")?;
-        let client = Client::builder()
-            .default_headers({
-                let mut h = reqwest::header::HeaderMap::new();
-                h.insert(reqwest::header::AUTHORIZATION,
-                    format!("Bearer {key}").parse()?);
-                h
-            })
-            .timeout(std::time::Duration::from_secs(10))
-            .build()?;
-        Ok(Self { base, client })
-    }
-
-    fn list_dialogs(&self, state: Option<&str>) -> Result<Vec<DialogSummary>> {
-        let mut all = Vec::new();
-        let mut offset = 0usize;
-        loop {
-            let mut req = self.client
-                .get(format!("{}/v1/dialogs", self.base))
-                .query(&[("limit", "100"), ("offset", &offset.to_string())]);
-            if let Some(s) = state {
-                req = req.query(&[("state", s)]);
-            }
-            let resp = req.send()?;
-            match resp.status().as_u16() {
-                401 => return Err(anyhow!("auth failed")),
-                503 => return Err(anyhow!("rate-limited or conn cap reached")),
-                code if code >= 400 => return Err(anyhow!("HTTP {code}")),
-                _ => {}
-            }
-            let page: DialogsPage = resp.json()?;
-            if page.dialogs.is_empty() { break; }
-            offset += page.dialogs.len();
-            let total = page.total;
-            all.extend(page.dialogs);
-            if all.len() >= total { break; }
-        }
-        Ok(all)
-    }
-
-    /// Fetch one full dialog (aggregated; no per-message data).
-    /// REST does not expose individual messages — for that, use the
-    /// CLI `sipnab -N --json` mode or the MCP `get_dialog` tool.
-    fn get_dialog(&self, call_id: &str) -> Result<serde_json::Value> {
-        let cid = urlencoding::encode(call_id);
-        let resp = self.client
-            .get(format!("{}/v1/dialogs/{}", self.base, cid))
-            .send()?;
-        Ok(resp.json()?)
-    }
-}
-
-fn main() -> Result<()> {
-    let s = Sipnab::new()?;
-    let failed = s.list_dialogs(Some("Failed"))?;
-    println!("{} failed dialogs", failed.len());
-
-    for d in failed.iter().take(5) {
-        let full = s.get_dialog(&d.call_id)?;
-        let pdd = full["timing"]["pdd_ms"].as_i64();
-        let nat_mismatch = full["diagnosis"]["nat_mismatch"].as_bool().unwrap_or(false);
-        println!("  {}  state={}  pdd={:?}ms  nat_mismatch={}",
-                 d.call_id, d.state, pdd, nat_mismatch);
-    }
-    Ok(())
-}
-```
-
-> The per-message `sipnab -N --json` records mentioned in `get_dialog`'s doc comment are documented in [Output Formats](@/docs/output-formats.md).
-
----
-
-### Go (`net/http` + `encoding/json`)
-
-```go
-// sipnab-client.go
-package main
-
-import (
-    "encoding/json"
-    "fmt"
-    "net/http"
-    "net/url"
-    "os"
-    "sort"
-    "time"
-)
-
-type DialogSummary struct {
-    CallID      string  `json:"call_id"`
-    State       string  `json:"state"`
-    From        string  `json:"from"`
-    To          string  `json:"to"`
-    DurationSec float64 `json:"duration_sec"`
-    MsgCount    int     `json:"msg_count"`
-}
-
-type DialogTiming struct {
-    PddMs      *int64 `json:"pdd_ms"`
-    SetupMs    *int64 `json:"setup_ms"`
-    Retransmits int   `json:"retransmits"`
-}
-
-type DialogDiagnosis struct {
-    OneWayAudio  bool `json:"one_way_audio"`
-    NatMismatch  bool `json:"nat_mismatch"`
-    NoMedia      bool `json:"no_media"`
-}
-
-type FullDialog struct {
-    CallID    string          `json:"call_id"`
-    State     string          `json:"state"`
-    Timing    DialogTiming    `json:"timing"`
-    Diagnosis DialogDiagnosis `json:"diagnosis"`
-}
-
-type DialogsPage struct {
-    Dialogs []DialogSummary `json:"dialogs"`
-    Total   int             `json:"total"`
-    Limit   int             `json:"limit"`
-    Offset  int             `json:"offset"`
-}
-
-type Sipnab struct {
-    Base   string
-    Token  string
-    Client *http.Client
-}
-
-func newSipnab() (*Sipnab, error) {
-    base := os.Getenv("SIPNAB_API")
-    if base == "" {
-        base = "http://localhost:8080"
-    }
-    token := os.Getenv("SIPNAB_API_KEY")
-    if token == "" {
-        return nil, fmt.Errorf("SIPNAB_API_KEY not set")
-    }
-    return &Sipnab{
-        Base:   base,
-        Token:  token,
-        Client: &http.Client{Timeout: 10 * time.Second},
-    }, nil
-}
-
-func (s *Sipnab) get(path string, params url.Values, out any) error {
-    u, _ := url.Parse(s.Base + path)
-    u.RawQuery = params.Encode()
-    req, _ := http.NewRequest(http.MethodGet, u.String(), nil)
-    req.Header.Set("Authorization", "Bearer "+s.Token)
-    resp, err := s.Client.Do(req)
-    if err != nil {
-        return err
-    }
-    defer resp.Body.Close()
-    switch resp.StatusCode {
-    case 401:
-        return fmt.Errorf("auth failed")
-    case 503:
-        return fmt.Errorf("rate-limited or conn cap reached")
-    }
-    if resp.StatusCode >= 400 {
-        return fmt.Errorf("HTTP %d", resp.StatusCode)
-    }
-    return json.NewDecoder(resp.Body).Decode(out)
-}
-
-func (s *Sipnab) ListDialogs(state string) ([]DialogSummary, error) {
-    var all []DialogSummary
-    offset := 0
-    for {
-        params := url.Values{"limit": {"100"}, "offset": {fmt.Sprint(offset)}}
-        if state != "" {
-            params.Set("state", state)
-        }
-        var page DialogsPage
-        if err := s.get("/v1/dialogs", params, &page); err != nil {
-            return nil, err
-        }
-        if len(page.Dialogs) == 0 {
-            break
-        }
-        all = append(all, page.Dialogs...)
-        offset += len(page.Dialogs)
-        if len(all) >= page.Total {
-            break
-        }
-    }
-    return all, nil
-}
-
-// GetDialog fetches the full (aggregated) dialog. REST has no
-// per-message detail — for that, use the CLI --json mode or the
-// MCP get_dialog tool.
-func (s *Sipnab) GetDialog(callID string) (*FullDialog, error) {
-    var full FullDialog
-    if err := s.get("/v1/dialogs/"+url.PathEscape(callID), nil, &full); err != nil {
-        return nil, err
-    }
-    return &full, nil
-}
-
-func main() {
-    s, err := newSipnab()
-    if err != nil {
-        fmt.Fprintln(os.Stderr, err)
-        os.Exit(1)
-    }
-    failed, err := s.ListDialogs("Failed")
-    if err != nil {
-        fmt.Fprintln(os.Stderr, err)
-        os.Exit(1)
-    }
-    fmt.Printf("%d failed dialogs\n", len(failed))
-
-    for i, d := range failed {
-        if i >= 5 {
-            break
-        }
-        full, err := s.GetDialog(d.CallID)
-        if err != nil {
-            continue
-        }
-        pdd := "—"
-        if full.Timing.PddMs != nil {
-            pdd = fmt.Sprintf("%dms", *full.Timing.PddMs)
-        }
-        fmt.Printf("  %s  state=%s  pdd=%s  nat_mismatch=%t\n",
-            d.CallID, d.State, pdd, full.Diagnosis.NatMismatch)
-    }
-    // sort import no longer needed
-    _ = sort.Strings
-}
-```
-
-Run:
-
-```bash
-SIPNAB_API_KEY=my-secret-token go run sipnab-client.go
-```
-
----
-
-## Common Patterns
-
-### Monitor failed calls in real-time (Python)
-
-```python
-import time
-import requests
-
-API = "http://127.0.0.1:8080"
-KEY = "my-secret-token"
-HEADERS = {"Authorization": f"Bearer {KEY}"}
-
-seen = set()
-while True:
-    resp = requests.get(f"{API}/v1/dialogs", headers=HEADERS,
-                        params={"state": "Failed"})
-    for d in resp.json()["dialogs"]:
-        cid = d["call_id"]
-        if cid not in seen:
-            seen.add(cid)
-            print(f"FAILED: {cid} from={d.get('from')} to={d.get('to')}")
-    time.sleep(5)
-```
-
-### Export all dialogs to CSV (bash)
-
-```bash
-curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
-  "http://127.0.0.1:8080/v1/dialogs?limit=1000" | \
-  jq -r '.dialogs[] | [.call_id, .method, .state, .from, .to, .duration_sec] | @csv'
-```
-
-### Alert on poor MOS (bash)
-
-```bash
-curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
-  "http://127.0.0.1:8080/v1/streams?mos_below=3.0" | \
-  jq -r '.streams[] | "LOW MOS: SSRC=\(.ssrc) MOS=\(.mos) call=\(.associated_dialog)"'
-```
-
-### Grafana dashboard via Prometheus
-
-```yaml
-# prometheus.yml
-scrape_configs:
-  - job_name: sipnab
-    bearer_token: your-api-key
-    static_configs:
-      - targets: ['127.0.0.1:8080']
-    scrape_interval: 15s
-```
-
-> **Tip:** The metrics endpoint is lightweight and suitable for 5-15 second scrape intervals. A sample Grafana dashboard JSON is included in the repository at `contrib/grafana-dashboard.json`.
-
-### Paginate through all dialogs (Python)
-
-```python
-import requests
-
-API = "http://127.0.0.1:8080"
-HEADERS = {"Authorization": "Bearer my-secret-token"}
-
-offset = 0
-limit = 100
-all_dialogs = []
-
-while True:
-    resp = requests.get(f"{API}/v1/dialogs",
-                        headers=HEADERS,
-                        params={"limit": limit, "offset": offset})
-    data = resp.json()
-    all_dialogs.extend(data["dialogs"])
-    if offset + limit >= data["total"]:
-        break
-    offset += limit
-
-print(f"Fetched {len(all_dialogs)} dialogs")
-```
-
-## HEP Protocol
-
-sipnab supports HEP v2/v3 (Homer Encapsulation Protocol) for integration with Homer/SIPCAPTURE.
-
-### Receiving HEP
-
-```bash
-sipnab -L 0.0.0.0:9060 -E
-```
-
-Restrict sources with `--hep-allow` and rate-limit with `--hep-rate-limit`:
-
-```bash
-sipnab -L 0.0.0.0:9060 -E --hep-allow 192.0.2.0/24 --hep-rate-limit 25000
-```
-
-### Sending HEP
-
-Mirror captured traffic to a Homer collector:
-
-```bash
-sipnab -d eth0 -H 192.0.2.50:9060
-```
-
 ## Security Model
 
 - The API thread only reads dialog/stream metadata: no capture fd access, no key material exposure
@@ -1477,63 +767,3 @@ sipnab -d eth0 -H 192.0.2.50:9060
 - Connection limits prevent resource exhaustion
 
 > **Note:** The API runs as a thread in the sipnab process, sharing the in-memory dialog/stream stores read-only. It never touches capture file descriptors or TLS key material, and exposes only dialog/stream metadata — but it is not a separate OS process; treat the API bind address and key accordingly.
-
-## Event Execution
-
-sipnab can execute external commands on dialog state changes or quality drops. The command receives event data via `SIPNAB_*` environment variables (`SIPNAB_JSON` carries the full dialog JSON) — never on stdin and never interpolated into the command line. Event execution works in **all modes** (TUI, CLI, and API) -- it is not specific to the API feature.
-
-```bash
-# Run a script when any dialog changes state
-sipnab -d eth0 --on-dialog-exec "/usr/local/bin/sip-event.sh"
-
-# Run a script when RTP quality drops below threshold
-sipnab -d eth0 --on-quality-exec "/usr/local/bin/quality-alert.sh" \
-  --quality-threshold 3.0
-
-# Rate limit exec invocations (default: 10/sec)
-sipnab -d eth0 --on-dialog-exec "logger" --exec-rate-limit 5
-```
-
-> **Warning:** Always use `--exec-rate-limit` in production to prevent response amplification. Under a SIP flood, an unthrottled exec handler could fork-bomb the system. The default limit of 10/sec is conservative -- adjust based on your use case.
-
-## Fail2ban Integration
-
-Generate fail2ban-compatible output for SIP security events:
-
-```bash
-sipnab -N -d eth0 --kill-scanner --fail2ban >> /var/log/sipnab-fail2ban.log
-```
-
-Example fail2ban filter configuration:
-
-```ini
-# /etc/fail2ban/filter.d/sipnab.conf
-[Definition]
-failregex = ^.*SCANNER.*from=<HOST>.*$
-            ^.*REG_FLOOD.*from=<HOST>.*$
-ignoreregex =
-```
-
-```ini
-# /etc/fail2ban/jail.d/sipnab.conf
-[sipnab]
-enabled = true
-filter = sipnab
-logpath = /var/log/sipnab-fail2ban.log
-maxretry = 3
-findtime = 300
-bantime = 3600
-action = iptables-allports[name=sipnab, protocol=udp]
-```
-
-> **Tip:** Combine `--kill-scanner` with `--kill-ua "friendly-scanner|sipvicious"` to target specific scanner signatures. The `--kill-response` flag (default: 200) controls what SIP response code is sent back to detected scanners.
-
-## Syslog Alerts
-
-Send security alerts to syslog:
-
-```bash
-sipnab -d eth0 --kill-scanner --alert syslog --syslog
-```
-
-Alerts are sent with facility `LOG_LOCAL0` and severity based on event type (scanner=warning, fraud=alert). Use your syslog server's filtering to route sipnab events to dedicated log files or SIEM systems.

--- a/website/content/docs/benchmarks.md
+++ b/website/content/docs/benchmarks.md
@@ -1,6 +1,6 @@
 +++
 title = "Benchmarks"
-weight = 12
+weight = 15
 description = "Reproducible throughput and memory benchmarks: sipnab multi-core scaling, and honest comparisons against sngrep and voipmonitor."
 +++
 

--- a/website/content/docs/build.md
+++ b/website/content/docs/build.md
@@ -1,0 +1,131 @@
++++
+title = "Build from Source"
+weight = 14
+description = "Build sipnab from source: cargo, the feature-flag matrix, release profile, and cross-compilation."
++++
+
+Most users should [install a binary](@/docs/install.md); build from source when you need a custom feature set or target.
+
+## Cargo (from source)
+
+```bash
+cargo install sipnab --features full
+```
+
+## Building from Source
+
+### Build prerequisites
+
+- **Rust 1.94+**
+- **libpcap headers** (`libpcap-dev` on Debian/Ubuntu, `libpcap-devel` on RHEL/Fedora)
+- **pkg-config** (for libpcap detection during build)
+
+### Basic build (TUI only, default features)
+
+```bash
+git clone https://github.com/NormB/sipnab.git
+cd sipnab
+cargo build --release
+sudo cp target/release/sipnab /usr/local/bin/
+```
+
+### Full-features build
+
+```bash
+cargo build --release --features full
+```
+
+### Debug build with logging
+
+```bash
+SIPNAB_LOG=trace cargo run -- -N -I test.pcap
+```
+
+## Feature Flags
+
+sipnab uses Cargo feature flags to control optional functionality. The default build includes `native`, `tui`, and `audio`.
+
+| Feature | Description | Dependencies |
+|---------|-------------|--------------|
+| `native` | Live capture, file capture, output writers, signal handling, CLI parser. **Required by every other feature except `wasm`.** Included by default. | `pcap`, `clap`, `crossbeam-channel`, `libc`, `pcap-file`, `tracing-subscriber` |
+| `tui` | Interactive terminal UI (ratatui + crossterm). Included by default. | `native`, `ratatui`, `crossterm`, `unicode-width` |
+| `audio` | RTP audio playback in the TUI + WAV export. Included by default. Builds the separate `sipnab-audio` plugin (`libsipnab_audio.so`) that the binary `dlopen`s lazily; the binary itself does **not** link `libasound.so.2`. | `libloading`, `libc` (plugin: `rodio`) |
+| `tls` | TLS/DTLS decryption and SRTP key extraction (pure Rust) | `ring`, `rustls`, `aes`, `cbc`, `zeroize` |
+| `hep` | HEP v2/v3 send + receive (Homer Encapsulation Protocol) | `native` |
+| `api` | REST API + Prometheus metrics endpoint (runs in isolated child process) | `native`, `axum`, `tokio` |
+| `mcp` | Model Context Protocol server, stdio transport. Lets an AI agent (Claude Code, Claude Desktop, …) drive sipnab. | `native`, `tokio`, `rmcp` |
+| `mcp-http` | MCP server over HTTP (Streamable-HTTP). Adds the `--mcp-transport http` option. | `mcp`, `api`, `rmcp/transport-streamable-http-server` |
+| `full` | Everything: `native` + `tui` + `audio` + `tls` + `hep` + `api` + `mcp` + `mcp-http` | all |
+| `wasm` | WebAssembly target for in-browser pcap analysis | wasm-bindgen toolchain |
+
+Build with specific features:
+
+```bash
+# TUI + TLS only
+cargo build --release --features tui,tls
+
+# Headless capture host with HEP listener + REST API + MCP HTTP
+cargo build --release --no-default-features --features native,hep,api,mcp,mcp-http
+
+# Everything
+cargo build --release --features full
+```
+
+### What Features Do You Need?
+
+- **Most users (interactive analysis):** `cargo build --release` -- default features (`native` + `tui` + `audio`) give you interactive TUI, CLI mode, and audio playback of captured RTP.
+- **CI/scripting only (no TUI):** `cargo build --release --no-default-features --features native` -- headless binary for automation pipelines.
+- **MCP / AI-agent server:** add `mcp` (stdio) or `mcp,mcp-http` (HTTP). See [MCP Server](@/docs/mcp.md) for the runtime configuration.
+- **Headless capture host with HEP + Prometheus + MCP:** `cargo build --release --no-default-features --features native,hep,api,mcp,mcp-http` -- the typical "fleet capture server" feature set, leaves out the TUI and audio playback you don't need on a server.
+- **Full installation:** `cargo build --release --features full` -- everything.
+- **WASM/browser analysis:** `cargo build --release --features wasm` -- WebAssembly target for in-browser pcap analysis (see Analyze page).
+
+### Runtime dependencies
+
+`libasound.so.2` is an **optional** runtime dependency. The `audio` feature builds a separate plugin, `libsipnab_audio.so`, installed to `/usr/lib/sipnab/` by the `.deb` (or placed next to the binary in dev builds). The `sipnab` binary `dlopen`s this plugin only when you actually play a stream, so an audio-enabled binary starts fine on a host without libasound. If libasound (or the plugin) is missing, playback returns a clear error and you can still export the stream to a WAV file (F2). Only `libpcap0.8` is a hard dependency:
+
+```bash
+apt-get install -y libpcap0.8            # required
+apt-get install -y libasound2           # optional, for live playback
+```
+
+If you don't need TUI audio playback on the host (typical for a `--hep-listen` / `--api` / `--mcp` server), install the `-noaudio` `.deb`, or build without the `audio` feature so the plugin is not built at all:
+
+```bash
+cargo build --release --no-default-features \
+    --features native,tui,tls,hep,api,mcp,mcp-http
+```
+
+### Cross-glibc compatibility
+
+The release `-gnu` builds require **glibc >= 2.39** (the installer's floor); on older hosts they refuse to start with `version 'GLIBC_2.39' not found`. The [installer script](@/docs/install.md#installer-recommended) handles this automatically — below the 2.39 floor it falls back to the static musl build.
+
+The same applies to your own builds: if you build on a newer Debian/Ubuntu (e.g. Debian 13 / glibc 2.41) and deploy to an older one (Debian 12 / glibc 2.36), build inside a container matching the target's glibc -- for example, `rust:1-bookworm` for Debian 12 deploys, or use musl (the static `--target x86_64-unknown-linux-musl` builds the release CI publishes).
+
+## Release Profile
+
+The release build uses LTO, single codegen unit, and symbol stripping for a small binary:
+
+```toml
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true
+```
+
+Target binary size (musl, stripped): <= 5 MB.
+
+## Cross-Compilation
+
+sipnab uses [cross](https://github.com/cross-rs/cross) for cross-compilation:
+
+```bash
+# Install cross
+cargo install cross
+
+# Build for aarch64 Linux
+cross build --release --features full --target aarch64-unknown-linux-gnu
+
+# Build for x86_64 Linux
+cross build --release --features full --target x86_64-unknown-linux-gnu
+```

--- a/website/content/docs/cli.md
+++ b/website/content/docs/cli.md
@@ -12,7 +12,11 @@ CLI flags always override config file values. Boolean flags default to `off` (fa
 
 ## Common Recipes
 
-Real-world examples to get productive fast. Each recipe combines flags that work well together.
+A few flag combinations to get productive fast. For the full task-oriented
+collection — triage, filtering, recording, security, HEP — see the
+[Cookbook](@/docs/cookbook.md); for symptom-driven diagnostics see
+[Troubleshooting](@/docs/troubleshooting.md). This page is otherwise a flag
+reference (grouped below).
 
 ### Debug a failed call
 

--- a/website/content/docs/filter-dsl.md
+++ b/website/content/docs/filter-dsl.md
@@ -189,7 +189,10 @@ NOT ua =~ 'friendly-scanner'
 
 ## Operational Recipes
 
-One deduplicated recipe per real-world task, each as a complete command line. Swap `-I capture.pcap` for `-d eth0` (as root) to run any of them against live traffic.
+Filter-DSL recipes, one per real-world task, each a complete command line. Swap
+`-I capture.pcap` for `-d eth0` (as root) to run any of them against live
+traffic. For broader task recipes beyond the DSL, see the
+[Cookbook](@/docs/cookbook.md) and [Troubleshooting](@/docs/troubleshooting.md).
 
 ### Poor audio quality (low MOS)
 

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -1,8 +1,10 @@
 +++
 title = "Installation"
 weight = 1
-description = "Install sipnab from pre-built binaries, cargo, package managers, or source."
+description = "Install sipnab from pre-built binaries, cargo, or package managers."
 +++
+
+> Want a custom feature set or a cross-compiled target? See [Build from Source](@/docs/build.md).
 
 ## Installer (recommended)
 
@@ -70,11 +72,13 @@ docker build -t sipnab .
 
 The multi-stage Dockerfile uses `rust:1.94-slim-trixie` for the build stage and `debian:trixie-slim` for the runtime image. The runtime image includes only `libpcap0.8t64` and runs as a non-root `sipnab` user.
 
-## Cargo (from source)
+## Cargo
 
 ```bash
 cargo install sipnab --features full
 ```
+
+For build prerequisites, the full feature-flag matrix, release profile, and cross-compilation, see [Build from Source](@/docs/build.md).
 
 ## Package Managers
 
@@ -128,180 +132,9 @@ sudo rpm -i sipnab-<version>-1.aarch64.rpm
 brew install sipnab
 ```
 
-## Building from Source
-
-### Build prerequisites
-
-- **Rust 1.94+**
-- **libpcap headers** (`libpcap-dev` on Debian/Ubuntu, `libpcap-devel` on RHEL/Fedora)
-- **pkg-config** (for libpcap detection during build)
-
-### Basic build (TUI only, default features)
-
-```bash
-git clone https://github.com/NormB/sipnab.git
-cd sipnab
-cargo build --release
-sudo cp target/release/sipnab /usr/local/bin/
-```
-
-### Full-features build
-
-```bash
-cargo build --release --features full
-```
-
-### Debug build with logging
-
-```bash
-SIPNAB_LOG=trace cargo run -- -N -I test.pcap
-```
-
-## Feature Flags
-
-sipnab uses Cargo feature flags to control optional functionality. The default build includes `native`, `tui`, and `audio`.
-
-| Feature | Description | Dependencies |
-|---------|-------------|--------------|
-| `native` | Live capture, file capture, output writers, signal handling, CLI parser. **Required by every other feature except `wasm`.** Included by default. | `pcap`, `clap`, `crossbeam-channel`, `libc`, `pcap-file`, `tracing-subscriber` |
-| `tui` | Interactive terminal UI (ratatui + crossterm). Included by default. | `native`, `ratatui`, `crossterm`, `unicode-width` |
-| `audio` | RTP audio playback in the TUI + WAV export. Included by default. Builds the separate `sipnab-audio` plugin (`libsipnab_audio.so`) that the binary `dlopen`s lazily; the binary itself does **not** link `libasound.so.2`. | `libloading`, `libc` (plugin: `rodio`) |
-| `tls` | TLS/DTLS decryption and SRTP key extraction (pure Rust) | `ring`, `rustls`, `aes`, `cbc`, `zeroize` |
-| `hep` | HEP v2/v3 send + receive (Homer Encapsulation Protocol) | `native` |
-| `api` | REST API + Prometheus metrics endpoint (runs in isolated child process) | `native`, `axum`, `tokio` |
-| `mcp` | Model Context Protocol server, stdio transport. Lets an AI agent (Claude Code, Claude Desktop, …) drive sipnab. | `native`, `tokio`, `rmcp` |
-| `mcp-http` | MCP server over HTTP (Streamable-HTTP). Adds the `--mcp-transport http` option. | `mcp`, `api`, `rmcp/transport-streamable-http-server` |
-| `full` | Everything: `native` + `tui` + `audio` + `tls` + `hep` + `api` + `mcp` + `mcp-http` | all |
-| `wasm` | WebAssembly target for in-browser pcap analysis | wasm-bindgen toolchain |
-
-Build with specific features:
-
-```bash
-# TUI + TLS only
-cargo build --release --features tui,tls
-
-# Headless capture host with HEP listener + REST API + MCP HTTP
-cargo build --release --no-default-features --features native,hep,api,mcp,mcp-http
-
-# Everything
-cargo build --release --features full
-```
-
-### What Features Do You Need?
-
-- **Most users (interactive analysis):** `cargo build --release` -- default features (`native` + `tui` + `audio`) give you interactive TUI, CLI mode, and audio playback of captured RTP.
-- **CI/scripting only (no TUI):** `cargo build --release --no-default-features --features native` -- headless binary for automation pipelines.
-- **MCP / AI-agent server:** add `mcp` (stdio) or `mcp,mcp-http` (HTTP). See [MCP Server](@/docs/mcp.md) for the runtime configuration.
-- **Headless capture host with HEP + Prometheus + MCP:** `cargo build --release --no-default-features --features native,hep,api,mcp,mcp-http` -- the typical "fleet capture server" feature set, leaves out the TUI and audio playback you don't need on a server.
-- **Full installation:** `cargo build --release --features full` -- everything.
-- **WASM/browser analysis:** `cargo build --release --features wasm` -- WebAssembly target for in-browser pcap analysis (see Analyze page).
-
-### Runtime dependencies
-
-`libasound.so.2` is an **optional** runtime dependency. The `audio` feature builds a separate plugin, `libsipnab_audio.so`, installed to `/usr/lib/sipnab/` by the `.deb` (or placed next to the binary in dev builds). The `sipnab` binary `dlopen`s this plugin only when you actually play a stream, so an audio-enabled binary starts fine on a host without libasound. If libasound (or the plugin) is missing, playback returns a clear error and you can still export the stream to a WAV file (F2). Only `libpcap0.8` is a hard dependency:
-
-```bash
-apt-get install -y libpcap0.8            # required
-apt-get install -y libasound2           # optional, for live playback
-```
-
-If you don't need TUI audio playback on the host (typical for a `--hep-listen` / `--api` / `--mcp` server), install the `-noaudio` `.deb`, or build without the `audio` feature so the plugin is not built at all:
-
-```bash
-cargo build --release --no-default-features \
-    --features native,tui,tls,hep,api,mcp,mcp-http
-```
-
-### Cross-glibc compatibility
-
-The release `-gnu` builds require **glibc >= 2.39** (the installer's floor); on older hosts they refuse to start with `version 'GLIBC_2.39' not found`. The [installer script](#installer-recommended) handles this automatically — below the 2.39 floor it falls back to the static musl build.
-
-The same applies to your own builds: if you build on a newer Debian/Ubuntu (e.g. Debian 13 / glibc 2.41) and deploy to an older one (Debian 12 / glibc 2.36), build inside a container matching the target's glibc -- for example, `rust:1-bookworm` for Debian 12 deploys, or use musl (the static `--target x86_64-unknown-linux-musl` builds the release CI publishes).
-
 ## Enabling MCP
 
-The Model Context Protocol server lets an AI agent (Claude Code, Claude Desktop, any MCP-capable client) drive sipnab. Two transports:
-
-- **stdio** (default, requires `mcp` feature) -- the agent launches sipnab as a subprocess and communicates over stdin/stdout. Best for local agents.
-- **HTTP** (requires `mcp-http` feature) -- sipnab listens on a TCP port for JSON-RPC requests. Best for remote agents.
-
-### Quick start (stdio, local agent)
-
-```bash
-# Build with mcp support
-cargo build --release --features full
-
-# Or, if you only want MCP without TUI/audio:
-cargo build --release --no-default-features --features native,api,mcp
-
-# Run sipnab in MCP stdio mode against a pcap file
-sipnab --mcp -I capture.pcap --quiet
-```
-
-For Claude Desktop, add to your MCP servers config:
-
-```json
-{
-  "mcpServers": {
-    "sipnab": {
-      "command": "sipnab",
-      "args": ["--mcp", "-I", "/path/to/capture.pcap", "--quiet"]
-    }
-  }
-}
-```
-
-`--quiet` is recommended in stdio mode so log output doesn't interfere with the JSON-RPC wire on stdout.
-
-### Quick start (HTTP, remote agent)
-
-```bash
-# Build with mcp-http support
-cargo build --release --no-default-features --features native,api,mcp,mcp-http
-
-# Generate a token (any random secret)
-echo "$(openssl rand -hex 32)" > /etc/sipnab/mcp-token
-chmod 0600 /etc/sipnab/mcp-token
-
-# Run with HTTP transport bound to all interfaces
-sipnab --mcp --mcp-transport http \
-       --mcp-bind 0.0.0.0:8731 \
-       --mcp-token-file /etc/sipnab/mcp-token \
-       --mcp-allowed-host capture.example.com \
-       -I capture.pcap --quiet
-```
-
-The agent then connects to `http://capture.example.com:8731/mcp` with header `Authorization: Bearer <token>`. See [MCP Server](@/docs/mcp.md) for the full protocol/security model, the list of available tools, and the systemd unit pattern for running MCP alongside an HEP listener.
-
-> **Security note:** The HTTP transport refuses to start on a non-loopback bind without a token. The default Host-header allowlist is `localhost`, `127.0.0.1`, `::1` only -- add your real hostname / IP via `--mcp-allowed-host` (repeatable). For TLS, terminate it in nginx in front of sipnab; sipnab itself doesn't serve HTTPS for MCP.
-
-## Release Profile
-
-The release build uses LTO, single codegen unit, and symbol stripping for a small binary:
-
-```toml
-[profile.release]
-lto = true
-codegen-units = 1
-strip = true
-```
-
-Target binary size (musl, stripped): <= 5 MB.
-
-## Cross-Compilation
-
-sipnab uses [cross](https://github.com/cross-rs/cross) for cross-compilation:
-
-```bash
-# Install cross
-cargo install cross
-
-# Build for aarch64 Linux
-cross build --release --features full --target aarch64-unknown-linux-gnu
-
-# Build for x86_64 Linux
-cross build --release --features full --target x86_64-unknown-linux-gnu
-```
+To run sipnab as a Model Context Protocol server for an AI agent (Claude Code, Claude Desktop, …), see the [MCP Server](@/docs/mcp.md) page, which documents building with the `mcp`/`mcp-http` features and the runtime configuration.
 
 ## Platform Notes
 

--- a/website/content/docs/integrations.md
+++ b/website/content/docs/integrations.md
@@ -1,0 +1,91 @@
++++
+title = "Integrations"
+weight = 12
+description = "Forward to HEP/Homer, run event-exec hooks, and emit fail2ban and syslog alerts."
++++
+
+Wire sipnab into your wider stack: forward captured traffic to HEP/Homer, run external commands on dialog and quality events, and emit fail2ban and syslog security alerts.
+
+## HEP Protocol
+
+sipnab supports HEP v2/v3 (Homer Encapsulation Protocol) for integration with Homer/SIPCAPTURE.
+
+### Receiving HEP
+
+```bash
+sipnab -L 0.0.0.0:9060 -E
+```
+
+Restrict sources with `--hep-allow` and rate-limit with `--hep-rate-limit`:
+
+```bash
+sipnab -L 0.0.0.0:9060 -E --hep-allow 192.0.2.0/24 --hep-rate-limit 25000
+```
+
+### Sending HEP
+
+Mirror captured traffic to a Homer collector:
+
+```bash
+sipnab -d eth0 -H 192.0.2.50:9060
+```
+
+## Event Execution
+
+sipnab can execute external commands on dialog state changes or quality drops. The command receives event data via `SIPNAB_*` environment variables (`SIPNAB_JSON` carries the full dialog JSON) — never on stdin and never interpolated into the command line. Event execution works in **all modes** (TUI, CLI, and API) -- it is not specific to the API feature.
+
+```bash
+# Run a script when any dialog changes state
+sipnab -d eth0 --on-dialog-exec "/usr/local/bin/sip-event.sh"
+
+# Run a script when RTP quality drops below threshold
+sipnab -d eth0 --on-quality-exec "/usr/local/bin/quality-alert.sh" \
+  --quality-threshold 3.0
+
+# Rate limit exec invocations (default: 10/sec)
+sipnab -d eth0 --on-dialog-exec "logger" --exec-rate-limit 5
+```
+
+> **Warning:** Always use `--exec-rate-limit` in production to prevent response amplification. Under a SIP flood, an unthrottled exec handler could fork-bomb the system. The default limit of 10/sec is conservative -- adjust based on your use case.
+
+## Fail2ban Integration
+
+Generate fail2ban-compatible output for SIP security events:
+
+```bash
+sipnab -N -d eth0 --kill-scanner --fail2ban >> /var/log/sipnab-fail2ban.log
+```
+
+Example fail2ban filter configuration:
+
+```ini
+# /etc/fail2ban/filter.d/sipnab.conf
+[Definition]
+failregex = ^.*SCANNER.*from=<HOST>.*$
+            ^.*REG_FLOOD.*from=<HOST>.*$
+ignoreregex =
+```
+
+```ini
+# /etc/fail2ban/jail.d/sipnab.conf
+[sipnab]
+enabled = true
+filter = sipnab
+logpath = /var/log/sipnab-fail2ban.log
+maxretry = 3
+findtime = 300
+bantime = 3600
+action = iptables-allports[name=sipnab, protocol=udp]
+```
+
+> **Tip:** Combine `--kill-scanner` with `--kill-ua "friendly-scanner|sipvicious"` to target specific scanner signatures. The `--kill-response` flag (default: 200) controls what SIP response code is sent back to detected scanners.
+
+## Syslog Alerts
+
+Send security alerts to syslog:
+
+```bash
+sipnab -d eth0 --kill-scanner --alert syslog --syslog
+```
+
+Alerts are sent with facility `LOG_LOCAL0` and severity based on event type (scanner=warning, fraud=alert). Use your syslog server's filtering to route sipnab events to dedicated log files or SIEM systems.

--- a/website/content/docs/mcp.md
+++ b/website/content/docs/mcp.md
@@ -1,7 +1,7 @@
 +++
 title = "MCP Server"
 description = "Run sipnab as a Model Context Protocol server, exposing its read-only analysis surface as tools for an AI agent."
-weight = 11
+weight = 13
 +++
 
 sipnab can run as a **Model Context Protocol** server, exposing its

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -95,6 +95,7 @@
           <div class="nav-drop-menu" role="menu">
             <a href="{{ get_url(path='@/docs/_index.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/" %}class="active"{% endif %}>Overview</a>
             <a href="{{ get_url(path='@/docs/install.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/install/" %}class="active"{% endif %}>Install</a>
+            <a href="{{ get_url(path='@/docs/build.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/build/" %}class="active"{% endif %}>Build from Source</a>
             <a href="{{ get_url(path='@/docs/cookbook.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/cookbook/" %}class="active"{% endif %}>Cookbook</a>
             <a href="{{ get_url(path='@/docs/troubleshooting.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/troubleshooting/" %}class="active"{% endif %}>Troubleshooting</a>
             <a href="{{ get_url(path='@/docs/cli.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/cli/" %}class="active"{% endif %}>CLI</a>
@@ -104,6 +105,8 @@
             <a href="{{ get_url(path='@/docs/keybindings.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/keybindings/" %}class="active"{% endif %}>Keybindings</a>
             <a href="{{ get_url(path='@/docs/theme.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/theme/" %}class="active"{% endif %}>Theme</a>
             <a href="{{ get_url(path='@/docs/api.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/api/" %}class="active"{% endif %}>API</a>
+            <a href="{{ get_url(path='@/docs/api-clients.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/api-clients/" %}class="active"{% endif %}>API Clients</a>
+            <a href="{{ get_url(path='@/docs/integrations.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/integrations/" %}class="active"{% endif %}>Integrations</a>
             <a href="{{ get_url(path='@/docs/mcp.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/mcp/" %}class="active"{% endif %}>MCP</a>
           </div>
         </div>


### PR DESCRIPTION
## Summary

The deferred structural-splits follow-up to the site overhaul (PRs #144–#146). Breaks up the two bloated docs pages and consolidates recipes, without losing any content — every command/flag/example moves rather than being deleted (a coverage test enforces this).

## What changed

- **Split the 1539-line `api.md`** into three focused pages:
  - `api.md` (769) — REST endpoint reference (getting started, auth, TLS, connection limits, endpoints, security model).
  - `api-clients.md` (695, **new**) — the multi-language client programs + common patterns.
  - `integrations.md` (91, **new**) — HEP forwarding, event-exec hooks, fail2ban, syslog.
- **Split `install.md`** (358 → 191) into `install.md` ("get a binary running") and `build.md` (131, **new**: cargo-from-source, feature-flag matrix, release profile, cross-compilation). MCP enablement is now a pointer to `mcp.md`.
- **De-duplicate recipes:** the Cookbook and Troubleshooting pages become the canonical task homes; `cli.md`'s "Common Recipes" and `filter-dsl.md`'s "Operational Recipes" now cross-link there and stay scoped as reference.
- **Nav + weights:** added Build from Source, API Clients, and Integrations to the Docs dropdown; renumbered weights so the section index reads install → … → api → api-clients → integrations → mcp → build → benchmarks.
- **Scrub:** a real routable IP (`200.57.7.195`) left in `api.md` Call-ID examples → RFC 5737, matching the earlier docs/ fix.

## A deliberate non-change

`keybindings.md` was **left intact**. Its "TUI Views" section looked like duplication of the per-view key tables, but on inspection it's unique terminal **mockups + usage tips** — not redundant prose — and the mockups are guarded by `mockup_alignment_test`. Folding it would lose content, so I preserved it.

## Verification

- `zola build`: 16 pages, 0 orphans, all 22 internal links (with anchors) resolve.
- Gates green: `docs_drift` 7/7 (new pages added to the include list; version markers intact), `doc_example_coverage` 2/2 (**every flag keeps ≥2 examples after the moves**), `keybinding_drift`, `mockup_alignment`.
- Pre-commit (clippy + `--features full` tests + version/count gates) passed.
