### PR TITLE
docs: close WS8.1/WS8.2 — A/B shows no version regression

### DIFF
--- a/MAINTAINABILITY-PERF-SPEC.md
+++ b/MAINTAINABILITY-PERF-SPEC.md
@@ -712,13 +712,20 @@ land once, after the structure settles.
 ## WS8 — 0.5.16 benchmark re-validation follow-ups (2026-07-20, thor-02)
 
 The 0.5.16 re-run (see docs/benchmarks page) improved every multi-core and
-sweep throughput number but surfaced two regressions vs the 0.4.16 session:
+sweep throughput number but appeared to surface two regressions vs the
+0.4.16 session. **Both were closed the same day by a controlled A/B** of the
+0.4.16 and 0.5.17 release binaries, same host/corpus/pinning, median-of-5:
 
-- **WS8.1 — single-core `-O` pcap re-emit −19%** (0.85M vs 1.05M p/s on the
-  535k corpus; plain single-core is flat at 1.22M and multi-core with `-O`
-  *improved* +14%, so the suspect is the pcap writer serializing against
-  single-core decode). Profile `-O` on `--cores 1`.
-- **WS8.2 — sweep RSS +18–43% at small scales** (39 vs 33 MiB @500 calls,
-  103 vs 72 @2000; converges by 8k calls: 233 vs 217, 522 vs 507 @20k).
-  Growth pattern suggests a new per-dialog/stream allocation; heap-profile
-  at 2000 calls.
+- **WS8.1 — CLOSED, not a regression.** cores=1 with `-O`: 0.4.16 = 826k
+  p/s, 0.5.17 = 814k p/s (−1.5%, noise); plain cores=1: 1.26M vs 1.24M.
+  The June "1.05M" row does not reproduce with the 0.4.16 binary itself —
+  session variance in the June figures.
+- **WS8.2 — CLOSED, not a regression.** Sweep RSS with `-O`: @500 calls
+  0.4.16 = 40 MiB vs 0.5.17 = 39; @2000 calls 99 vs 103. The June 33/72
+  figures do not reproduce with 0.4.16 either.
+- **WS8.3 — OPEN (opportunity, version-independent):** `-O` pcap re-emit
+  costs ~35% of single-core throughput on either version (1.26M → 0.83M
+  p/s), while multi-core absorbs it. The writer sits inline in the packet
+  loop (src/app/batch.rs, PcapWriter::write per packet); candidate: batch
+  or buffer writes off the hot path. Not scheduled — pick up
+  opportunistically.

--- a/website/content/docs/benchmarks.md
+++ b/website/content/docs/benchmarks.md
@@ -11,11 +11,15 @@ sipnab numbers are measured on sipnab 0.5.16 (2026-07-20); the
 current release 0.5.17 is a dependency-and-docs delta with no changes to the
 measured paths, so the numbers carry over. The comparison tools' numbers come from the
 2026-06-24 session — same host, corpus, and method, and their versions are
-unchanged. Versus 0.4.16, 0.5.16 is faster at every
+unchanged. Versus the 0.4.16 session, 0.5.16 measures faster at every
 multi-core operating point (+13–30%) and across the carrier sweep
-(+31–107%); two regressions are called out honestly below and tracked for
-the next release: single-core throughput with `-O` pcap re-emit (−19%) and
-small-scale sweep RSS (+18–43%, still far below the peer tool).
+(+31–107%). Two apparent regressions in the first re-run (single-core `-O`
+throughput, small-scale RSS) were checked with a controlled same-day A/B of
+the 0.4.16 and 0.5.17 binaries: both measure identically, so those deltas
+were session variance in the June figures, not version regressions. What the
+A/B does confirm — for either version — is that `-O` pcap re-emit costs
+about a third of single-core throughput (1.26M → 0.83M p/s), a standing
+optimization opportunity (WS8.3), not a regression.
 
 > **Read this first.** These tools do *different amounts of work*, so a raw
 > throughput number only means something next to *what was reconstructed*.
@@ -79,9 +83,10 @@ Read it in three buckets:
   voipmonitor**, four-core is **13.1× sngrep and 3.6× voipmonitor** — and four-core
   now beats grep-only sipgrep's wall-clock (0.20 s vs 0.22 s) *while also
   reconstructing all 200 RTP streams*. There is no configuration where sipnab is
-  the slowest at comparable work. (Single-core with `-O` re-emit is 19% slower
-  than 0.4.16 measured — a tracked regression; without `-O` single-core is flat
-  at 1.22M.)
+  the slowest at comparable work. (Single-core with `-O` re-emit measures the
+  same on 0.4.16 and 0.5.17 in a controlled A/B — the June 1.05M row was
+  session variance. The `-O` write itself costs ~35% single-core on either
+  version; without `-O` single-core is flat at 1.22M.)
 
 > **Fairness notes.** The corpus is synthetic and reuses SDP media endpoints, so
 > voipmonitor's default `sdp_multiplication=3` DoS-guard would suppress the
@@ -112,9 +117,10 @@ with scale (72k → 264k p/s) — on 0.4.16 that climb crossed over at roughly
 ~40k calls; on 0.5.16 the sweep no longer flags a crossover inside any
 plausible operating range. sipnab's standing advantage is still **memory** —
 about 9.2× less RSS at 20k calls (0.5 GiB vs 4.7 GiB), because voipmonitor
-buffers and spools heavily. (sipnab's small-scale RSS grew vs 0.4.16 — 39 vs
-33 MiB at 500 calls, 103 vs 72 at 2000 — a tracked regression, though still
-4–5× below voipmonitor at those scales.) (voipmonitor's *live*
+buffers and spools heavily. (An apparent small-scale RSS growth vs the June
+figures — 39 vs 33 MiB at 500 calls — was A/B-checked: 0.4.16 measures
+40/99 MiB on the same day 0.5.17 measures 39/103, so the delta was session
+variance, not a version regression.) (voipmonitor's *live*
 capture reconstructed 0 calls on this box's virtual NIC — an mmap-ring quirk — so
 this comparison is offline-only.)
 


### PR DESCRIPTION
Controlled same-day A/B on thor-02 (0.4.16 vs 0.5.17 release binaries, same corpus/pinning, median-of-5):

| measurement | 0.4.16 | 0.5.17 |
|---|---:|---:|
| cores=1, plain | 1.26M p/s | 1.24M p/s |
| cores=1, with `-O` | 826k p/s | 814k p/s |
| sweep RSS @500 calls | 40 MiB | 39 MiB |
| sweep RSS @2000 calls | 99 MiB | 103 MiB |

The June-session figures (1.05M with -O; 33/72 MiB RSS) do not reproduce with the 0.4.16 binary itself — the apparent 0.5.16 regressions were **session variance, not version deltas**. This PR corrects the benchmarks page claims, closes WS8.1/WS8.2 in the spec with the evidence, and records the genuine version-independent finding as **WS8.3**: `-O` pcap re-emit costs ~35% of single-core throughput (writer sits inline in the packet loop) — an opportunity, unscheduled.