### PR TITLE
fix(cli): --show-empty reveals bodyless message headers in -N output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `-N` CLI output: `--show-empty` was a dead flag — bodyless SIP messages
+  (all responses, `OPTIONS`, `REGISTER`, `ACK`, `BYE`, in-dialog `SUBSCRIBE`)
+  could only ever show their one-line summary; their header block
+  (From/To/Call-ID/CSeq/Via/Contact/...) was unreachable. `--show-empty`
+  (new alias `--full`) now prints the full headers of bodyless messages as
+  documented. The terse one-line default is unchanged.
+
 ## [0.5.19] - 2026-07-20
 
 No packet-path code changes versus 0.5.18 — this release exists to ship

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -195,7 +195,7 @@ sipnab -N -I capture.pcap --short-calls --report
 | `--hexdump` | -- | off | Include hex dump of SIP payloads. Requires `-N` |
 | `--delta-time` | -- | off | Show delta time between consecutive messages |
 | `-A`, `--after` | `<N>` | -- | Show N messages after each match (like `grep -A`) |
-| `--show-empty` | -- | off | Show messages with empty bodies |
+| `--show-empty` (`--full`) | -- | off | Show the full header block of bodyless messages (responses, OPTIONS, REGISTER, ACK, BYE); by default they show only the summary line |
 | `--proto-number` | -- | off | Annotate the transport tag with the IANA IP protocol number, e.g. `UDP(17)` / `TCP(6)` (sipgrep `-N`). Long-only because `-N` is `--no-tui` here; TLS/WS report their TCP carrier's number (6) |
 | `--line-buffer` | -- | off | Flush output after each line (useful for piping) |
 | `--color` | `<WHEN>` | `auto` | Color output mode: `auto`, `always`, `never` |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,8 +389,11 @@ pub struct Cli {
     #[arg(help_heading = "Output", short = 'A', long = "after", value_name = "N")]
     pub after: Option<usize>,
 
-    /// Show messages with empty bodies.
-    #[arg(help_heading = "Output", long)]
+    /// Show the full header block of messages that have no body (responses,
+    /// OPTIONS, REGISTER, ACK, BYE, ...). Without this, bodyless messages show
+    /// only their one-line summary; messages that carry a body always show
+    /// their full detail.
+    #[arg(help_heading = "Output", long, visible_alias = "full")]
     pub show_empty: bool,
 
     /// Annotate the transport tag with the IANA IP protocol number, e.g.
@@ -1378,6 +1381,14 @@ mod tests {
         // Long-only: `-N` is already taken by `--no-tui`.
         assert!(Cli::parse_from_args(["sipnab", "--proto-number"]).proto_number);
         assert!(!Cli::parse_from_args(["sipnab"]).proto_number);
+    }
+
+    #[test]
+    fn show_empty_flag_and_full_alias_parse() {
+        assert!(Cli::parse_from_args(["sipnab", "--show-empty"]).show_empty);
+        // `--full` is a visible alias of --show-empty.
+        assert!(Cli::parse_from_args(["sipnab", "--full"]).show_empty);
+        assert!(!Cli::parse_from_args(["sipnab"]).show_empty);
     }
 
     #[test]

--- a/src/output/cli_print.rs
+++ b/src/output/cli_print.rs
@@ -172,12 +172,13 @@ pub fn format_sip_message(
                 out.push_str("\n[truncated]\n");
             }
             _ => {
-                // Don't dump full raw for show_empty with no body
-                if !msg.body.is_empty() {
-                    out.push_str(&raw_str);
-                    if !raw_str.ends_with('\n') {
-                        out.push('\n');
-                    }
+                // We only reach here when the message has a body OR show_empty
+                // is set (the outer guard). Either way, print the full raw so
+                // bodyless messages reveal their header block instead of being
+                // stuck at the one-line summary.
+                out.push_str(&raw_str);
+                if !raw_str.ends_with('\n') {
+                    out.push('\n');
                 }
             }
         }
@@ -263,6 +264,71 @@ mod tests {
             TransportProto::Udp,
         )
         .expect("should parse response")
+    }
+
+    fn make_options() -> SipMessage {
+        // A bodyless request, like the OPTIONS keepalives in a real trace.
+        let raw = build_sip(
+            "OPTIONS sip:bob@example.com SIP/2.0",
+            &[
+                "Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bKopt",
+                "From: <sip:alice@example.com>;tag=opt1",
+                "To: <sip:bob@example.com>",
+                "Call-ID: options-keepalive@example.com",
+                "CSeq: 42 OPTIONS",
+                "Content-Length: 0",
+            ],
+            b"",
+        );
+        parse_sip(
+            &raw,
+            ts(),
+            localhost(),
+            localhost(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("should parse OPTIONS")
+    }
+
+    // Regression: `--show-empty` was a dead flag. Bodyless messages (every
+    // response, OPTIONS, REGISTER, ACK, BYE, in-dialog SUBSCRIBE) could only
+    // ever show their one-line summary — the raw header block was hard-blocked
+    // regardless of the flag, so From/To/Call-ID/CSeq/Via were unreachable in
+    // `-N` output. show_empty must actually reveal those headers.
+    #[test]
+    fn show_empty_reveals_headers_of_bodyless_messages() {
+        for msg in [make_options(), make_error_response()] {
+            let opts = OutputOptions {
+                color: ColorMode::Never,
+                show_empty: true,
+                ..Default::default()
+            };
+            let out = format_sip_message(&msg, &opts, None);
+            assert!(
+                out.contains("Call-ID:") && out.contains("CSeq:"),
+                "show_empty must print the full header block of a bodyless \
+                 message, but got only:\n{out}"
+            );
+        }
+    }
+
+    // The terse default (no --show-empty) still shows only the summary line for
+    // bodyless messages — no wall of headers for every OPTIONS keepalive.
+    #[test]
+    fn bodyless_messages_stay_terse_without_show_empty() {
+        let opts = OutputOptions {
+            color: ColorMode::Never,
+            show_empty: false,
+            ..Default::default()
+        };
+        let out = format_sip_message(&make_options(), &opts, None);
+        assert!(
+            out.contains("OPTIONS") && !out.contains("Call-ID:"),
+            "without show_empty a bodyless message must be one line only, \
+             got:\n{out}"
+        );
     }
 
     #[test]

--- a/website/content/docs/cli.md
+++ b/website/content/docs/cli.md
@@ -251,7 +251,7 @@ sipnab -N -I capture.pcap --short-calls --report
 | `--no-cli-print` | -- | off | Suppress per-message CLI output (use with `--report` / `--call-report` so only the post-capture summary reaches stdout) |
 | `--delta-time` | -- | off | Show delta time between consecutive messages |
 | `-A`, `--after` | `<N>` | -- | Show N messages after each match (like `grep -A`) |
-| `--show-empty` | -- | off | Show messages with empty bodies |
+| `--show-empty` (`--full`) | -- | off | Show the full header block of bodyless messages (responses, OPTIONS, REGISTER, ACK, BYE); by default they show only the summary line |
 | `--line-buffer` | -- | off | Flush output after each line (useful for piping) |
 | `--color` | `<WHEN>` | `auto` | Color output mode: `auto`, `always`, `never` |
 | `--from-to-mode` | `<MODE>` | `default` | Default TUI From/To column display: `default` (user else host:port), `host-port`, `user`, `user-host-port`. Cycle at runtime with `u` |

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -165,7 +165,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2571 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2574 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -236,7 +236,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.5.18)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2571" data-suffix="">2571</span>
+        <span class="arch-stat" data-count="2574" data-suffix="">2574</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
**The bug (reported from live `sipnab -N` output):** most SIP messages showed only their one-line summary, never their headers. Root cause: `--show-empty` was a dead flag. `format_sip_message()` gated the raw header dump on a non-empty body, so every bodyless message — all responses (200/401/OPTIONS replies), `OPTIONS`, `REGISTER`, `ACK`, `BYE`, in-dialog `SUBSCRIBE` — could only ever show the summary line. Their From/To/Call-ID/CSeq/Via/Contact headers were unreachable, and `--show-empty` (whose doc said it revealed exactly these) did nothing.

**Fix:** the inner `!body.is_empty()` guard contradicted the outer guard that already admits `show_empty`; removing it makes the flag honor its contract. Added a `--full` visible alias and sharpened the help + docs. The terse one-line default for bodyless messages is unchanged, so busy captures (thousands of OPTIONS keepalives) aren't flooded unless you ask.

So `sipnab -N --full -I capture.pcap` now prints full headers for every message.

**TDD:** `show_empty_reveals_headers_of_bodyless_messages` (red→green), `bodyless_messages_stay_terse_without_show_empty` (guards the default), `show_empty_flag_and_full_alias_parse`. Synthetic example.com fixtures only. Homepage count → 2574. All pre-commit + full-feature gates green.