### PR TITLE
docs(site): --one-way/--problems on troubleshooting + first-run TUI walkthrough

### DIFF
--- a/website/content/docs/api-clients.md
+++ b/website/content/docs/api-clients.md
@@ -1,6 +1,6 @@
 +++
 title = "API Client Examples"
-weight = 11
+weight = 12
 description = "Client code for the sipnab REST API in curl, Python, Node/TypeScript, Rust, and Go."
 +++
 

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -1,6 +1,6 @@
 +++
 title = "REST API & Metrics"
-weight = 10
+weight = 11
 description = "REST API endpoints and Prometheus metrics."
 +++
 

--- a/website/content/docs/benchmarks.md
+++ b/website/content/docs/benchmarks.md
@@ -1,6 +1,6 @@
 +++
 title = "Benchmarks"
-weight = 15
+weight = 16
 description = "Reproducible throughput and memory benchmarks: sipnab multi-core scaling, and honest comparisons against sngrep and voipmonitor."
 +++
 

--- a/website/content/docs/build.md
+++ b/website/content/docs/build.md
@@ -1,6 +1,6 @@
 +++
 title = "Build from Source"
-weight = 14
+weight = 15
 description = "Build sipnab from source: cargo, the feature-flag matrix, release profile, and cross-compilation."
 +++
 

--- a/website/content/docs/cli.md
+++ b/website/content/docs/cli.md
@@ -1,6 +1,6 @@
 +++
 title = "CLI Reference"
-weight = 6
+weight = 7
 description = "Complete flag reference for sipnab, organized by functional group."
 +++
 

--- a/website/content/docs/config.md
+++ b/website/content/docs/config.md
@@ -1,6 +1,6 @@
 +++
 title = "Config Reference"
-weight = 9
+weight = 10
 description = "TOML configuration file format and all configurable sections."
 +++
 

--- a/website/content/docs/filter-dsl.md
+++ b/website/content/docs/filter-dsl.md
@@ -1,6 +1,6 @@
 +++
 title = "Filter DSL"
-weight = 7
+weight = 8
 description = "Declarative filter language for matching SIP dialogs and RTP streams."
 +++
 

--- a/website/content/docs/integrations.md
+++ b/website/content/docs/integrations.md
@@ -1,6 +1,6 @@
 +++
 title = "Integrations"
-weight = 12
+weight = 13
 description = "Forward to HEP/Homer, run event-exec hooks, and emit fail2ban and syslog alerts."
 +++
 

--- a/website/content/docs/keybindings.md
+++ b/website/content/docs/keybindings.md
@@ -1,6 +1,6 @@
 +++
 title = "Keybindings"
-weight = 4
+weight = 5
 description = "Complete TUI keyboard shortcut reference for all views."
 +++
 

--- a/website/content/docs/mcp.md
+++ b/website/content/docs/mcp.md
@@ -1,7 +1,7 @@
 +++
 title = "MCP Server"
 description = "Run sipnab as a Model Context Protocol server, exposing its read-only analysis surface as tools for an AI agent."
-weight = 13
+weight = 14
 +++
 
 sipnab can run as a **Model Context Protocol** server, exposing its

--- a/website/content/docs/output-formats.md
+++ b/website/content/docs/output-formats.md
@@ -1,6 +1,6 @@
 +++
 title = "Output Formats"
-weight = 8
+weight = 9
 description = "Machine-readable output: NDJSON, summary reports, dialog/stream JSON, and pcap/pcapng."
 +++
 

--- a/website/content/docs/theme.md
+++ b/website/content/docs/theme.md
@@ -1,6 +1,6 @@
 +++
 title = "Theme Guide"
-weight = 5
+weight = 6
 description = "Customize sipnab's TUI colors with 10 semantic color slots and preset themes."
 +++
 

--- a/website/content/docs/troubleshooting.md
+++ b/website/content/docs/troubleshooting.md
@@ -6,6 +6,20 @@ description = "Real-world VoIP diagnostic workflows with exact commands."
 
 > **Under pressure?** Each scenario below is: Problem, Command, What to look for, Next steps. Copy-paste and go.
 
+## Start here: one pass over everything
+
+Don't know which problem you have yet? The `--problems` alias surfaces every
+troubled call in a single sweep -- failed calls **plus** one-way audio, high
+loss/jitter, NAT mismatches, retransmit storms, slow setup, and media
+asymmetries:
+
+```bash
+# Every problematic call, newest signal first
+sipnab -N -I capture.pcap --problems --json
+```
+
+`--problems` is shorthand for the full Filter-DSL expression `state == 'Failed' OR one_way == true OR rtp.loss > 2.0 OR rtp.jitter > 50.0 OR nat_mismatch == true OR retransmits > 3 OR pdd > 32.0 OR ...` -- so it is a superset of "failed calls". Once you know the symptom, jump to the matching section below for the precise filter.
+
 ## Failed Calls
 
 Calls rejected with `403 Forbidden`, `404 Not Found`, `486 Busy Here`, `488 Not Acceptable Here`, or timing out with `408 Request Timeout`? Find every call that never established, then triage by response code.
@@ -100,11 +114,14 @@ The call report's **SDP timeline** lists each offer/answer with its codec set. A
 One direction of RTP has zero packets. The caller can hear the callee (or vice versa) but not both.
 
 ```bash
-# Find calls flagged for one-way audio
-sipnab -N -I capture.pcap --filter "one_way == true" --json
+# Find calls flagged for one-way audio (--one-way is shorthand for the filter below)
+sipnab -N -I capture.pcap --one-way --json
 
 # Full diagnostic output
-sipnab -N -I capture.pcap --filter "one_way == true" --report
+sipnab -N -I capture.pcap --one-way --report
+
+# The equivalent explicit Filter-DSL form, if you want to combine it with others
+sipnab -N -I capture.pcap --filter "one_way == true" --json
 ```
 
 You should see one NDJSON record per SIP message of each flagged call (abridged -- real records carry the full field set):

--- a/website/content/docs/tui.md
+++ b/website/content/docs/tui.md
@@ -1,0 +1,111 @@
++++
+title = "TUI Walkthrough"
+weight = 4
+description = "Your first analysis in the interactive TUI, step by step -- open a capture, read the ladder, measure a delay, and inspect RTP."
++++
+
+> New to sipnab? Start here. This is a guided first run through the interactive
+> TUI. Every key you press is called out, and the full reference lives in
+> [Keybindings](@/docs/keybindings.md). If you prefer the command line, see the
+> [Cookbook](@/docs/cookbook.md) instead.
+
+## 1. Open a capture
+
+Point sipnab at a pcap and it drops you straight into the **Call List**:
+
+```bash
+sipnab -I capture.pcap
+```
+
+No file handy? Launch it live on an interface (needs `sudo`), or start with no
+argument and open a file from inside the TUI with `O` (the File Open dialog):
+
+```bash
+sudo sipnab -d eth0     # live capture
+sipnab                  # then press O to open a pcap
+```
+
+You can open a different capture at any time with `O` -- no restart needed.
+
+## 2. Find your way around the Call List
+
+The Call List is the home view: one row per SIP dialog, with method, endpoints,
+state, message count, and PDD (post-dial delay).
+
+- `j` / `k` (or `Down` / `Up`) move the selection; `PgUp` / `PgDn`, `Home`, `End` jump around.
+- `<` / `>` sort by the previous / next column; `Z` reverses the direction. Sort by **State** to bring `Failed` calls to the top, or by **PDD** to find slow setups.
+- `t` cycles the timestamp mode (absolute → delta-prev → delta-first → scaled). Delta-prev is the one that makes latency spikes jump out.
+- Too many columns, or missing one you want (Source IP, PDD)? `F10` opens the column selector.
+
+Land on the call you care about, then press `Enter`.
+
+## 3. Read the call-flow ladder
+
+`Enter` opens the **Call Flow** -- a ladder diagram of the dialog across every
+host it touched (UAC → proxy → UAS), with a detail panel beside it.
+
+- `j` / `k` walk message-to-message; the detail panel updates to show the parsed message under the cursor.
+- `d` cycles how SDP is shown in the detail panel (none / summary / full).
+- `w` toggles line wrapping in the detail panel; with wrap off, long lines truncate and a horizontal scrollbar appears (`Left` / `Right` scroll it).
+- `Enter` on a message opens the full-screen **Raw Message** view (`/` searches within it, `n` / `N` jump between matches, `Esc` returns).
+- `c` recolors the ladder by method, Call-ID, or CSeq; `t` shares the timestamp mode with the Call List.
+
+`Esc` takes you back to the Call List at any time.
+
+## 4. Measure the delay between two messages
+
+This is the trick most people come to sipnab for. In the Call Flow:
+
+1. Move to the first message (say the `INVITE`) and press `m` to drop a **mark**.
+2. Navigate to a later message (the `200 OK`). A **delta badge** appears showing the elapsed time between the mark and your current position.
+3. Press `M` to clear the mark.
+
+Now you can read "how long from INVITE to 200 OK?" straight off the ladder,
+without doing timestamp math in your head.
+
+## 5. Compare two messages side by side
+
+Suspect a header changed across a retransmit or a proxy hop? Press `Space` on
+one message, then `Space` on another, to open the **Message Diff** -- a
+line-by-line comparison. `Esc` returns to the ladder.
+
+## 6. Search and filter
+
+- `/` searches the current view (Call List, Raw Message, or RTP Streams).
+- `F7` opens the **Filter dialog**, which accepts the full [Filter DSL](@/docs/filter-dsl.md) plus quick From/To fields and checkboxes. Try `state == 'Failed'` to keep only calls that never established, or `rtp.mos < 3.0` for poor audio.
+- `F9` clears the active filter; `i` / `I` prune matching / non-matching dialogs from the list.
+
+## 7. Inspect RTP quality
+
+Press `Tab` to switch from the Call List to the **RTP Streams** view: every
+media stream with codec, packet count, jitter, loss, and MOS. Streams flagged
+`orphan` have no matching SIP dialog (often a NAT/ALG symptom).
+
+Press `Enter` on a stream -- or on an `██ RTP ██` bar back in the Call Flow --
+to open **Stream Detail**: MOS, jitter statistics, quality intervals, burst/gap
+analysis, silence detection, and MOS/jitter sparklines. With an `audio` build,
+`Shift+P` plays the stream (G.711). `Tab` switches back to the Call List.
+
+## 8. Trace a call through proxies (multi-leg)
+
+If a call crossed a B2BUA or SBC, press `x` (or `F4`) in the Call Flow to toggle
+**extended multi-leg flow** -- the related legs render together in one ladder,
+so you can follow the call end-to-end through the middle boxes.
+
+## 9. Save what you found
+
+Select the dialogs you want with `Space` in the Call List (they show a `▸`),
+then press `F2`. In the Save dialog, `Tab` cycles the format -- PCAP, PCAP-NG,
+TXT, JSON, NDJSON, CSV, **Mermaid** (a sequence diagram for your ticket/wiki),
+Markdown, WAV, SIPp XML, RTP JSON -- and `Enter` writes the file. If nothing is
+selected, it saves everything.
+
+## Where to go next
+
+- `F1` (or `?`) opens context help in any view -- the fastest way to see what a
+  view can do without leaving it.
+- [Keybindings](@/docs/keybindings.md) -- the complete per-view reference, plus
+  an annotated visual tour of every screen.
+- [Theme Guide](@/docs/theme.md) -- recolor the TUI to taste.
+- [Cookbook](@/docs/cookbook.md) -- the same investigations as one-shot CLI
+  commands, for scripting and CI.

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -101,6 +101,7 @@
             <a href="{{ get_url(path='@/docs/install.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/install/" %}class="active"{% endif %}>Install</a>
             <a href="{{ get_url(path='@/docs/cookbook.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/cookbook/" %}class="active"{% endif %}>Cookbook</a>
             <a href="{{ get_url(path='@/docs/troubleshooting.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/troubleshooting/" %}class="active"{% endif %}>Troubleshooting</a>
+            <a href="{{ get_url(path='@/docs/tui.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/tui/" %}class="active"{% endif %}>TUI Walkthrough</a>
             <a href="{{ get_url(path='@/docs/keybindings.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/keybindings/" %}class="active"{% endif %}>Keybindings</a>
             <a href="{{ get_url(path='@/docs/theme.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/theme/" %}class="active"{% endif %}>Theme</a>
             <a href="{{ get_url(path='@/docs/cli.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/cli/" %}class="active"{% endif %}>CLI</a>

--- a/website/templates/page.html
+++ b/website/templates/page.html
@@ -11,7 +11,7 @@
   <aside class="doc-sidebar" aria-label="Documentation navigation" id="doc-sidebar">
     <nav class="doc-nav" aria-label="Docs sections">
       {{ macros::nav_group(title="Getting started", paths=["install.md", "cookbook.md", "troubleshooting.md"], current_url=page.permalink) }}
-      {{ macros::nav_group(title="Using the TUI", paths=["keybindings.md", "theme.md"], current_url=page.permalink) }}
+      {{ macros::nav_group(title="Using the TUI", paths=["tui.md", "keybindings.md", "theme.md"], current_url=page.permalink) }}
       {{ macros::nav_group(title="CLI & automation", paths=["cli.md", "filter-dsl.md", "output-formats.md"], current_url=page.permalink) }}
       {{ macros::nav_group(title="Configuration", paths=["config.md"], current_url=page.permalink) }}
       {{ macros::nav_group(title="API & integrations", paths=["api.md", "api-clients.md", "integrations.md", "mcp.md"], current_url=page.permalink) }}

--- a/website/templates/section.html
+++ b/website/templates/section.html
@@ -11,7 +11,7 @@
   <aside class="doc-sidebar" aria-label="Documentation navigation" id="doc-sidebar">
     <nav class="doc-nav" aria-label="Docs sections">
       {{ macros::nav_group(title="Getting started", paths=["install.md", "cookbook.md", "troubleshooting.md"], current_url=section.permalink) }}
-      {{ macros::nav_group(title="Using the TUI", paths=["keybindings.md", "theme.md"], current_url=section.permalink) }}
+      {{ macros::nav_group(title="Using the TUI", paths=["tui.md", "keybindings.md", "theme.md"], current_url=section.permalink) }}
       {{ macros::nav_group(title="CLI & automation", paths=["cli.md", "filter-dsl.md", "output-formats.md"], current_url=section.permalink) }}
       {{ macros::nav_group(title="Configuration", paths=["config.md"], current_url=section.permalink) }}
       {{ macros::nav_group(title="API & integrations", paths=["api.md", "api-clients.md", "integrations.md", "mcp.md"], current_url=section.permalink) }}


### PR DESCRIPTION
Closes the two low-severity notes from the semantic review:

1. **Alias visibility** -- the docs task cards advertise `--one-way` and `--problems`, but the Troubleshooting page only showed `--filter` forms. Added a 'Start here' `--problems` one-pass sweep and led the One-Way Audio section with `--one-way` (verified both flags exist: `cli.rs`, and `--one-way`≡`one_way == true`, `--problems`=the broad problem OR-expression).
2. **First-run TUI tutorial** -- `docs/tui.md`, a guided walkthrough (open capture → ladder → mark/delta → diff → filter → RTP → multi-leg → save). The 'Using the TUI' nav group was reference-only; the walkthrough now leads it. All keys verified against the Keybindings reference.

Website-only. Zola anchor/link check + site/link/drift/coverage tests green; full suite 2542 pass.