### PR TITLE
site: organize downloads for devops and source personas

### DIFF
--- a/tests/site_journey_test.rs
+++ b/tests/site_journey_test.rs
@@ -666,6 +666,69 @@ fn stylesheet_link_is_content_hash_cachebusted() {
 }
 
 // ---------------------------------------------------------------------------
+// Download-personas journey: the download page serves two audiences that the
+// platform tabs alone don't. DevOps wants binaries with no interactive steps:
+// the ghcr.io container image (published on every tag since v0.5.x but absent
+// from the site for months), a version-pinned scripted install, raw artifact
+// URLs with checksum sidecars, and latest-version discovery without HTML
+// scraping. Developers want the source alongside the binaries: source
+// archives for the tag, cargo install, and the build docs. Modeled on how
+// rclone ("Downloads for scripting") and Prometheus (artifact table with
+// checksums) organize theirs.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn download_page_serves_devops_and_source_personas() {
+    let tpl = read("website/templates/download.html");
+
+    // DevOps: container image, pinned + latest tags.
+    assert!(
+        tpl.contains("ghcr.io/normb/sipnab"),
+        "download page must offer the ghcr.io/normb/sipnab container image \
+         (docker.yml publishes it on every tag)"
+    );
+    // DevOps: an automation section, reachable from the page ToC.
+    assert!(
+        tpl.contains("id=\"automation\""),
+        "download page needs an #automation section for the scripted/CI path"
+    );
+    assert!(
+        tpl.contains("href=\"#automation\""),
+        "the page ToC must link to #automation"
+    );
+    // DevOps: version-pinned scripted install (install.sh honors these).
+    assert!(
+        tpl.contains("SIPNAB_VERSION"),
+        "automation section must document SIPNAB_VERSION for pinned installs"
+    );
+    // DevOps: latest-version discovery without scraping HTML.
+    assert!(
+        tpl.contains("api.github.com/repos/NormB/sipnab/releases/latest"),
+        "automation section must show latest-version discovery via the \
+         releases API"
+    );
+    // DevOps: checksum sidecars are linked next to the artifacts.
+    assert!(
+        tpl.contains(".tar.gz.sha256"),
+        "artifact table must link the per-tarball .sha256 sidecars"
+    );
+
+    // Developers: source alongside binaries.
+    assert!(
+        tpl.contains("archive/refs/tags/v"),
+        "source panel must link the tag's source archives"
+    );
+    assert!(
+        tpl.contains("cargo install sipnab"),
+        "source panel must offer cargo install (sipnab is on crates.io)"
+    );
+    assert!(
+        tpl.contains("@/docs/build.md"),
+        "source panel must link the Build-from-Source docs page"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // CSP hash journey: the production CSP (a Cloudflare transform rule, managed
 // by ops/cloudflare/refresh_csp_hashes.py) allows inline <script> blocks by
 // sha256 hash, NOT 'unsafe-inline'. Editing an inline script without
@@ -692,7 +755,7 @@ fn inline_script_edits_require_csp_hash_refresh() {
         ),
         (
             "download.html",
-            "sha256-ctMMjX6eGBuCwOn4PgMH0LM2iCFYYMKSllifowD+6fA=",
+            "sha256-Xtyi8+j9vCissO93mpqXa8azlys1i9B1bM6M7KOXx6Q=",
         ),
         (
             "index.html",

--- a/website/templates/download.html
+++ b/website/templates/download.html
@@ -19,6 +19,7 @@
           <li><a class="doc-nav-link dl-toc-os" data-os="debian" href="#platforms">Debian &amp; RHEL packages</a></li>
           <li><a class="doc-nav-link dl-toc-os" data-os="linux" href="#platforms">Linux static binary</a></li>
           <li><a class="doc-nav-link dl-toc-os" data-os="source" href="#platforms">Build from source</a></li>
+          <li><a class="doc-nav-link" href="#automation">Docker &amp; automation</a></li>
           <li><a class="doc-nav-link" href="#all-files">All release files</a></li>
           <li><a class="doc-nav-link" href="#verify">Verify your download</a></li>
         </ul>
@@ -205,32 +206,99 @@
         <button type="button" class="dl-copy" data-copy="git clone {{ config.extra.github_url }}.git&#10;cd sipnab &amp;&amp; cargo build --release --features full" aria-label="Copy commands"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
       </div>
     </div>
-    <p class="dl-note">The release binary lands at <code>target/release/sipnab</code>.</p>
+    <p class="dl-note">The release binary lands at <code>target/release/sipnab</code>. Toolchain, build deps, and feature flags: <a href="{{ get_url(path='@/docs/build.md') }}">Build from Source</a>.</p>
+    <div class="dl-term">
+      <div class="dl-term-head"><span class="dl-dots"><i></i><i></i><i></i></span><span class="dl-term-title">or straight from crates.io</span></div>
+      <div class="dl-term-body">
+        <code><span class="dl-prompt">$</span>cargo install sipnab --features full</code>
+        <button type="button" class="dl-copy" data-copy="cargo install sipnab --features full" aria-label="Copy command"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
+      </div>
+    </div>
+    <div class="dl-direct">
+      <span class="dl-direct-label">Source archives for v{{ v }} &mdash; the exact tagged tree, no git needed</span>
+      <div class="dl-tiles">
+        <a class="dl-tile dl-tile--sm" href="{{ config.extra.github_url }}/archive/refs/tags/v{{ v }}.tar.gz">
+          <span class="dl-tile-txt"><span class="dl-tile-name">Source</span><span class="dl-tile-sub">v{{ v }} &middot; tar.gz</span></span>
+          <span class="dl-tile-dl"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></span>
+        </a>
+        <a class="dl-tile dl-tile--sm" href="{{ config.extra.github_url }}/archive/refs/tags/v{{ v }}.zip">
+          <span class="dl-tile-txt"><span class="dl-tile-name">Source</span><span class="dl-tile-sub">v{{ v }} &middot; zip</span></span>
+          <span class="dl-tile-dl"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></span>
+        </a>
+      </div>
+    </div>
   </div>
 
   <p class="dl-verify-hint"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true"><path d="M12 3l7 4v5c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V7l7-4z"/><path d="M9 12l2 2 4-4"/></svg><span>Grabbed a file above? <a href="#verify">Verify its checksum &darr;</a> &mdash; sipnab is a security tool.</span></p>
+
+  <section class="dl-automation" id="automation">
+    <div class="dl-method-head"><h2>Docker &amp; automation</h2><span class="dl-rec dl-rec--blue">for CI &amp; fleets</span></div>
+    <p class="dl-lead">No interactive steps: a container image on every release, version-pinned scripted installs, and raw artifact URLs your tooling can fetch and verify.</p>
+
+    <div class="dl-direct">
+      <span class="dl-direct-label">Container image &mdash; ghcr.io, x86-64 &amp; ARM64, runs as non-root</span>
+      <div class="dl-term">
+        <div class="dl-term-head"><span class="dl-dots"><i></i><i></i><i></i></span><span class="dl-term-title">pin the version tag; <code>latest</code> tracks releases</span></div>
+        <div class="dl-term-body dl-term-body--multi">
+          <code><span class="dl-prompt">$</span>docker pull ghcr.io/normb/sipnab:{{ v }}
+<span class="dl-prompt">$</span>docker run --rm -v "$PWD:/data" ghcr.io/normb/sipnab:{{ v }} -N -I /data/capture.pcap --report</code>
+          <button type="button" class="dl-copy" data-copy="docker pull ghcr.io/normb/sipnab:{{ v }}&#10;docker run --rm -v &quot;$PWD:/data&quot; ghcr.io/normb/sipnab:{{ v }} -N -I /data/capture.pcap --report" aria-label="Copy docker commands"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
+        </div>
+      </div>
+      <p class="dl-note">Offline pcap analysis needs nothing extra. Live capture inside the container needs <code>--cap-add NET_RAW --net host</code>.</p>
+    </div>
+
+    <div class="dl-direct">
+      <span class="dl-direct-label">Scripted install &mdash; pin the version, checksum-verified, no prompts</span>
+      <div class="dl-term">
+        <div class="dl-term-head"><span class="dl-dots"><i></i><i></i><i></i></span><span class="dl-term-title">same installer the Quick-install path uses</span></div>
+        <div class="dl-term-body">
+          <code><span class="dl-prompt">$</span>curl -fsSL https://www.sipnab.com/install.sh | SIPNAB_VERSION={{ v }} sh</code>
+          <button type="button" class="dl-copy" data-copy="curl -fsSL https://www.sipnab.com/install.sh | SIPNAB_VERSION={{ v }} sh" aria-label="Copy pinned install command"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
+        </div>
+      </div>
+      <p class="dl-note">Omit <code>SIPNAB_VERSION</code> to track the latest release; <code>SIPNAB_INSTALL_DIR</code> overrides the <code>/usr/local/bin</code> destination. The script picks the CPU and glibc-appropriate build and verifies its <code>sha256</code> before installing.</p>
+    </div>
+
+    <div class="dl-direct">
+      <span class="dl-direct-label">Raw URLs for your own tooling</span>
+      <div class="dl-term">
+        <div class="dl-term-head"><span class="dl-dots"><i></i><i></i><i></i></span><span class="dl-term-title">fetch artifact + checksum sidecar, then verify</span></div>
+        <div class="dl-term-body dl-term-body--multi">
+          <code><span class="dl-prompt">$</span>curl -fsSLO {{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-musl.tar.gz \
+       -O {{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-musl.tar.gz.sha256
+<span class="dl-prompt">$</span>sha256sum -c sipnab-{{ v }}-x86_64-unknown-linux-musl.tar.gz.sha256</code>
+          <button type="button" class="dl-copy" data-copy="curl -fsSLO {{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-musl.tar.gz -O {{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-musl.tar.gz.sha256&#10;sha256sum -c sipnab-{{ v }}-x86_64-unknown-linux-musl.tar.gz.sha256" aria-label="Copy fetch-and-verify commands"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
+        </div>
+      </div>
+      <p class="dl-note">Swap the target triple from the <a href="#all-files">table below</a>. Latest-version discovery without scraping HTML: <code>curl -fsSL https://api.github.com/repos/NormB/sipnab/releases/latest | jq -r .tag_name</code></p>
+    </div>
+  </section>
 
   <section class="dl-allfiles" id="all-files">
     <div class="dl-method-head"><h2>Every file, one table</h2><span class="dl-rec dl-rec--dim">for the seasoned</span></div>
     <div class="dl-table-wrap" tabindex="0" role="region" aria-label="Release artifacts table">
       <table class="dl-table">
-        <caption class="dl-table-cap">Every sipnab v{{ v }} release artifact &mdash; filename, CPU architecture, what it runs on, and notes.</caption>
-        <thead><tr><th scope="col">File</th><th scope="col">CPU</th><th scope="col">Runs on</th><th scope="col">Notes</th></tr></thead>
+        <caption class="dl-table-cap">Every sipnab v{{ v }} release artifact &mdash; filename, CPU architecture, what it runs on, notes, and its checksum.</caption>
+        <thead><tr><th scope="col">File</th><th scope="col">CPU</th><th scope="col">Runs on</th><th scope="col">Notes</th><th scope="col">sha256</th></tr></thead>
         <tbody>
-          <tr><td><a href="{{ rel }}/sipnab_{{ v }}_amd64.deb"><code>sipnab_{{ v }}_amd64.deb</code></a></td><td>x86_64 / amd64</td><td>{{ config.extra.glibc_floor_distros }}</td><td>apt-managed, full features</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab_{{ v }}_arm64.deb"><code>sipnab_{{ v }}_arm64.deb</code></a></td><td>aarch64 / arm64</td><td>{{ config.extra.glibc_floor_distros }}</td><td>apt-managed, full features</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab_{{ v }}_amd64-noaudio.deb"><code>sipnab_{{ v }}_amd64-noaudio.deb</code></a></td><td>x86_64 / amd64</td><td>{{ config.extra.glibc_floor_distros }}</td><td>no ALSA dependency &mdash; headless servers</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab_{{ v }}_arm64-noaudio.deb"><code>sipnab_{{ v }}_arm64-noaudio.deb</code></a></td><td>aarch64 / arm64</td><td>{{ config.extra.glibc_floor_distros }}</td><td>no ALSA dependency &mdash; headless servers</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-1.x86_64.rpm"><code>sipnab-{{ v }}-1.x86_64.rpm</code></a></td><td>x86_64 / amd64</td><td>RHEL/Fedora (glibc &ge; {{ config.extra.glibc_floor }})</td><td>dnf/rpm-managed, full features</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-1.aarch64.rpm"><code>sipnab-{{ v }}-1.aarch64.rpm</code></a></td><td>aarch64 / arm64</td><td>RHEL/Fedora (glibc &ge; {{ config.extra.glibc_floor }})</td><td>dnf/rpm-managed, full features</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-1.x86_64-noaudio.rpm"><code>sipnab-{{ v }}-1.x86_64-noaudio.rpm</code></a></td><td>x86_64 / amd64</td><td>RHEL/Fedora (glibc &ge; {{ config.extra.glibc_floor }})</td><td>no ALSA weak dep &mdash; headless servers</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-1.aarch64-noaudio.rpm"><code>sipnab-{{ v }}-1.aarch64-noaudio.rpm</code></a></td><td>aarch64 / arm64</td><td>RHEL/Fedora (glibc &ge; {{ config.extra.glibc_floor }})</td><td>no ALSA weak dep &mdash; headless servers</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-musl.tar.gz"><code>&hellip;x86_64-unknown-linux-musl.tar.gz</code></a></td><td>x86_64 / amd64</td><td>any Linux, any glibc, Alpine</td><td>static &mdash; no audio playback</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-aarch64-unknown-linux-musl.tar.gz"><code>&hellip;aarch64-unknown-linux-musl.tar.gz</code></a></td><td>aarch64 / arm64</td><td>any Linux, any glibc, Alpine</td><td>static &mdash; no audio playback</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-gnu.tar.gz"><code>&hellip;x86_64-unknown-linux-gnu.tar.gz</code></a></td><td>x86_64 / amd64</td><td>glibc &ge; {{ config.extra.glibc_floor }} + libpcap</td><td>full features incl. audio</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-aarch64-unknown-linux-gnu.tar.gz"><code>&hellip;aarch64-unknown-linux-gnu.tar.gz</code></a></td><td>aarch64 / arm64</td><td>glibc &ge; {{ config.extra.glibc_floor }} + libpcap</td><td>full features incl. audio</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-aarch64-apple-darwin.tar.gz"><code>&hellip;aarch64-apple-darwin.tar.gz</code></a></td><td>Apple Silicon</td><td>macOS 12+</td><td>M-series Macs</td></tr>
-          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-x86_64-apple-darwin.tar.gz"><code>&hellip;x86_64-apple-darwin.tar.gz</code></a></td><td>Intel</td><td>macOS 12+</td><td>Intel Macs</td></tr>
+          <tr><td><a href="{{ rel }}/sipnab_{{ v }}_amd64.deb"><code>sipnab_{{ v }}_amd64.deb</code></a></td><td>x86_64 / amd64</td><td>{{ config.extra.glibc_floor_distros }}</td><td>apt-managed, full features</td><td><a href="{{ rel }}/SHA256SUMS.txt">SUMS</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab_{{ v }}_arm64.deb"><code>sipnab_{{ v }}_arm64.deb</code></a></td><td>aarch64 / arm64</td><td>{{ config.extra.glibc_floor_distros }}</td><td>apt-managed, full features</td><td><a href="{{ rel }}/SHA256SUMS.txt">SUMS</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab_{{ v }}_amd64-noaudio.deb"><code>sipnab_{{ v }}_amd64-noaudio.deb</code></a></td><td>x86_64 / amd64</td><td>{{ config.extra.glibc_floor_distros }}</td><td>no ALSA dependency &mdash; headless servers</td><td><a href="{{ rel }}/SHA256SUMS.txt">SUMS</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab_{{ v }}_arm64-noaudio.deb"><code>sipnab_{{ v }}_arm64-noaudio.deb</code></a></td><td>aarch64 / arm64</td><td>{{ config.extra.glibc_floor_distros }}</td><td>no ALSA dependency &mdash; headless servers</td><td><a href="{{ rel }}/SHA256SUMS.txt">SUMS</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-1.x86_64.rpm"><code>sipnab-{{ v }}-1.x86_64.rpm</code></a></td><td>x86_64 / amd64</td><td>RHEL/Fedora (glibc &ge; {{ config.extra.glibc_floor }})</td><td>dnf/rpm-managed, full features</td><td><a href="{{ rel }}/SHA256SUMS.txt">SUMS</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-1.aarch64.rpm"><code>sipnab-{{ v }}-1.aarch64.rpm</code></a></td><td>aarch64 / arm64</td><td>RHEL/Fedora (glibc &ge; {{ config.extra.glibc_floor }})</td><td>dnf/rpm-managed, full features</td><td><a href="{{ rel }}/SHA256SUMS.txt">SUMS</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-1.x86_64-noaudio.rpm"><code>sipnab-{{ v }}-1.x86_64-noaudio.rpm</code></a></td><td>x86_64 / amd64</td><td>RHEL/Fedora (glibc &ge; {{ config.extra.glibc_floor }})</td><td>no ALSA weak dep &mdash; headless servers</td><td><a href="{{ rel }}/SHA256SUMS.txt">SUMS</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-1.aarch64-noaudio.rpm"><code>sipnab-{{ v }}-1.aarch64-noaudio.rpm</code></a></td><td>aarch64 / arm64</td><td>RHEL/Fedora (glibc &ge; {{ config.extra.glibc_floor }})</td><td>no ALSA weak dep &mdash; headless servers</td><td><a href="{{ rel }}/SHA256SUMS.txt">SUMS</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-musl.tar.gz"><code>&hellip;x86_64-unknown-linux-musl.tar.gz</code></a></td><td>x86_64 / amd64</td><td>any Linux, any glibc, Alpine</td><td>static &mdash; no audio playback</td><td><a href="{{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-musl.tar.gz.sha256">.sha256</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-aarch64-unknown-linux-musl.tar.gz"><code>&hellip;aarch64-unknown-linux-musl.tar.gz</code></a></td><td>aarch64 / arm64</td><td>any Linux, any glibc, Alpine</td><td>static &mdash; no audio playback</td><td><a href="{{ rel }}/sipnab-{{ v }}-aarch64-unknown-linux-musl.tar.gz.sha256">.sha256</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-gnu.tar.gz"><code>&hellip;x86_64-unknown-linux-gnu.tar.gz</code></a></td><td>x86_64 / amd64</td><td>glibc &ge; {{ config.extra.glibc_floor }} + libpcap</td><td>full features incl. audio</td><td><a href="{{ rel }}/sipnab-{{ v }}-x86_64-unknown-linux-gnu.tar.gz.sha256">.sha256</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-aarch64-unknown-linux-gnu.tar.gz"><code>&hellip;aarch64-unknown-linux-gnu.tar.gz</code></a></td><td>aarch64 / arm64</td><td>glibc &ge; {{ config.extra.glibc_floor }} + libpcap</td><td>full features incl. audio</td><td><a href="{{ rel }}/sipnab-{{ v }}-aarch64-unknown-linux-gnu.tar.gz.sha256">.sha256</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-aarch64-apple-darwin.tar.gz"><code>&hellip;aarch64-apple-darwin.tar.gz</code></a></td><td>Apple Silicon</td><td>macOS 12+</td><td>M-series Macs</td><td><a href="{{ rel }}/sipnab-{{ v }}-aarch64-apple-darwin.tar.gz.sha256">.sha256</a></td></tr>
+          <tr><td><a href="{{ rel }}/sipnab-{{ v }}-x86_64-apple-darwin.tar.gz"><code>&hellip;x86_64-apple-darwin.tar.gz</code></a></td><td>Intel</td><td>macOS 12+</td><td>Intel Macs</td><td><a href="{{ rel }}/sipnab-{{ v }}-x86_64-apple-darwin.tar.gz.sha256">.sha256</a></td></tr>
+          <tr><td><a href="{{ rel }}/SHA256SUMS.txt"><code>SHA256SUMS.txt</code></a></td><td>&mdash;</td><td>&mdash;</td><td>checksums for every artifact above</td><td>&mdash;</td></tr>
+          <tr><td><a href="{{ config.extra.github_url }}/archive/refs/tags/v{{ v }}.tar.gz"><code>v{{ v }}.tar.gz</code> (source)</a></td><td>&mdash;</td><td>anywhere Rust 1.92+ builds</td><td>tagged source tree</td><td>&mdash;</td></tr>
+          <tr><td><a href="{{ config.extra.github_url }}/archive/refs/tags/v{{ v }}.zip"><code>v{{ v }}.zip</code> (source)</a></td><td>&mdash;</td><td>anywhere Rust 1.92+ builds</td><td>tagged source tree</td><td>&mdash;</td></tr>
         </tbody>
       </table>
     </div>
@@ -317,7 +385,7 @@
         if (en.isIntersecting) { tocSection = en.target.id; markToc(); }
       });
     }, { rootMargin: '-15% 0px -70% 0px' });
-    ['installer', 'platforms', 'all-files', 'verify'].forEach(function (id) {
+    ['installer', 'platforms', 'automation', 'all-files', 'verify'].forEach(function (id) {
       var el = document.getElementById(id);
       if (el) { io.observe(el); }
     });

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -165,7 +165,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2567 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2568 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -236,7 +236,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.4.16)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2567" data-suffix="">2562</span>
+        <span class="arch-stat" data-count="2568" data-suffix="">2562</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Modeled on how rclone ("Downloads for scripting") and Prometheus (checksummed artifact table) organize their downloads, for two audiences the platform tabs alone didn't serve:

**DevOps — binaries only, no interactive steps.** New "Docker & automation" section: the `ghcr.io/normb/sipnab` container image (published on every tag by docker.yml but absent from the site until now) with pin-vs-latest tags, a run example, and the `--cap-add NET_RAW --net host` note for live capture; version-pinned scripted install documenting `SIPNAB_VERSION` / `SIPNAB_INSTALL_DIR`; raw artifact URL + `.sha256` sidecar fetch-and-verify; latest-version discovery via the releases API.

**Developers — source alongside binaries.** The Source panel gains the tag's source archives (tar.gz/zip), `cargo install sipnab --features full` from crates.io, and the Build-from-Source docs link.

**Artifact table** gains a sha256 column (sidecars for tarballs, SHA256SUMS.txt for packages) plus rows for SHA256SUMS.txt and the source archives.

The scrollspy id list gained `automation`, changing the download page's inline-script hash — the CSP pin is updated in this PR (the #170 gate caught it, as designed), and `refresh_csp_hashes.py` must run right after this deploys. New drift gate locks every persona affordance (proven red first). Homepage count 2567 → 2568. Verified: 15/15 site tests, clean Zola build with anchor checking.