### PR TITLE
site: content-hash CSS buster; sync benchmarks docs with website

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -3,6 +3,25 @@
 How fast sipnab is, measured honestly. Every number here is reproducible — the
 host, corpus, tool versions, and exact commands are listed so you can re-run it.
 
+sipnab numbers are measured on the released 0.5.18 artifact — the
+current release 0.5.18, checksum-verified, run 2026-07-20. The comparison
+tools' numbers come from the 2026-06-24 session — same host, corpus, and
+method, and their versions are unchanged. Versus the 0.4.16 session, 0.5.18
+measures faster at every multi-core operating point (+9–16%) and across the
+carrier sweep (+30–107%).
+
+0.5.18's rebuilt `-O` re-emit writer (WS8.3) deserves an honest word: a
+same-toolchain A/B shows the per-packet write cost down 43%, and write
+errors (full disk, dead mount) now surface instead of being silently
+discarded — but end-to-end `-O` throughput on *this* host is unchanged,
+because here the re-emit is bound by pushing the corpus's bytes through the
+page cache, not by per-packet overhead. On an x86 dev box the same change
+measures +8–16% end-to-end. (Two apparent regressions in an earlier re-run —
+single-core `-O` throughput and small-scale RSS — were checked with a
+controlled same-day A/B of the 0.4.16 and 0.5.17 binaries: both measured
+identically, so those deltas were session variance in the June figures, not
+version regressions.)
+
 > **Read this first.** These tools do *different amounts of work*, so a raw
 > throughput number only means something next to *what was reconstructed*.
 > `sipgrep` is a grep-style line matcher; `sngrep` builds an interactive SIP
@@ -19,7 +38,7 @@ host, corpus, tool versions, and exact commands are listed so you can re-run it.
   `INVITE → … → 200 → ACK → [bidirectional RTP] → BYE`, ~93% RTP by packet count.
 - **Method:** offline pcap reconstruction (`-I file`), median-of-5 after one
   discarded warmup. `pkts/s = packets ÷ wall-clock seconds`.
-- **Version:** sipnab 0.4.16. **Date:** 2026-06-24.
+- **Version:** sipnab 0.5.18 (release artifact). **Date:** 2026-07-20.
 
 ## Multi-core offline reconstruction (sipnab)
 
@@ -28,10 +47,10 @@ throughput holds a flat plateau from 2 cores up:
 
 | cores | pkts/s |
 |------:|-------:|
-| 1 | 1.24M |
-| 2 | **2.51M** |
-| 4 | 2.27M |
-| 8 | 2.16M |
+| 1 | 1.20M |
+| 2 | **2.90M** |
+| 4 | 2.52M |
+| 8 | 2.35M |
 
 The plateau past cores 2 is the single sequential pcap reader (read + buffer copy
 + host-pair peek), not the core count. Before v0.4.16 a per-packet cross-core
@@ -51,8 +70,8 @@ throughput number only means something next to the work behind it.
 | sngrep 1.8.0 | 0.20M | 1.0× | SIP dialogs (100); no RTP-stream reconstruction headless |
 | sipgrep 2.2.0 | 2.46M | 12.2× | grep-style SIP line match + Call-ID grouping; **no RTP** |
 | voipmonitor 2026.05.0 | 0.73M | 3.7× | full call/CDR + RTP-stream association |
-| **sipnab 0.4.16 `--cores 1`** | 1.05M | **5.2×** | SIP dialogs + **200 RTP streams** |
-| **sipnab 0.4.16 `--cores 4`** | 2.30M | **11.4×** | identical full SIP + RTP reconstruction |
+| **sipnab 0.5.18 `--cores 1`** | 0.83M | **4.2×** | SIP dialogs + **200 RTP streams** |
+| **sipnab 0.5.18 `--cores 4`** | 2.50M | **12.5×** | identical full SIP + RTP reconstruction |
 
 Read it in three buckets:
 
@@ -61,11 +80,14 @@ Read it in three buckets:
   500k RTP packets into streams). Its lead is mostly "it does less."
 - **Full reconstruction (sngrep, voipmonitor, sipnab)** parse SIP into dialogs;
   voipmonitor and sipnab additionally associate RTP into media streams.
-- Within that class **sipnab wins**: single-core is **5.2× sngrep and 1.4×
-  voipmonitor**, four-core is **11.4× sngrep and 3.1× voipmonitor** — and four-core
-  matches grep-only sipgrep's wall-clock (0.23 s vs 0.22 s) *while also
+- Within that class **sipnab wins**: single-core is **4.2× sngrep and 1.1×
+  voipmonitor**, four-core is **12.5× sngrep and 3.4× voipmonitor** — and four-core
+  matches grep-only sipgrep's wall-clock (0.21 s vs 0.22 s) *while also
   reconstructing all 200 RTP streams*. There is no configuration where sipnab is
-  the slowest at comparable work.
+  the slowest at comparable work. (Single-core with `-O` re-emit measures the
+  same on 0.4.16 and 0.5.17 in a controlled A/B — the June 1.05M row was
+  session variance. The `-O` write itself costs ~35% single-core on either
+  version; without `-O` single-core is flat at 1.20M.)
 
 > **Fairness notes.** The corpus is synthetic and reuses SDP media endpoints, so
 > voipmonitor's default `sdp_multiplication=3` DoS-guard would suppress the
@@ -85,16 +107,21 @@ correctly at every scale** — the difference is throughput and memory:
 
 | calls | pkts | voipmonitor | sipnab | sipnab speed-up | sipnab RSS edge |
 |------:|-----:|---|---|---:|---:|
-| 500 | 53.5k | 72k p/s · 150 MiB | 539k p/s · 33 MiB | 7.5× | 4.5× |
-| 2000 | 214k | 155k p/s · 506 MiB | 500k p/s · 72 MiB | 3.2× | 7.0× |
-| 8000 | 856k | 233k p/s · 1931 MiB | 409k p/s · 217 MiB | 1.75× | 8.9× |
-| 20000 | 2.14M | 264k p/s · 4782 MiB | 340k p/s · 507 MiB | 1.29× | 9.4× |
+| 500 | 53.5k | 72k p/s · 150 MiB | 699k p/s · 42 MiB | 9.7× | 3.6× |
+| 2000 | 214k | 155k p/s · 506 MiB | 697k p/s · 96 MiB | 4.5× | 5.3× |
+| 8000 | 856k | 233k p/s · 1931 MiB | 726k p/s · 230 MiB | 3.1× | 8.4× |
+| 20000 | 2.14M | 264k p/s · 4782 MiB | 703k p/s · 519 MiB | 2.7× | 9.2× |
 
-**Honest read:** sipnab leads on throughput at every scale up to 20k calls, but
-voipmonitor is multithreaded and its per-packet throughput *climbs* with scale
-(72k → 264k p/s), overtaking sipnab on raw speed at roughly ~40k calls. sipnab's
-standing advantage is **memory** — about 9.4× less RSS at 20k calls (0.5 GiB vs
-4.7 GiB), because voipmonitor buffers and spools heavily. (voipmonitor's *live*
+**Honest read:** sipnab leads on throughput at every measured scale, holding a
+flat ~700k p/s while voipmonitor's multithreaded per-packet throughput *climbs*
+with scale (72k → 264k p/s) — on 0.4.16 that climb crossed over at roughly
+~40k calls; on 0.5.18 the sweep no longer flags a crossover inside any
+plausible operating range. sipnab's standing advantage is still **memory** —
+about 9.2× less RSS at 20k calls (0.5 GiB vs 4.7 GiB), because voipmonitor
+buffers and spools heavily. (An apparent small-scale RSS growth vs the June
+figures — 39 vs 33 MiB at 500 calls — was A/B-checked: 0.4.16 measures
+40/99 MiB on the same day 0.5.17 measures 39/103, so the delta was session
+variance, not a version regression.) (voipmonitor's *live*
 capture reconstructed 0 calls on this box's virtual NIC — an mmap-ring quirk — so
 this comparison is offline-only.)
 
@@ -109,5 +136,7 @@ voipmonitor  voipmonitor -r corpus.pcap -c -k --config-file=vm.conf   # sdp_mult
 sipnab       sipnab -N -I corpus.pcap --cores 4 --report --no-cli-print
 ```
 
-The carrier corpus generator and the comparison harness live in the companion
-`siptest` repo (`bench/carrier.py`, `bench/fourtool.sh`).
+The carrier corpus generator and the comparison harness
+(`bench/carrier.py`, `bench/fourtool.sh`) live in the internal `siptest`
+harness, which is not publicly published — the corpus parameters and the
+exact commands above are the full recipe.

--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -414,3 +414,30 @@ fn docs_current_version_markers_match_cargo() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// The benchmarks page exists twice — docs/benchmarks.md (source of the GitHub
+// Wiki) and website/content/docs/benchmarks.md (the site) — with deliberately
+// different framing but the SAME measured data. A re-benchmark once landed
+// only on the website (0.5.18 numbers) while the wiki kept publishing the
+// 0.4.16 tables plus a perf claim the same PR had retracted. The prose may
+// differ; the tables may not.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn benchmark_tables_match_between_docs_and_website() {
+    fn rows(text: &str) -> Vec<&str> {
+        text.lines()
+            .filter(|l| l.starts_with('|'))
+            .map(str::trim_end)
+            .collect()
+    }
+    let docs = rows(include_str!("../docs/benchmarks.md"));
+    let site = rows(include_str!("../website/content/docs/benchmarks.md"));
+    assert_eq!(
+        docs, site,
+        "benchmark tables differ between docs/benchmarks.md (wiki source) and \
+         website/content/docs/benchmarks.md — re-benchmarks must update BOTH \
+         files in the same commit, or the wiki publishes stale numbers"
+    );
+}

--- a/tests/site_journey_test.rs
+++ b/tests/site_journey_test.rs
@@ -637,3 +637,30 @@ fn footer_is_one_non_wrapping_row_with_icon_sponsor_links() {
          breaks into a second line"
     );
 }
+
+// ---------------------------------------------------------------------------
+// CSS cache-buster journey: the stylesheet link once used `?v=<version>`, so
+// a site-only change (same crate version) shipped new HTML against CACHED old
+// CSS — the single-row footer rendered as three unstyled block rows for every
+// returning visitor until their cache expired. The buster must be Zola's
+// content hash (`cachebust=true`), which changes whenever the CSS does.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stylesheet_link_is_content_hash_cachebusted() {
+    let base = read("website/templates/base.html");
+    let link = base
+        .lines()
+        .find(|l| l.contains("style.css") && l.contains("stylesheet"))
+        .expect("base.html has no style.css <link>");
+    assert!(
+        !link.contains("?v="),
+        "style.css is busted by release version — a site-only change keeps \
+         the URL identical and ships new HTML with stale cached CSS: {link}"
+    );
+    assert!(
+        link.contains("cachebust=true"),
+        "style.css link must use get_url(..., cachebust=true) so the URL \
+         changes whenever the CSS content does: {link}"
+    );
+}

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -43,8 +43,9 @@
   <link href="https://fonts.bunny.net/css?family=inter:400,500,600,700|jetbrains-mono:400,500&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <!-- Buster tracks the release version so CSS can't go stale between releases. -->
-  <link rel="stylesheet" href="{{ get_url(path='style.css') }}?v={{ config.extra.version }}">
+  <!-- Content-hash buster: the URL changes whenever the CSS does, so site-only
+       edits (same release version) can never ship new HTML on stale CSS. -->
+  <link rel="stylesheet" href="{{ get_url(path='style.css', cachebust=true) }}">
 
   <!-- Search -->
   {% if config.build_search_index %}

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -165,7 +165,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2564 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2566 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -236,7 +236,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.4.16)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2564" data-suffix="">2562</span>
+        <span class="arch-stat" data-count="2566" data-suffix="">2562</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Two fixes for content shipped out of sync:

**Stale-CSS footer.** The stylesheet was cache-busted by release version (`?v=0.5.18`), so the footer redesign — a site-only change with the version unchanged — shipped new HTML against cached old CSS: the single-row footer rendered as three unstyled block rows for returning visitors. The link now uses Zola's `cachebust=true` content hash, which changes whenever the CSS does. A drift gate forbids `?v=` busting. Verified: local Zola build emits `style.css?h=23eee498`.

**Stale wiki benchmarks.** `docs/benchmarks.md` (the GitHub Wiki source) still published the June 0.4.16 tables and the WS8.3 perf claim retracted in #167, which updated only `website/content/docs/benchmarks.md`. The docs page now carries the 0.5.18 artifact numbers and corrected claims; a new drift gate requires the benchmark tables in both files to be row-identical, so a re-benchmark can never again update one and not the other. Merging this touches `docs/`, which auto-triggers the wiki-sync workflow. Verified: local `build-wiki.py` run emits a Benchmarks page with the 0.5.18 data and no stale rows.

Homepage test count moves 2564 → 2566 for the two new gates.