### PR TITLE
fix(site): footer on every page + two-tier layout

### DIFF
--- a/tests/site_journey_test.rs
+++ b/tests/site_journey_test.rs
@@ -485,3 +485,41 @@ fn download_page_has_left_toc_sidebar_like_docs() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Footer journey: the site footer must appear on every page. base.html wraps
+// it in `{% block footer %}` so a child template can blank it away with an
+// empty override — analyze.html did exactly that, so the app page shipped
+// with no footer at all (no nav links, no license, no credits).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_page_template_keeps_the_site_footer() {
+    let base = read("website/templates/base.html");
+    assert!(
+        base.contains("class=\"site-footer\""),
+        "base.html no longer renders .site-footer"
+    );
+
+    let empty_override = regex::Regex::new(r"\{%\s*block footer\s*%\}\s*\{%\s*endblock").unwrap();
+    let mut offenders = Vec::new();
+    for entry in std::fs::read_dir(repo().join("website/templates")).expect("templates dir") {
+        let p = entry.expect("entry").path();
+        if p.extension().and_then(|e| e.to_str()) != Some("html") {
+            continue;
+        }
+        let name = p.file_name().expect("name").to_string_lossy().to_string();
+        if name == "base.html" {
+            continue;
+        }
+        let text = std::fs::read_to_string(&p).expect("read template");
+        if empty_override.is_match(&text) {
+            offenders.push(name);
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these templates blank the footer block, hiding the site footer on \
+         their pages: {offenders:?}"
+    );
+}

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -1791,11 +1791,28 @@ input:focus-visible,
 .footer-inner {
   max-width: $max-width;
   margin: 0 auto;
+}
+
+// Two deliberate tiers instead of one overloaded row that wrapped wherever
+// it ran out of width: brand + site nav on top, license/credits below a
+// hairline.
+.footer-top {
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 1rem;
+}
+
+.footer-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin-top: 1.2rem;
+  padding-top: 1.1rem;
+  border-top: 1px solid rgba($border, 0.6);
 }
 
 .footer-col {

--- a/website/templates/analyze.html
+++ b/website/templates/analyze.html
@@ -252,5 +252,3 @@
 
 <script type="module" src="{{ get_url(path='js/analyze.js') }}?v=12"></script>
 {% endblock content %}
-
-{% block footer %}{% endblock footer %}

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -153,26 +153,32 @@
   {% block footer %}
   <footer class="site-footer">
     <div class="footer-inner">
-      <div class="footer-col">
-        <span class="footer-logo">sipnab</span>
-        <span class="footer-version">v{{ config.extra.version }}</span>
+      <div class="footer-top">
+        <div class="footer-col">
+          <span class="footer-logo">sipnab</span>
+          <span class="footer-version">v{{ config.extra.version }}</span>
+        </div>
+        <nav class="footer-col footer-links" aria-label="Footer">
+          <a href="{{ get_url(path='@/download.md') }}">Download</a>
+          <a href="{{ get_url(path='@/docs/_index.md') }}">Documentation</a>
+          <a href="{{ get_url(path='@/analyze/_index.md') }}">Analyze</a>
+          <a href="{{ config.extra.github_url }}">GitHub</a>
+          <a href="{{ config.extra.github_url }}/blob/main/CHANGELOG.md">Changelog</a>
+        </nav>
       </div>
-      <div class="footer-col footer-links">
-        <a href="{{ get_url(path='@/download.md') }}">Download</a>
-        <a href="{{ get_url(path='@/docs/_index.md') }}">Documentation</a>
-        <a href="{{ get_url(path='@/analyze/_index.md') }}">Analyze</a>
-        <a href="{{ config.extra.github_url }}">GitHub</a>
-        <a href="{{ config.extra.github_url }}/blob/main/CHANGELOG.md">Changelog</a>
-        <a href="{{ config.extra.github_url }}#license">License: MIT / Apache-2.0</a>
-      </div>
-      <div class="footer-col footer-meta">
-        <span class="footer-credit">Built with <a href="https://www.rust-lang.org">Rust</a></span>
-        <span class="footer-sep">&middot;</span>
-        <span class="footer-credit"><a href="{{ config.extra.linkedin_url }}">{{ config.extra.author }}</a></span>
-        <span class="footer-sep">&middot;</span>
-        <span class="footer-credit"><a href="{{ config.extra.patreon_url }}">Support on Patreon</a></span>
-        <span class="footer-sep">&middot;</span>
-        <span class="footer-credit"><a href="{{ config.extra.github_sponsors_url }}">GitHub Sponsors</a></span>
+      <div class="footer-bottom">
+        <div class="footer-col">
+          <span class="footer-credit"><a href="{{ config.extra.github_url }}#license">MIT / Apache-2.0</a></span>
+          <span class="footer-sep">&middot;</span>
+          <span class="footer-credit">Built with <a href="https://www.rust-lang.org">Rust</a></span>
+        </div>
+        <div class="footer-col footer-meta">
+          <span class="footer-credit"><a href="{{ config.extra.linkedin_url }}">{{ config.extra.author }}</a></span>
+          <span class="footer-sep">&middot;</span>
+          <span class="footer-credit"><a href="{{ config.extra.patreon_url }}">Support on Patreon</a></span>
+          <span class="footer-sep">&middot;</span>
+          <span class="footer-credit"><a href="{{ config.extra.github_sponsors_url }}">GitHub Sponsors</a></span>
+        </div>
       </div>
     </div>
   </footer>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -165,7 +165,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2544 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2545 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -236,7 +236,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.4.16)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2544" data-suffix="">2544</span>
+        <span class="arch-stat" data-count="2545" data-suffix="">2545</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Two footer problems, one PR:

**Missing footer on the analyze page** — `analyze.html` blanked the footer block with an empty `{% block footer %}` override, so the app page shipped with no footer at all (no nav links, no license, no credits). The override is removed, and a new `site_journey_test` gate (`every_page_template_keeps_the_site_footer`) fails on any template that blanks the footer block again — RED before the fix, GREEN after.

**Ragged two-line wrap** — the footer was one flex row holding eleven items (brand, six links, four credits), which overflowed `$max-width` and wrapped wherever it ran out of width. It's now two deliberate tiers:
- top: `sipnab` + version chip left, site nav links right (Download / Documentation / Analyze / GitHub / Changelog)
- bottom, under a hairline: `MIT / Apache-2.0 · Built with Rust` left, author / Patreon / GitHub Sponsors right

Moving the overlong license link down is what lets the top row hold one line.

## Verification
- All 10 site-journey gates green; full suite via pre-commit (2545).
- Site built with CI's pinned Zola 0.19.2: footer present on the rendered analyze page, two-tier markup on the homepage.
- Homepage test count 2544 → 2545.