### PR TITLE
feat(site): give the download page the docs-style left ToC

### DIFF
--- a/tests/site_journey_test.rs
+++ b/tests/site_journey_test.rs
@@ -430,3 +430,58 @@ fn no_inline_event_handlers_in_templates() {
         offenders.join("\n")
     );
 }
+
+// ---------------------------------------------------------------------------
+// Download-page ToC journey: every other content-heavy page (the docs) gives
+// the reader a left sidebar to jump around with; the download page shipped
+// without one, leaving its six sections (installer, four platform panels,
+// all-files table, verify) reachable only by scrolling. The sidebar must use
+// the same doc-sidebar treatment as the docs pages, and every anchor it
+// offers must resolve to a real id in the template — a ToC that points at
+// nothing is worse than no ToC.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn download_page_has_left_toc_sidebar_like_docs() {
+    let tpl = read("website/templates/download.html");
+
+    let aside_at = tpl.find("<aside class=\"doc-sidebar").unwrap_or_else(|| {
+        panic!(
+            "download.html has no <aside class=\"doc-sidebar\"> — the download \
+             page must carry the same left ToC treatment as the docs pages"
+        )
+    });
+    let aside = &tpl[aside_at
+        ..aside_at
+            + tpl[aside_at..]
+                .find("</aside>")
+                .expect("doc-sidebar aside is unterminated")];
+
+    // Every anchor the ToC offers must land on a real id in the template.
+    let href = regex::Regex::new(r##"href="#([A-Za-z0-9_-]+)""##).unwrap();
+    let anchors: Vec<String> = href
+        .captures_iter(aside)
+        .map(|c| c[1].to_string())
+        .collect();
+    assert!(
+        anchors.len() >= 4,
+        "download ToC lists only {} section link(s) — expected the page's \
+         major sections (installer, platforms, all files, verify)",
+        anchors.len()
+    );
+    for id in &anchors {
+        assert!(
+            tpl.contains(&format!("id=\"{id}\"")),
+            "download ToC links to #{id} but no element in download.html \
+             carries id=\"{id}\" — dead anchor"
+        );
+    }
+
+    // The two sections visitors most often want must be one click away.
+    for must in ["all-files", "verify"] {
+        assert!(
+            anchors.iter().any(|a| a == must),
+            "download ToC is missing a link to #{must}"
+        );
+    }
+}

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -2098,6 +2098,12 @@ input:focus-visible,
 // Download page
 .dl { max-width: 840px; margin: 0 auto; padding: 5rem 1.5rem 6rem; }
 
+// Inside the docs-style left-rail layout the grid supplies the horizontal
+// rhythm, so the section drops its own centering; ToC anchors need to clear
+// the sticky top nav.
+.dl-layout .dl { margin: 0; padding: 2rem 0 6rem; }
+.dl-layout .dl [id] { scroll-margin-top: calc(#{$nav-height} + 1.25rem); }
+
 .dl-hero { text-align: center; margin-bottom: 2.75rem; animation: dlUp 0.6s ease both; }
 .dl-kicker { font-family: $font-mono; font-size: 0.74rem; letter-spacing: 0.22em; text-transform: uppercase; color: $accent; margin: 0; }
 .dl-hero h1 { font-size: clamp(2.1rem, 5vw, 3rem); margin: 0.6rem 0 0; letter-spacing: -0.02em; }

--- a/website/templates/download.html
+++ b/website/templates/download.html
@@ -8,6 +8,24 @@
 {% block content %}
 {% set v = config.extra.version %}
 {% set rel = config.extra.github_url ~ "/releases/download/v" ~ v %}
+<div class="doc-layout dl-layout">
+  <aside class="doc-sidebar" aria-label="Download page navigation">
+    <nav class="doc-nav" aria-label="On this page">
+      <div class="doc-nav-group">
+        <p class="doc-nav-group-title">On this page</p>
+        <ul class="doc-nav-list">
+          <li><a class="doc-nav-link" href="#installer">Quick install</a></li>
+          <li><a class="doc-nav-link dl-toc-os" data-os="mac" href="#platforms">macOS &middot; Homebrew</a></li>
+          <li><a class="doc-nav-link dl-toc-os" data-os="debian" href="#platforms">Debian &amp; RHEL packages</a></li>
+          <li><a class="doc-nav-link dl-toc-os" data-os="linux" href="#platforms">Linux static binary</a></li>
+          <li><a class="doc-nav-link dl-toc-os" data-os="source" href="#platforms">Build from source</a></li>
+          <li><a class="doc-nav-link" href="#all-files">All release files</a></li>
+          <li><a class="doc-nav-link" href="#verify">Verify your download</a></li>
+        </ul>
+      </div>
+    </nav>
+  </aside>
+  <div class="doc-content dl-content">
 <section class="dl">
   <header class="dl-hero">
     <p class="dl-kicker">Download</p>
@@ -22,7 +40,7 @@
     <a href="#all-files">not right? see all files &darr;</a>
   </div>
 
-  <div class="dl-method-head"><h2>Fastest path &mdash; the installer picks for you</h2><span class="dl-rec">recommended &middot; start here</span></div>
+  <div class="dl-method-head" id="installer"><h2>Fastest path &mdash; the installer picks for you</h2><span class="dl-rec">recommended &middot; start here</span></div>
   <div class="dl-term">
     <div class="dl-term-head"><span class="dl-dots"><i></i><i></i><i></i></span><span class="dl-term-title">any Linux or macOS &middot; detects OS, CPU, and glibc</span></div>
     <div class="dl-term-body">
@@ -40,7 +58,7 @@
     </div>
   </div>
 
-  <div class="dl-tabs" role="tablist" aria-label="Platform">
+  <div class="dl-tabs" role="tablist" aria-label="Platform" id="platforms">
     <button type="button" class="dl-tab active" data-os="mac" id="dl-tab-mac" role="tab" aria-controls="dl-panel-mac" aria-selected="true" tabindex="0"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.05 12.04c-.03-2.6 2.13-3.85 2.23-3.91-1.22-1.78-3.11-2.02-3.78-2.05-1.61-.16-3.14.95-3.96.95-.81 0-2.07-.93-3.4-.9-1.75.03-3.36 1.02-4.26 2.58-1.82 3.16-.47 7.84 1.3 10.39.86 1.25 1.89 2.66 3.24 2.61 1.3-.05 1.79-.84 3.36-.84 1.57 0 2.01.84 3.39.81 1.4-.02 2.28-1.28 3.14-2.54.99-1.45 1.4-2.85 1.42-2.93-.03-.01-2.73-1.05-2.76-4.16zM14.5 4.7c.72-.87 1.2-2.08 1.07-3.28-1.03.04-2.28.69-3.02 1.56-.66.77-1.24 2-1.08 3.18 1.15.09 2.32-.58 3.03-1.46z"/></svg><span>macOS</span></button>
     <button type="button" class="dl-tab" data-os="debian" id="dl-tab-debian" role="tab" aria-controls="dl-panel-debian" aria-selected="false" tabindex="-1"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg><span>Deb/RPM</span></button>
     <button type="button" class="dl-tab" data-os="linux" id="dl-tab-linux" role="tab" aria-controls="dl-panel-linux" aria-selected="false" tabindex="-1"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg><span>Linux</span></button>
@@ -249,11 +267,26 @@
     <a href="{{ config.extra.github_url }}">Source on GitHub</a>
   </footer>
 </section>
+  </div>
+</div>
 
 <script>
 (function () {
   var tabs = Array.prototype.slice.call(document.querySelectorAll('.dl-tab'));
   var panels = Array.prototype.slice.call(document.querySelectorAll('.dl-panel'));
+  // Left-rail ToC state: which section is in view, and which platform tab is
+  // active — the four platform ToC entries share the #platforms anchor, so
+  // the highlight follows the tab, not just the scroll position.
+  var tocLinks = Array.prototype.slice.call(document.querySelectorAll('.doc-nav-link'));
+  var tocSection = '';
+  var activeOs = 'mac';
+  function markToc() {
+    tocLinks.forEach(function (a) {
+      var on = a.getAttribute('href') === '#' + tocSection &&
+               (!a.hasAttribute('data-os') || a.getAttribute('data-os') === activeOs);
+      a.classList.toggle('active', on);
+    });
+  }
   // Selects a tab/panel and updates the roving tabindex (only the active tab is
   // in the tab order; arrows move between the rest). Tolerates the pre-active
   // macOS tab rendered in the markup for the no-JS case.
@@ -268,6 +301,26 @@
     });
     panels.forEach(function (p) { p.classList.toggle('active', p.getAttribute('data-os') === os); });
     if (focus && activeTab) { activeTab.focus(); }
+    activeOs = os;
+    markToc();
+  }
+  // ToC platform entries switch the tab, then the anchor scrolls to it.
+  tocLinks.forEach(function (a) {
+    if (a.hasAttribute('data-os')) {
+      a.addEventListener('click', function () { show(a.getAttribute('data-os')); });
+    }
+  });
+  // Scrollspy: light up the ToC entry for the section under the reading line.
+  if ('IntersectionObserver' in window) {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (en.isIntersecting) { tocSection = en.target.id; markToc(); }
+      });
+    }, { rootMargin: '-15% 0px -70% 0px' });
+    ['installer', 'platforms', 'all-files', 'verify'].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) { io.observe(el); }
+    });
   }
   // WAI-ARIA APG tabs keyboard pattern: arrows wrap, Home/End jump to ends.
   tabs.forEach(function (t, i) {

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -165,7 +165,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2543 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2544 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -236,7 +236,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.4.16)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2543" data-suffix="">2543</span>
+        <span class="arch-stat" data-count="2544" data-suffix="">2544</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Every docs page carries a sticky left sidebar; the download page shipped without one, so its sections (installer, four platform panels, all-files table, verify) were reachable only by scrolling.

## Changes
- Wrap the download page in the same `doc-layout` grid with a `doc-sidebar` **On this page** nav: Quick install, macOS · Homebrew, Debian & RHEL packages, Linux static binary, Build from source, All release files, Verify your download.
- The four platform entries share the `#platforms` anchor and **activate their tab on click** — a plain anchor would scroll to a hidden panel.
- IntersectionObserver scrollspy keeps the active entry in sync with the reading position, tab-aware for the platform links. Sidebar collapses below 1140px exactly like the docs pages.
- Small `.dl-layout` SCSS block: the rail supplies the horizontal rhythm, anchors clear the sticky top nav.
- Homepage test count 2543 → 2544.

## Verification
- New `site_journey_test` gate `download_page_has_left_toc_sidebar_like_docs` (sidebar exists, every ToC anchor resolves to a real id, all-files + verify one click away) — RED against the old template, GREEN after.
- Site built with CI's pinned Zola 0.19.2: rendered page has the sidebar, all four anchor targets, compiled CSS rule present.
- Full suite green via pre-commit (2544).