### PR TITLE
site: move sponsor/GitHub links to footer, single-row footer

### DIFF
--- a/tests/site_journey_test.rs
+++ b/tests/site_journey_test.rs
@@ -523,3 +523,117 @@ fn every_page_template_keeps_the_site_footer() {
          their pages: {offenders:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Sponsor/GitHub placement journey: the Patreon sponsor button, the GitHub
+// Sponsors heart, and the GitHub link belong ONLY in the footer — the top nav
+// carries navigation and search, nothing else. In the footer they render as
+// icon links (svg + aria-label), not as "Support on Patreon"-style text, and
+// the whole footer is ONE non-wrapping row: no footer-top/footer-bottom
+// tiers, no "Built with Rust" credit.
+// ---------------------------------------------------------------------------
+
+/// Slice a named `{% block X %}...{% endblock %}` region out of base.html.
+fn base_block(name: &str) -> String {
+    let base = read("website/templates/base.html");
+    let open = format!("{{% block {name} %}}");
+    let start = base
+        .find(&open)
+        .unwrap_or_else(|| panic!("base.html has no `{open}`"));
+    let end = base[start..]
+        .find("{% endblock")
+        .unwrap_or_else(|| panic!("`{open}` is unterminated"));
+    base[start..start + end].to_string()
+}
+
+#[test]
+fn sponsor_heart_and_github_live_only_in_the_footer() {
+    let nav = base_block("nav");
+    for banned in [
+        "patreon_url",
+        "github_sponsors_url",
+        "config.extra.github_url",
+    ] {
+        assert!(
+            !nav.contains(banned),
+            "top nav still links `{banned}` — sponsor/heart/GitHub links \
+             belong only in the footer"
+        );
+    }
+
+    let footer = base_block("footer");
+    for required in [
+        "patreon_url",
+        "github_sponsors_url",
+        "config.extra.github_url",
+    ] {
+        assert!(
+            footer.contains(required),
+            "footer lost its `{required}` link — moving it out of the nav \
+             must not drop it from the site"
+        );
+    }
+}
+
+#[test]
+fn footer_is_one_non_wrapping_row_with_icon_sponsor_links() {
+    let footer = base_block("footer");
+
+    // One row, not two tiers.
+    for tier in ["footer-top", "footer-bottom"] {
+        assert!(
+            !footer.contains(tier),
+            "footer still has the two-tier `{tier}` layout — it must be a \
+             single `footer-row`"
+        );
+    }
+    assert!(
+        footer.contains("class=\"footer-row\""),
+        "footer has no .footer-row container"
+    );
+
+    // "Built with Rust" is gone.
+    assert!(
+        !footer.contains("Built with"),
+        "footer still carries the `Built with Rust` credit"
+    );
+
+    // Patreon / GitHub Sponsors are icons, not text links.
+    for text in ["Support on Patreon", ">GitHub Sponsors<"] {
+        assert!(
+            !footer.contains(text),
+            "footer still renders `{text}` as a text link — use an icon"
+        );
+    }
+    for (url, what) in [
+        ("patreon_url", "Patreon"),
+        ("github_sponsors_url", "GitHub Sponsors"),
+    ] {
+        let at = footer
+            .find(url)
+            .unwrap_or_else(|| panic!("footer has no `{url}` link"));
+        let anchor_end = footer[at..]
+            .find("</a>")
+            .unwrap_or_else(|| panic!("`{url}` anchor is unterminated"));
+        let anchor = &footer[at..at + anchor_end];
+        assert!(
+            anchor.contains("<svg") && anchor.contains("aria-label"),
+            "the {what} footer link must be an svg icon with an aria-label"
+        );
+    }
+
+    // The stylesheet must actually forbid wrapping on the row.
+    let scss = read("website/sass/style.scss");
+    let rule_at = scss
+        .find(".footer-row")
+        .expect("style.scss has no .footer-row rule");
+    let rule_end = scss[rule_at..]
+        .find('}')
+        .expect(".footer-row rule is unterminated");
+    let rule = &scss[rule_at..rule_at + rule_end];
+    assert!(
+        rule.contains("flex-wrap: nowrap"),
+        ".footer-row must declare `flex-wrap: nowrap` so the footer never \
+         breaks into a second line"
+    );
+}

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -103,10 +103,7 @@ input:focus-visible,
 .nav-logo:focus-visible,
 .nav-links a:focus-visible,
 .nav-toggle:focus-visible,
-.search-trigger:focus-visible,
-.nav-github:focus-visible,
-.nav-sponsor:focus-visible,
-.nav-gh-sponsor:focus-visible {
+.search-trigger:focus-visible {
   outline: 2px solid $accent;
   outline-offset: 2px;
 }
@@ -268,39 +265,6 @@ input:focus-visible,
   align-items: center;
   transition: border-color 0.15s, color 0.15s;
   &:hover { border-color: $text-dim; color: $text; }
-}
-
-.nav-github {
-  color: $text-dim;
-  display: flex;
-  align-items: center;
-  &:hover { color: $text; }
-}
-
-// GitHub Sponsors heart link (the GitHub-native equivalent of the Patreon button).
-.nav-gh-sponsor {
-  color: $text-dim;
-  display: flex;
-  align-items: center;
-  transition: color 0.15s, transform 0.15s;
-  // GitHub Sponsors' signature pink on hover.
-  &:hover { color: #db61a2; transform: scale(1.1); }
-}
-
-.nav-sponsor {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  border: 1px solid $accent;
-  border-radius: 6px;
-  color: $accent;
-  padding: 0.375rem 0.7rem;
-  font-size: 0.85rem;
-  font-weight: 600;
-  white-space: nowrap;
-  transition: background 0.15s, color 0.15s;
-  .heart { color: $accent; line-height: 1; }
-  &:hover { background: $accent; color: $bg; .heart { color: $bg; } }
 }
 
 .nav-toggle {
@@ -1793,32 +1757,16 @@ input:focus-visible,
   margin: 0 auto;
 }
 
-// Two deliberate tiers instead of one overloaded row that wrapped wherever
-// it ran out of width: brand + site nav on top, license/credits below a
-// hairline.
-.footer-top {
+// One row: brand · site nav · license/author · sponsor+GitHub icons. It must
+// never break onto a second line — on screens too narrow to fit everything
+// the row scrolls horizontally instead of wrapping.
+.footer-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  white-space: nowrap;
   gap: 1rem;
-}
-
-.footer-bottom {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 0.5rem 1rem;
-  margin-top: 1.2rem;
-  padding-top: 1.1rem;
-  border-top: 1px solid rgba($border, 0.6);
-}
-
-.footer-col {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
+  overflow-x: auto;
 }
 
 .footer-logo {
@@ -1838,15 +1786,19 @@ input:focus-visible,
   border: 1px solid $border;
 }
 
+// Centered between the brand on the left and the credits pushed right.
 .footer-links {
-  flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
   justify-content: center;
-}
 
-.footer-col a {
-  font-size: 0.85rem;
-  color: $text-dim;
-  &:hover { color: $text; }
+  a {
+    font-size: 0.85rem;
+    color: $text-dim;
+    &:hover { color: $text; }
+  }
 }
 
 .footer-sep {
@@ -1855,8 +1807,10 @@ input:focus-visible,
 }
 
 .footer-meta {
-  flex-wrap: wrap;
-  justify-content: flex-end;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: auto;
 }
 
 .footer-credit {
@@ -1868,6 +1822,18 @@ input:focus-visible,
     &:hover { color: $text; }
   }
 }
+
+// Patreon / GitHub Sponsors / GitHub as icons, brand color on hover.
+.footer-icon {
+  color: $text-dim;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s, transform 0.15s;
+  &:hover { color: $text; transform: scale(1.1); }
+}
+
+.footer-icon-patreon:hover { color: #f96854; }
+.footer-icon-heart:hover { color: #db61a2; }
 
 // =============================================================================
 // 404
@@ -2078,16 +2044,15 @@ input:focus-visible,
   .doc-prevnext { grid-template-columns: 1fr; }
   .doc-next { grid-column: 1; text-align: left; align-items: flex-start; }
 
-  .footer-inner { flex-direction: column; text-align: center; }
-  .footer-col { justify-content: center; }
-  .footer-meta { justify-content: center; }
+  // The footer row stays a single line on phones too; tighten it and let it
+  // scroll sideways rather than wrap.
+  .footer-row { gap: 0.75rem; }
+  .footer-meta { gap: 0.5rem; }
 
   .terminal-body { font-size: 0.65rem; padding: 0.75rem; }
 }
 
 @media (max-width: 480px) {
-  .nav-sponsor-text { display: none; }
-  .nav-sponsor { padding: 0.375rem 0.5rem; }
   .nav-right { gap: 0.5rem; }
   .hero { padding: 3.25rem 1rem 1.5rem; }
   .hero-kicker { font-size: 0.66rem; letter-spacing: 0.18em; }

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -119,16 +119,9 @@
       </div>
 
       <div class="nav-right">
-        <a href="{{ config.extra.patreon_url }}" class="nav-sponsor" aria-label="Sponsor sipnab on Patreon"><span class="nav-sponsor-text">Sponsor</span> <span class="heart">&#9829;</span></a>
-        <a href="{{ config.extra.github_sponsors_url }}" class="nav-gh-sponsor" aria-label="Sponsor sipnab on GitHub Sponsors" title="GitHub Sponsors" target="_blank" rel="noopener">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
-        </a>
         <button class="search-trigger" id="search-trigger" aria-label="Search">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
         </button>
-        <a href="{{ config.extra.github_url }}" class="nav-github" aria-label="GitHub">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
-        </a>
       </div>
     </div>
   </nav>
@@ -153,31 +146,28 @@
   {% block footer %}
   <footer class="site-footer">
     <div class="footer-inner">
-      <div class="footer-top">
-        <div class="footer-col">
-          <span class="footer-logo">sipnab</span>
-          <span class="footer-version">v{{ config.extra.version }}</span>
-        </div>
-        <nav class="footer-col footer-links" aria-label="Footer">
+      <div class="footer-row">
+        <span class="footer-logo">sipnab</span>
+        <span class="footer-version">v{{ config.extra.version }}</span>
+        <nav class="footer-links" aria-label="Footer">
           <a href="{{ get_url(path='@/download.md') }}">Download</a>
-          <a href="{{ get_url(path='@/docs/_index.md') }}">Documentation</a>
+          <a href="{{ get_url(path='@/docs/_index.md') }}">Docs</a>
           <a href="{{ get_url(path='@/analyze/_index.md') }}">Analyze</a>
-          <a href="{{ config.extra.github_url }}">GitHub</a>
           <a href="{{ config.extra.github_url }}/blob/main/CHANGELOG.md">Changelog</a>
         </nav>
-      </div>
-      <div class="footer-bottom">
-        <div class="footer-col">
+        <div class="footer-meta">
           <span class="footer-credit"><a href="{{ config.extra.github_url }}#license">MIT / Apache-2.0</a></span>
           <span class="footer-sep">&middot;</span>
-          <span class="footer-credit">Built with <a href="https://www.rust-lang.org">Rust</a></span>
-        </div>
-        <div class="footer-col footer-meta">
           <span class="footer-credit"><a href="{{ config.extra.linkedin_url }}">{{ config.extra.author }}</a></span>
-          <span class="footer-sep">&middot;</span>
-          <span class="footer-credit"><a href="{{ config.extra.patreon_url }}">Support on Patreon</a></span>
-          <span class="footer-sep">&middot;</span>
-          <span class="footer-credit"><a href="{{ config.extra.github_sponsors_url }}">GitHub Sponsors</a></span>
+          <a href="{{ config.extra.patreon_url }}" class="footer-icon footer-icon-patreon" aria-label="Support sipnab on Patreon" title="Patreon" target="_blank" rel="noopener">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M14.82 2.41c-4.5 0-8.16 3.66-8.16 8.16 0 4.49 3.66 8.14 8.16 8.14 4.49 0 8.14-3.65 8.14-8.14 0-4.5-3.65-8.16-8.14-8.16M1.04 21.6h3.99V2.41H1.04z"/></svg>
+          </a>
+          <a href="{{ config.extra.github_sponsors_url }}" class="footer-icon footer-icon-heart" aria-label="Sponsor sipnab on GitHub Sponsors" title="GitHub Sponsors" target="_blank" rel="noopener">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+          </a>
+          <a href="{{ config.extra.github_url }}" class="footer-icon" aria-label="sipnab on GitHub" title="GitHub">
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+          </a>
         </div>
       </div>
     </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -165,7 +165,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2562 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2564 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -236,7 +236,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.4.16)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2562" data-suffix="">2562</span>
+        <span class="arch-stat" data-count="2564" data-suffix="">2562</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
The top nav carried a Patreon Sponsor button, a GitHub Sponsors heart, and a GitHub icon; all three now live only in the footer. The footer collapses from two tiers to one non-wrapping row (it scrolls horizontally on narrow screens instead of wrapping), drops the 'Built with Rust' credit, and renders Patreon / GitHub Sponsors / GitHub as icon links with aria-labels and brand-colored hovers.

Two new drift gates in `site_journey_test.rs` lock the placement, the single-row layout, and the icon treatment; the homepage test count moves 2562 → 2564 to match.

Verified locally: full `cargo test --features full` green, clippy `-D warnings` clean, and a Zola 0.19.2 build (docker) renders 17 pages with all internal anchors resolving.