### PR TITLE
site: drop hero kicker, sharpen hero sub-line

### DIFF
--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -445,16 +445,6 @@ input:focus-visible,
   margin: 0 auto;
 }
 
-.hero-kicker {
-  font-family: $font-mono;
-  font-size: 0.74rem;
-  font-weight: 600;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: $accent;
-  margin: 0 0 1.1rem;
-}
-
 .hero-title {
   font-family: $font-mono;
   font-size: clamp(3rem, 8vw, 4.75rem);
@@ -2055,7 +2045,6 @@ input:focus-visible,
 @media (max-width: 480px) {
   .nav-right { gap: 0.5rem; }
   .hero { padding: 3.25rem 1rem 1.5rem; }
-  .hero-kicker { font-size: 0.66rem; letter-spacing: 0.18em; }
   .hero-actions { flex-direction: column; align-items: stretch; }
   .hero-actions .btn { justify-content: center; }
   .arch-grid { grid-template-columns: 1fr; }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -9,10 +9,9 @@
 <section class="hero">
   <div class="hero-bg" aria-hidden="true"></div>
   <div class="hero-inner">
-    <p class="hero-kicker">SIP &middot; RTP &middot; built in Rust</p>
     <h1 class="hero-title">sipnab <span class="version-badge" aria-hidden="true">v{{ config.extra.version }}</span></h1>
     <p class="hero-tagline">The <a class="std-ref" href="https://www.rfc-editor.org/rfc/rfc3261" target="_blank" rel="noopener noreferrer">SIP</a> &amp; <a class="std-ref" href="https://www.rfc-editor.org/rfc/rfc3550" target="_blank" rel="noopener noreferrer">RTP</a> analysis tool for people who ship voice infrastructure.</p>
-    <p class="hero-sub">One static binary. One dependency (libpcap). Interactive TUI, CLI, and REST API.</p>
+    <p class="hero-sub">One static binary, one dependency &mdash; reads live traffic or a pcap and shows you the call flow, RTP quality, and security signals.</p>
     <div class="hero-actions">
       <a href="{{ get_url(path='@/docs/install.md') }}" class="btn btn-primary">Get Started &rarr;</a>
       <a href="{{ config.extra.github_url }}" class="btn btn-secondary">View on GitHub &rarr;</a>


### PR DESCRIPTION
Removes the 'SIP · RTP · built in Rust' hero kicker (and its now-dead `.hero-kicker` styles), and reworks the hero sub-line from a packaging/feature list into an outcome:

> One static binary, one dependency — reads live traffic or a pcap and shows you the call flow, RTP quality, and security signals.

Verified with a Zola build (kicker gone, new sub-line renders; `public/` is gitignored).