### PR TITLE
release 0.5.16: transparent gzip captures, download ToC, footer fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.16] - 2026-07-19
+
+### Added
+- **Gzip-compressed captures open transparently everywhere.** A
+  `.pcap`/`.pcapng` file that is gzip-compressed — including one mislabeled
+  as plain `.pcap`, which previously failed with
+  `Not a pcap/pcapng file (magic: 0x00088b1f)` (that magic is the gzip
+  header read as a little-endian word) — is now decompressed automatically,
+  the way Wireshark does. The native CLI/TUI paths already gunzipped;
+  the browser analyzer and the TUI's pcapng-metadata pass (NRB names /
+  DSB secrets) now do too, sharing one bounded core: 1 GiB inflation cap
+  (a decompression bomb is refused, not materialized), concatenated gzip
+  members supported, zero-copy passthrough for plain files. The analyze
+  page accepts `.pcap.gz`/`.pcapng.gz`, shows a notice with
+  compressed → decompressed sizes when it gunzipped, and a gzip stream
+  wrapping non-capture data reports the decompressed magic instead of a
+  bare parse failure.
+- The download page now carries the same left "On this page" sidebar as the
+  docs pages: quick install, the four platform choices (which also switch
+  the matching tab), the all-files table, and download verification — with
+  a scrollspy tracking the reading position.
+
+### Fixed
+- **The analyze page had no site footer** — the template blanked the footer
+  block. Every page keeps the footer now, enforced by a journey gate.
+- **The filter demo showed nothing filtering.** It searched `INVITE`, which
+  matches every dialog via `Allow:` headers, so the list never narrowed.
+  The tape now types queries that visibly narrow, and a journey gate
+  replays every tape query against the tape's own pcap through the real
+  TUI search path.
+
+### Changed
+- The site footer is restructured into two deliberate tiers (brand + nav
+  links; license and credits under a hairline) instead of one overloaded
+  row that wrapped raggedly.
+
 ## [0.5.15] - 2026-07-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.5.15"
+version = "0.5.16"
 dependencies = [
  "aes",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 
 [package]
 name = "sipnab"
-version = "0.5.15"
+version = "0.5.16"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Norm Brandinger"]

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ curl -fsSL https://www.sipnab.com/install.sh | sh
 ```
 
 Prefer to read it first: <https://www.sipnab.com/install.sh>. Pin a version
-with `SIPNAB_VERSION=0.5.15`, change the destination with `SIPNAB_INSTALL_DIR`.
+with `SIPNAB_VERSION=0.5.16`, change the destination with `SIPNAB_INSTALL_DIR`.
 
 ## Pre-built Binaries
 
@@ -27,7 +27,7 @@ you which one you are.
 
 ```bash
 # Linux x86_64 (static musl -- runs on any distro, any glibc, Alpine included)
-# Replace <version> with the latest, e.g. 0.5.15
+# Replace <version> with the latest, e.g. 0.5.16
 curl -LO https://github.com/NormB/sipnab/releases/download/v<version>/sipnab-<version>-x86_64-unknown-linux-musl.tar.gz
 tar xzf sipnab-<version>-x86_64-unknown-linux-musl.tar.gz
 sudo install -m 755 sipnab-<version>-x86_64-unknown-linux-musl/sipnab /usr/local/bin/sipnab
@@ -56,7 +56,7 @@ cargo install sipnab --features full
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install with `apt` (it resolves the `libpcap0.8` runtime dependency). The `.deb` needs glibc >= 2.39, i.e. Debian 13+ / Ubuntu 24.04+ -- on older releases use the static musl tarball above:
 
 ```bash
-# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.15
+# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.16
 curl -LO https://github.com/NormB/sipnab/releases/latest/download/sipnab_<version>_amd64.deb
 sudo apt install ./sipnab_<version>_amd64.deb
 
@@ -96,11 +96,11 @@ standard and a `-noaudio` variant (no audio plugin, no `alsa-lib` weak
 dependency — for headless servers, mirroring the `.deb` variants):
 
 ```bash
-sudo rpm -i sipnab-0.5.15-1.x86_64.rpm
+sudo rpm -i sipnab-0.5.16-1.x86_64.rpm
 # headless / no-ALSA variant:
-sudo rpm -i sipnab-0.5.15-1.x86_64-noaudio.rpm
+sudo rpm -i sipnab-0.5.16-1.x86_64-noaudio.rpm
 # arm64 hosts:
-sudo rpm -i sipnab-0.5.15-1.aarch64.rpm
+sudo rpm -i sipnab-0.5.16-1.aarch64.rpm
 ```
 
 ### Homebrew (macOS)
@@ -282,7 +282,7 @@ sipnab --help
 `--version` lists the Cargo features compiled into the binary, e.g.
 
 ```
-sipnab 0.5.15 (2595058) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+sipnab 0.5.16 (2595058) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 ```
 
 This is the fastest way to confirm a build was produced with the feature set

--- a/man/sipnab.1
+++ b/man/sipnab.1
@@ -1,7 +1,7 @@
 .\" sipnab.1 -- man page for sipnab
 .\" Copyright 2024-2026 Norm Brandinger
 .\" License: MIT OR Apache-2.0
-.TH SIPNAB 1 "2026-07-18" "sipnab 0.5.15" "User Commands"
+.TH SIPNAB 1 "2026-07-19" "sipnab 0.5.16" "User Commands"
 .SH NAME
 sipnab \- SIP & RTP capture, analysis, and security tool
 .SH SYNOPSIS

--- a/website/config.toml
+++ b/website/config.toml
@@ -26,10 +26,10 @@ theme = "ayu-dark"
 # overwrites this from Cargo.toml at build time (single source of truth), and a
 # pre-commit hook fails if the two drift — so the homepage version badge and the
 # download links always match the released crate. Update Cargo.toml, not this.
-version = "0.5.15"
+version = "0.5.16"
 # Release date of the current `version` above. Shown on /download next to the
 # version. Update alongside Cargo.toml/version when cutting a release.
-release_date = "2026-07-18"
+release_date = "2026-07-19"
 # Minimum glibc of the released -gnu binaries and .debs (see the "Enforce
 # glibc floor" step in release.yml). Drives the guidance on /download and
 # must match SIPNAB_GLIBC_FLOOR in static/install.sh. 2.39 = Debian 13 /

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -754,7 +754,7 @@ Metric names emitted by `src/output/prometheus.rs`:
 | `sipnab_jitter_ms` | histogram | RTP jitter distribution (buckets at 5/10/20/50/100/200ms). |
 | `sipnab_loss_percent` | histogram | RTP packet-loss distribution (buckets at 0.1/0.5/1/2/5/10%). |
 
-The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.15 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
+The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.16 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
 
 ## Security Model
 

--- a/website/content/docs/benchmarks.md
+++ b/website/content/docs/benchmarks.md
@@ -7,7 +7,7 @@ description = "Reproducible throughput and memory benchmarks: sipnab multi-core 
 How fast sipnab is, measured honestly. Every number here is reproducible — the
 host, corpus, tool versions, and exact commands are listed so you can re-run it.
 
-Measured on sipnab 0.4.16 (2026-06-24); current release 0.5.15 — numbers not
+Measured on sipnab 0.4.16 (2026-06-24); current release 0.5.16 — numbers not
 yet re-validated.
 
 > **Read this first.** These tools do *different amounts of work*, so a raw

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -40,7 +40,7 @@ Every [GitHub release](https://github.com/NormB/sipnab/releases) ships versioned
 - `sipnab-<version>-aarch64-unknown-linux-musl.tar.gz` — same, for arm64
 - `sipnab-<version>-x86_64-apple-darwin.tar.gz` / `sipnab-<version>-aarch64-apple-darwin.tar.gz` — macOS
 
-Manual download with checksum verification (replace `<version>` with the latest, e.g. 0.5.15):
+Manual download with checksum verification (replace `<version>` with the latest, e.g. 0.5.16):
 
 ```bash
 V=<version> T=x86_64-unknown-linux-gnu
@@ -89,7 +89,7 @@ For build prerequisites, the full feature-flag matrix, release profile, and cros
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install it with `apt`, which resolves the `libpcap0.8` runtime dependency automatically:
 
 ```bash
-# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.15
+# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.16
 curl -LO https://github.com/NormB/sipnab/releases/latest/download/sipnab_<version>_amd64.deb
 sudo apt install ./sipnab_<version>_amd64.deb
 
@@ -121,7 +121,7 @@ standard and a `-noaudio` variant (no audio plugin, no `alsa-lib` weak
 dependency — for headless servers, mirroring the `.deb` variants):
 
 ```bash
-sudo rpm -i sipnab-<version>-1.x86_64.rpm  # replace <version> with the latest, e.g. 0.5.15
+sudo rpm -i sipnab-<version>-1.x86_64.rpm  # replace <version> with the latest, e.g. 0.5.16
 # headless / no-ALSA variant:
 sudo rpm -i sipnab-<version>-1.x86_64-noaudio.rpm
 # arm64 hosts:
@@ -179,7 +179,7 @@ sipnab -D
 <span class="terminal-title">Verify Installation</span>
 </div>
 <pre class="terminal-body"><span class="t-muted">$</span> sipnab --version
-sipnab 0.5.15 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+sipnab 0.5.16 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 
 <span class="t-muted">$</span> sipnab -N -I demo.pcap | head -3
 <span class="t-accent">INVITE</span> alice -> bob  192.0.2.1:5060 -> 192.0.2.2:5060 <span class="t-good">InCall</span> PDD=847ms


### PR DESCRIPTION
Version bump 0.5.15 → 0.5.16 across Cargo.toml/Cargo.lock, website/config.toml (+release_date 2026-07-19), man/sipnab.1, and docs version strings; CHANGELOG entry covering:

- **Gzip-compressed captures open transparently everywhere** (#159) — bounded 1 GiB inflation, concatenated members, analyze-page notice with sizes, `.pcap.gz` accepted.
- **Download page left ToC** (#157) — docs-style sidebar with tab-aware scrollspy.
- **Footer on every page + two-tier layout** (#158).
- **Filter demo actually filters** (#156).

Pre-commit version-sync gates (site badge, man/docs strings) enforce consistency; full suite 2556.