### PR TITLE
fix(site): align docs task card + Download/Install identity

### DIFF
--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -9,7 +9,7 @@ page_template = "page.html"
 # entry points for people who arrive with a problem, not a topic.
 tasks = [
   { title = "Analyze a pcap file", cmd = "sipnab -I capture.pcap", href = "/docs/cookbook/" },
-  { title = "Capture live SIP traffic", cmd = "sudo sipnab -d eth0", href = "/docs/cli/" },
+  { title = "Capture live SIP traffic", cmd = "sudo sipnab -d eth0", href = "/docs/cookbook/#2-live-capture-narrow-to-a-single-user" },
   { title = "Diagnose one-way audio", cmd = "sipnab -I dump.pcap --one-way", href = "/docs/troubleshooting/" },
   { title = "Find failed calls", cmd = "sipnab -N -I dump.pcap --problems", href = "/docs/troubleshooting/" },
   { title = "Set up a HEP capture server", cmd = "sipnab --hep-listen 0.0.0.0:9060", href = "/docs/cookbook/" },

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -4,6 +4,8 @@ weight = 1
 description = "Install sipnab from pre-built binaries, cargo, or package managers."
 +++
 
+> Just want the binary? The [Download page](@/download.md) auto-detects your OS, CPU, and glibc and highlights the right file. This page is the full reference — every method, package manager, and platform note.
+>
 > Want a custom feature set or a cross-compiled target? See [Build from Source](@/docs/build.md).
 
 ## Installer (recommended)

--- a/website/templates/download.html
+++ b/website/templates/download.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}Download -- {{ config.title }}{% endblock title %}
-{% block og_title %}Install sipnab{% endblock og_title %}
+{% block og_title %}Download sipnab{% endblock og_title %}
 {% block description %}Install sipnab {{ config.extra.version }} -- Homebrew for macOS, .deb for Debian/Ubuntu, .rpm for RHEL/Fedora, static binaries for Linux. Intel and ARM64.{% endblock description %}
 {% block og_description %}Install sipnab {{ config.extra.version }} -- one-line installer, Homebrew, .deb, .rpm, or static binaries. Intel and ARM64.{% endblock og_description %}
 
@@ -10,7 +10,7 @@
 {% set rel = config.extra.github_url ~ "/releases/download/v" ~ v %}
 <section class="dl">
   <header class="dl-hero">
-    <p class="dl-kicker">Install</p>
+    <p class="dl-kicker">Download</p>
     <h1>Get sipnab running</h1>
     <p class="dl-sub">One binary, one dependency. <a href="{{ config.extra.github_url }}/releases/latest">v{{ v }}</a> &middot; released {{ config.extra.release_date }} &mdash; built and checksummed by CI for every platform below.</p>
   </header>


### PR DESCRIPTION
Two IA fixes from the semantic link review:

1. **'Capture live SIP traffic' task card** pointed at `/docs/cli/` (flag reference) while every other task card lands on a task page. Repointed to Cookbook recipe 2 (`#2-live-capture-narrow-to-a-single-user`).
2. **Nav 'Download' → page labeled 'Install'**, overlapping `/docs/install/`. Relabeled the download page as Download (its real role: OS-detected binary picker) and added a `/docs/install/` → `/download/` cross-link so the split is intentional and bidirectional.

Website-only. Zola anchor/link check + site/link/drift tests green; full suite 2542 pass.