### PR TITLE
release 0.5.19: sigstore attestations + download/site overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.19] - 2026-07-20
+
+No packet-path code changes versus 0.5.18 — this release exists to ship
+build provenance and the reworked website/download experience.
+
+### Added
+- Sigstore build-provenance attestations on every release artifact
+  (tarballs, `.deb`, `.rpm`, `SHA256SUMS.txt`) and on the ghcr container
+  image. Verify a download with
+  `gh attestation verify <file> --repo NormB/sipnab`, or the image with
+  `gh attestation verify oci://ghcr.io/normb/sipnab:<tag> --repo NormB/sipnab`.
+- Download page: "Docker & automation" section (ghcr image with pin-vs-latest
+  tags, version-pinned scripted install via `SIPNAB_VERSION`, raw-URL
+  fetch-and-verify, latest-version discovery through the releases API);
+  source archives, `cargo install`, and build-docs links on the Source tab;
+  sha256 column and complete artifact inventory in the all-files table.
+- Site footer states authorship and content licensing:
+  MIT / Apache-2.0 (code) · CC BY 4.0 (docs) · copyright.
+
+### Fixed
+- Download page platform tabs (Deb/RPM, Linux, Source) were dead in
+  production: the tab script's sha256 no longer matched the CSP header's
+  allowlist, so browsers silently blocked it. The CSP rule is refreshed and
+  a pinned-hash test gate now fails any inline-script edit until the rule
+  is updated.
+- Footer rendered as three unstyled rows for returning visitors: the
+  stylesheet cache-buster was the release version, which site-only changes
+  never bump, so new HTML shipped against stale cached CSS. The stylesheet
+  URL now carries a content hash.
+- GitHub Wiki benchmarks were stale (0.4.16 tables and a retracted perf
+  claim): the wiki-source docs are re-synced and a drift gate keeps the
+  benchmark tables identical between the wiki source and the website.
+
+### Changed
+- Site footer is a single non-wrapping row; the Patreon / GitHub Sponsors /
+  GitHub links moved out of the top nav into the footer as icons.
+
 ## [0.5.18] - 2026-07-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "aes",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 
 [package]
 name = "sipnab"
-version = "0.5.18"
+version = "0.5.19"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Norm Brandinger"]

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -3,8 +3,10 @@
 How fast sipnab is, measured honestly. Every number here is reproducible — the
 host, corpus, tool versions, and exact commands are listed so you can re-run it.
 
-sipnab numbers are measured on the released 0.5.18 artifact — the
-current release 0.5.18, checksum-verified, run 2026-07-20. The comparison
+sipnab numbers are measured on the released 0.5.18 artifact,
+checksum-verified, run 2026-07-20. The current release 0.5.19 changes no
+packet-path code versus 0.5.18 (release provenance, website, and docs work
+only), so the numbers carry over unchanged. The comparison
 tools' numbers come from the 2026-06-24 session — same host, corpus, and
 method, and their versions are unchanged. Versus the 0.4.16 session, 0.5.18
 measures faster at every multi-core operating point (+9–16%) and across the

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ curl -fsSL https://www.sipnab.com/install.sh | sh
 ```
 
 Prefer to read it first: <https://www.sipnab.com/install.sh>. Pin a version
-with `SIPNAB_VERSION=0.5.18`, change the destination with `SIPNAB_INSTALL_DIR`.
+with `SIPNAB_VERSION=0.5.19`, change the destination with `SIPNAB_INSTALL_DIR`.
 
 ## Pre-built Binaries
 
@@ -27,7 +27,7 @@ you which one you are.
 
 ```bash
 # Linux x86_64 (static musl -- runs on any distro, any glibc, Alpine included)
-# Replace <version> with the latest, e.g. 0.5.18
+# Replace <version> with the latest, e.g. 0.5.19
 curl -LO https://github.com/NormB/sipnab/releases/download/v<version>/sipnab-<version>-x86_64-unknown-linux-musl.tar.gz
 tar xzf sipnab-<version>-x86_64-unknown-linux-musl.tar.gz
 sudo install -m 755 sipnab-<version>-x86_64-unknown-linux-musl/sipnab /usr/local/bin/sipnab
@@ -56,7 +56,7 @@ cargo install sipnab --features full
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install with `apt` (it resolves the `libpcap0.8` runtime dependency). The `.deb` needs glibc >= 2.39, i.e. Debian 13+ / Ubuntu 24.04+ -- on older releases use the static musl tarball above:
 
 ```bash
-# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.18
+# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.19
 curl -LO https://github.com/NormB/sipnab/releases/latest/download/sipnab_<version>_amd64.deb
 sudo apt install ./sipnab_<version>_amd64.deb
 
@@ -96,9 +96,9 @@ standard and a `-noaudio` variant (no audio plugin, no `alsa-lib` weak
 dependency — for headless servers, mirroring the `.deb` variants):
 
 ```bash
-sudo rpm -i sipnab-0.5.18-1.x86_64.rpm
+sudo rpm -i sipnab-0.5.19-1.x86_64.rpm
 # headless / no-ALSA variant:
-sudo rpm -i sipnab-0.5.18-1.x86_64-noaudio.rpm
+sudo rpm -i sipnab-0.5.19-1.x86_64-noaudio.rpm
 # arm64 hosts:
 sudo rpm -i sipnab-0.5.18-1.aarch64.rpm
 ```
@@ -282,7 +282,7 @@ sipnab --help
 `--version` lists the Cargo features compiled into the binary, e.g.
 
 ```
-sipnab 0.5.18 (2595058) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+sipnab 0.5.19 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 ```
 
 This is the fastest way to confirm a build was produced with the feature set

--- a/man/sipnab.1
+++ b/man/sipnab.1
@@ -1,7 +1,7 @@
 .\" sipnab.1 -- man page for sipnab
 .\" Copyright 2024-2026 Norm Brandinger
 .\" License: MIT OR Apache-2.0
-.TH SIPNAB 1 "2026-07-20" "sipnab 0.5.18" "User Commands"
+.TH SIPNAB 1 "2026-07-20" "sipnab 0.5.19" "User Commands"
 .SH NAME
 sipnab \- SIP & RTP capture, analysis, and security tool
 .SH SYNOPSIS

--- a/website/config.toml
+++ b/website/config.toml
@@ -26,7 +26,7 @@ theme = "ayu-dark"
 # overwrites this from Cargo.toml at build time (single source of truth), and a
 # pre-commit hook fails if the two drift — so the homepage version badge and the
 # download links always match the released crate. Update Cargo.toml, not this.
-version = "0.5.18"
+version = "0.5.19"
 # Release date of the current `version` above. Shown on /download next to the
 # version. Update alongside Cargo.toml/version when cutting a release.
 release_date = "2026-07-20"

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -754,7 +754,7 @@ Metric names emitted by `src/output/prometheus.rs`:
 | `sipnab_jitter_ms` | histogram | RTP jitter distribution (buckets at 5/10/20/50/100/200ms). |
 | `sipnab_loss_percent` | histogram | RTP packet-loss distribution (buckets at 0.1/0.5/1/2/5/10%). |
 
-The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.18 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
+The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.19 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
 
 ## Security Model
 

--- a/website/content/docs/benchmarks.md
+++ b/website/content/docs/benchmarks.md
@@ -7,8 +7,10 @@ description = "Reproducible throughput and memory benchmarks: sipnab multi-core 
 How fast sipnab is, measured honestly. Every number here is reproducible — the
 host, corpus, tool versions, and exact commands are listed so you can re-run it.
 
-sipnab numbers are measured on the released 0.5.18 artifact — the
-current release 0.5.18, checksum-verified, run 2026-07-20. The comparison
+sipnab numbers are measured on the released 0.5.18 artifact,
+checksum-verified, run 2026-07-20. The current release 0.5.19 changes no
+packet-path code versus 0.5.18 (release provenance, website, and docs work
+only), so the numbers carry over unchanged. The comparison
 tools' numbers come from the 2026-06-24 session — same host, corpus, and
 method, and their versions are unchanged. Versus the 0.4.16 session, 0.5.18
 measures faster at every multi-core operating point (+9–16%) and across the

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -40,7 +40,7 @@ Every [GitHub release](https://github.com/NormB/sipnab/releases) ships versioned
 - `sipnab-<version>-aarch64-unknown-linux-musl.tar.gz` — same, for arm64
 - `sipnab-<version>-x86_64-apple-darwin.tar.gz` / `sipnab-<version>-aarch64-apple-darwin.tar.gz` — macOS
 
-Manual download with checksum verification (replace `<version>` with the latest, e.g. 0.5.18):
+Manual download with checksum verification (replace `<version>` with the latest, e.g. 0.5.19):
 
 ```bash
 V=<version> T=x86_64-unknown-linux-gnu
@@ -89,7 +89,7 @@ For build prerequisites, the full feature-flag matrix, release profile, and cros
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install it with `apt`, which resolves the `libpcap0.8` runtime dependency automatically:
 
 ```bash
-# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.18
+# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.19
 curl -LO https://github.com/NormB/sipnab/releases/latest/download/sipnab_<version>_amd64.deb
 sudo apt install ./sipnab_<version>_amd64.deb
 
@@ -121,7 +121,7 @@ standard and a `-noaudio` variant (no audio plugin, no `alsa-lib` weak
 dependency — for headless servers, mirroring the `.deb` variants):
 
 ```bash
-sudo rpm -i sipnab-<version>-1.x86_64.rpm  # replace <version> with the latest, e.g. 0.5.18
+sudo rpm -i sipnab-<version>-1.x86_64.rpm  # replace <version> with the latest, e.g. 0.5.19
 # headless / no-ALSA variant:
 sudo rpm -i sipnab-<version>-1.x86_64-noaudio.rpm
 # arm64 hosts:
@@ -179,7 +179,7 @@ sipnab -D
 <span class="terminal-title">Verify Installation</span>
 </div>
 <pre class="terminal-body"><span class="t-muted">$</span> sipnab --version
-sipnab 0.5.18 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+sipnab 0.5.19 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 
 <span class="t-muted">$</span> sipnab -N -I demo.pcap | head -3
 <span class="t-accent">INVITE</span> alice -> bob  192.0.2.1:5060 -> 192.0.2.2:5060 <span class="t-good">InCall</span> PDD=847ms


### PR DESCRIPTION
No packet-path code changes versus 0.5.18 — this release exists to ship build provenance and the reworked website/download experience (see CHANGELOG for the full list): sigstore attestations on every artifact and the ghcr image, the Docker & automation download section, the CSP tab fix + pinned-hash gate, the content-hash CSS buster, the wiki benchmarks re-sync, and the footer authorship / CC BY 4.0 notice.

Benchmarks provenance reworded honestly: the numbers stay measured on the 0.5.18 artifact, which is packet-path-identical.

After merge: tag `v0.5.19` on the merge commit → release.yml builds + attests all artifacts, docker.yml attests the image, tap auto-bumps, Pages deploys the 0.5.19 site.