### PR TITLE
fix(tui): widen call-list Method column so SUBSCRIBE never truncates

### DIFF
--- a/src/tui/call_list.rs
+++ b/src/tui/call_list.rs
@@ -756,9 +756,10 @@ fn compute_column_widths(total_width: u16) -> Vec<Constraint> {
             Constraint::Length(8),
         ]
     } else {
-        // Tighter layout: #(5) + Method(8) + State(10) + Msgs(4) + Date(8)
-        // + PDD(6) + Duration(7) = 48. #(5) holds "[ ]" plus a 2-digit index.
-        let fixed: u16 = 48 + overhead;
+        // Tighter layout: #(5) + Method(9) + State(10) + Msgs(4) + Date(8)
+        // + PDD(6) + Duration(7) = 49. #(5) holds "[ ]" plus a 2-digit index.
+        // Method is 9 so the longest common method (SUBSCRIBE) never truncates.
+        let fixed: u16 = 49 + overhead;
         let flex = total_width.saturating_sub(fixed);
         let addr_each = (flex * 2 / 5).max(11);
         let from_to_pool = flex.saturating_sub(addr_each * 2);
@@ -766,7 +767,7 @@ fn compute_column_widths(total_width: u16) -> Vec<Constraint> {
         let to_w = from_to_pool.saturating_sub(from_w).max(4);
         vec![
             Constraint::Length(5),
-            Constraint::Length(8),
+            Constraint::Length(9),
             Constraint::Length(from_w),
             Constraint::Length(to_w),
             Constraint::Length(addr_each),
@@ -997,6 +998,25 @@ fn format_from_to(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: below 120 cols the Method column was `Length(8)`, which
+    /// truncated `SUBSCRIBE` (9 chars) — visible on any 80-119-col terminal
+    /// and in the 98-col demo GIFs. The Method column is a key field and must
+    /// never truncate a standard SIP method.
+    #[test]
+    fn method_column_fits_longest_sip_method_below_120_cols() {
+        // Longest common SIP methods: SUBSCRIBE(9), REGISTER(8), OPTIONS(7).
+        for width in [80u16, 98, 110, 119] {
+            let widths = compute_column_widths(width);
+            // Index 1 is the Method column (see COLUMN_LABELS order).
+            assert!(
+                matches!(widths[1], Constraint::Length(w) if w >= 9),
+                "Method column at {width} cols must be >= 9 to fit SUBSCRIBE, \
+                 got {:?}",
+                widths[1]
+            );
+        }
+    }
 
     /// The allocation-free search must match exactly what
     /// `to_ascii_lowercase().contains()` matched: ASCII case folding only,

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_with_filter_active.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__call_list_with_filter_active.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/tui_snapshot_test.rs
-assertion_line: 523
 expression: output
 ---
  Current Mode: Online (any)    Dialogs: 3 (1 displayed)  [A]
  Match Expression: from.user =~ '1003'    BPF Filter:
  Display Filter: from.user =~ '1003'
-  # ▲   Method   From To   Source           Destination      State      Msgs Date     PDD    Duratio
-> [ ]1  INVITE   1003 1004 10.0.0.1         10.0.0.2         FAILED     2    +0.000s         1.0s
+  # ▲   Method    From To    Source          Destination     State      Msgs Date     PDD    Duratio
+> [ ]1  INVITE    1003 1004  10.0.0.1        10.0.0.2        FAILED     2    +0.000s         1.0s
 
 
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -164,7 +164,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2574 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2575 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -235,7 +235,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.5.18)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2574" data-suffix="">2574</span>
+        <span class="arch-stat" data-count="2575" data-suffix="">2575</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Reported as truncated SIP methods in the demo videos — traced to a real TUI bug, not just a demo artifact.

`compute_column_widths()` gave the Method column `Length(8)` below 120 columns, so `SUBSCRIBE` (9 chars) truncated on any 80–119-col terminal. The demos render at ~98 cols (1200px / DejaVu Mono FS20), hitting exactly that branch. Confirmed by rendering the call list at the 98×28 demo geometry (which also showed the rightmost Duration column clipping).

Fix: Method → `Length(9)` and the fixed-column budget 48→49 so the flex pool compensates (also stops the Duration clip). Method is a key field and must never truncate a standard SIP method.

TDD: `method_column_fits_longest_sip_method_below_120_cols` asserts ≥9 across 80–119 cols (red→green). `call_list_with_filter_active` snapshot updated for the one-column shift; all 51 snapshot tests green. Homepage count → 2575.

First of the demo-rework changes; the demo GIFs themselves get regenerated (against this fixed layout, plus the keycap overlay) in the follow-up.