### PR TITLE
release: sigstore build-provenance attestations; site: authorship notice

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   packages: write
+  id-token: write
+  attestations: write
 
 env:
   REGISTRY: ghcr.io
@@ -40,6 +42,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -48,3 +51,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Sigstore provenance for the image, stored in ghcr next to it so
+      #   gh attestation verify oci://ghcr.io/normb/sipnab:<tag> --repo NormB/sipnab
+      # proves the image came from this workflow. subject-name is the
+      # lowercase registry path — github.repository is mixed-case.
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ghcr.io/normb/sipnab
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,6 +302,13 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    # id-token + attestations power the sigstore provenance step below;
+    # contents must be restated because a job-level block replaces the
+    # workflow-level grant.
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v7
 
@@ -316,6 +323,19 @@ jobs:
           cd artifacts
           sha256sum *.tar.gz *.deb *.rpm > SHA256SUMS.txt
           cat SHA256SUMS.txt
+
+      # Sigstore build provenance for every artifact: cryptographic proof it
+      # was built by THIS workflow from THIS commit, so a rehosted or tampered
+      # copy is detectable. Anyone can check a download with
+      #   gh attestation verify <file> --repo NormB/sipnab
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            artifacts/*.tar.gz
+            artifacts/*.deb
+            artifacts/*.rpm
+            artifacts/SHA256SUMS.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/tests/site_journey_test.rs
+++ b/tests/site_journey_test.rs
@@ -729,6 +729,68 @@ fn download_page_serves_devops_and_source_personas() {
 }
 
 // ---------------------------------------------------------------------------
+// Provenance & authorship journey: sipnab is a security tool, so a rehosted
+// or tampered copy of its artifacts must be detectable. Every release binary
+// and the container image carry sigstore build-provenance attestations
+// (verify with `gh attestation verify`), and the site states its authorship
+// and content license so republished copies without attribution are a clean
+// takedown case. These guards keep the attestation steps and the notice from
+// being silently dropped.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn releases_are_attested_and_site_content_is_licensed() {
+    // Release artifacts: one attestation pass over everything uploaded.
+    let rel = read(".github/workflows/release.yml");
+    assert!(
+        rel.contains("actions/attest-build-provenance@"),
+        "release.yml lost its build-provenance attestation step"
+    );
+    for perm in ["id-token: write", "attestations: write"] {
+        assert!(
+            rel.contains(perm),
+            "release.yml needs `{perm}` for sigstore attestations"
+        );
+    }
+
+    // Container image: attested by digest and pushed to the registry.
+    let docker = read(".github/workflows/docker.yml");
+    assert!(
+        docker.contains("actions/attest-build-provenance@"),
+        "docker.yml lost its image attestation step"
+    );
+    for perm in ["id-token: write", "attestations: write"] {
+        assert!(
+            docker.contains(perm),
+            "docker.yml needs `{perm}` for sigstore attestations"
+        );
+    }
+    assert!(
+        docker.contains("push-to-registry: true"),
+        "the image attestation must be pushed to ghcr so \
+         `gh attestation verify oci://...` works"
+    );
+
+    // The download page tells verifiers the attestation exists.
+    let dl = read("website/templates/download.html");
+    assert!(
+        dl.contains("gh attestation verify"),
+        "download verify section must mention `gh attestation verify`"
+    );
+
+    // Site footer: copyright + docs content license.
+    let footer = base_block("footer");
+    assert!(
+        footer.contains("&copy;"),
+        "footer must carry a copyright notice"
+    );
+    assert!(
+        footer.contains("creativecommons.org/licenses/by/4.0"),
+        "footer must link the docs content license (CC BY 4.0)"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // CSP hash journey: the production CSP (a Cloudflare transform rule, managed
 // by ops/cloudflare/refresh_csp_hashes.py) allows inline <script> blocks by
 // sha256 hash, NOT 'unsafe-inline'. Editing an inline script without

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -159,7 +159,9 @@
         <div class="footer-meta">
           <span class="footer-credit"><a href="{{ config.extra.github_url }}#license">MIT / Apache-2.0</a></span>
           <span class="footer-sep">&middot;</span>
-          <span class="footer-credit"><a href="{{ config.extra.linkedin_url }}">{{ config.extra.author }}</a></span>
+          <span class="footer-credit"><a href="https://creativecommons.org/licenses/by/4.0/" rel="license">docs CC BY 4.0</a></span>
+          <span class="footer-sep">&middot;</span>
+          <span class="footer-credit"><a href="{{ config.extra.linkedin_url }}">&copy; {{ now() | date(format="%Y") }} {{ config.extra.author }}</a></span>
           <a href="{{ config.extra.patreon_url }}" class="footer-icon footer-icon-patreon" aria-label="Support sipnab on Patreon" title="Patreon" target="_blank" rel="noopener">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M14.82 2.41c-4.5 0-8.16 3.66-8.16 8.16 0 4.49 3.66 8.14 8.16 8.14 4.49 0 8.14-3.65 8.14-8.14 0-4.5-3.65-8.16-8.14-8.16M1.04 21.6h3.99V2.41H1.04z"/></svg>
           </a>

--- a/website/templates/download.html
+++ b/website/templates/download.html
@@ -323,6 +323,7 @@
       </div>
     </div>
     <p class="dl-note">Grab <a href="{{ rel }}/SHA256SUMS.txt">SHA256SUMS.txt</a> into the same folder as your download, then run the check for your OS. An <code>OK</code> line means it&rsquo;s authentic. Each tarball also ships an individual <code>.sha256</code>; <code>.deb</code> and <code>.rpm</code> checksums live only in <code>SHA256SUMS.txt</code>.</p>
+    <p class="dl-note">Beyond checksums, releases carry sigstore build provenance &mdash; cryptographic proof an artifact was built by this repository&rsquo;s CI from a specific commit, so a rehosted or tampered copy can&rsquo;t impersonate a real one: <code>gh attestation verify sipnab-&lt;file&gt; --repo NormB/sipnab</code> (or <code>oci://ghcr.io/normb/sipnab:&lt;tag&gt;</code> for the container image).</p>
   </section>
 
   <footer class="dl-meta">

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -165,7 +165,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2568 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2569 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -236,7 +236,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.4.16)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2568" data-suffix="">2562</span>
+        <span class="arch-stat" data-count="2569" data-suffix="">2562</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
**Attestations.** Every release artifact (tarballs, deb, rpm, SHA256SUMS.txt) and the ghcr container image now carry sigstore build-provenance attestations via `actions/attest-build-provenance@v4` — cryptographic proof they were built by this repository's CI from a specific commit, so a rehosted or tampered copy can't impersonate a real one. Verify with `gh attestation verify <file> --repo NormB/sipnab` or `oci://ghcr.io/normb/sipnab:<tag>`. The image attestation is pushed to ghcr so the oci:// form works. Effective from the next tag. The download page's verify section documents the check.

**Authorship / content license.** The footer now states `MIT / Apache-2.0 · docs CC BY 4.0 · © <year> <author>` (year via `now()` at build time), making unattributed republication of the docs a clean takedown case.

Drift gate locks the workflow permissions, attestation steps, footer notice, and verify mention (proven red first). Homepage count 2568 → 2569. 16/16 site tests, clean Zola build; the CSP pin gate confirms no inline script changed.