### PR TITLE
perf(output): buffered batch sink + direct JSON serialization for -N/--json and MCP

### DIFF
--- a/src/app/batch.rs
+++ b/src/app/batch.rs
@@ -666,6 +666,12 @@ impl BatchRunner {
         let mut last_sweep = std::time::Instant::now();
         let sweep_interval = std::time::Duration::from_secs(5);
 
+        // Shared buffered stdout sink for every per-message emitter (JSON,
+        // sipgrep-style text, fail2ban, hexdump). Flushed whenever the packet
+        // channel goes idle — live output stays real-time — and at end of
+        // capture; `--line-buffer` flushes after every message.
+        let mut sink = output::BatchSink::stdout(cli.line_buffer);
+
         // 18. Main receive loop
         let start = std::time::Instant::now();
         let mut total_count: u64 = 0;
@@ -722,7 +728,12 @@ impl BatchRunner {
                 last_sweep = std::time::Instant::now();
             }
 
-            // Use recv_timeout so we can check shutdown periodically
+            // Use recv_timeout so we can check shutdown periodically. Flush
+            // pending output first whenever the channel has gone idle, so a
+            // quiet live capture never sits on buffered messages.
+            if rx.is_empty() {
+                sink.flush();
+            }
             let packet = match rx.recv_timeout(std::time::Duration::from_millis(100)) {
                 Ok(pkt) => pkt,
                 Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
@@ -846,6 +857,7 @@ impl BatchRunner {
                         &mut proc_state,
                         &mut engines,
                         &mut counters,
+                        &mut sink,
                     );
                 }
 
@@ -902,6 +914,10 @@ impl BatchRunner {
                 break;
             }
         }
+
+        // Drain the per-message output sink before anything else writes to
+        // stdout (reports, wireshark/tshark lines), preserving output order.
+        sink.flush();
 
         // Flush the output writer explicitly: BufWriter's Drop discards
         // flush errors, so without this an ENOSPC at end of capture would
@@ -1098,12 +1114,13 @@ fn decide_emit(
     emit
 }
 
-fn process_parsed_packet(
+fn process_parsed_packet<W: std::io::Write>(
     pp: &ParsedPacket,
     ctx: &BatchContext<'_>,
     state: &mut ProcessingState<'_>,
     engines: &mut DetectionEngines,
     counters: &mut PacketCounters,
+    sink: &mut output::BatchSink<W>,
 ) {
     let matcher = ctx.matcher;
     let filter_expr = ctx.filter_expr;
@@ -1131,7 +1148,8 @@ fn process_parsed_packet(
     // Hexdump output (applies to all packets)
     if cli.hexdump && cli.no_tui {
         let dump = output::hexdump(&pp.payload);
-        print!(
+        write!(
+            sink,
             "{} {}:{} -> {}:{} {}\n{}",
             pp.timestamp.format("%H:%M:%S%.3f"),
             pp.src_addr,
@@ -1238,7 +1256,8 @@ fn process_parsed_packet(
                         &alert.ua,
                         &alert.method,
                     );
-                    println!("{event}");
+                    sink.write_str(&event);
+                    sink.write_str("\n");
                 }
 
                 // D16: Send kill response via isolated worker thread
@@ -1274,7 +1293,8 @@ fn process_parsed_packet(
                 if cli.fail2ban {
                     let event =
                         output::format_scanner_event(&sip_msg.src_addr.to_string(), ua, method);
-                    println!("{event}");
+                    sink.write_str(&event);
+                    sink.write_str("\n");
                 }
                 if let Some(handle) = &scanner_kill_handle
                     && let Some(response_bytes) =
@@ -1332,7 +1352,8 @@ fn process_parsed_packet(
                         &alert.src_ip.to_string(),
                         alert.register_count,
                     );
-                    println!("{event}");
+                    sink.write_str(&event);
+                    sink.write_str("\n");
                 }
             }
 
@@ -1386,7 +1407,7 @@ fn process_parsed_packet(
             );
 
             if emit && cli.no_tui {
-                dispatch_sip_output(&sip_msg, output_opts, cli, *prev_timestamp);
+                dispatch_sip_output(&sip_msg, output_opts, cli, *prev_timestamp, sink);
             }
 
             *prev_timestamp = Some(sip_msg.timestamp);
@@ -1507,11 +1528,12 @@ fn try_tls_decrypt(
 // ── SIP output dispatch ──────────────────────────────────────────────
 
 /// Dispatch a matched SIP message to the configured output backend.
-fn dispatch_sip_output(
+fn dispatch_sip_output<W: std::io::Write>(
     msg: &sip::SipMessage,
     opts: &OutputOptions,
     cli: &Cli,
     prev_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    sink: &mut output::BatchSink<W>,
 ) {
     // Phase 8.1 — MCP mode owns stdout; no per-packet text/JSON output.
     #[cfg(feature = "mcp")]
@@ -1525,31 +1547,32 @@ fn dispatch_sip_output(
     }
     if cli.json_pretty {
         let json = output::json::message_to_json_pretty(msg);
-        print!("{json}");
+        sink.write_str(&json);
     } else if cli.json {
-        let json = output::json::message_to_json(msg);
-        print!("{json}");
+        // Hot path: serialize straight into the sink's buffer — no
+        // per-message String, no per-message write(2).
+        let _ = output::json::write_message_json(msg, sink.writer());
     } else if cli.fail2ban {
         // Fail2ban output for scanner-like messages
         if msg.is_request {
             let ua = msg.user_agent().unwrap_or("unknown");
             let method = msg.method.as_ref().map(|m| m.as_str()).unwrap_or("UNKNOWN");
             let event = output::format_scanner_event(&msg.src_addr.to_string(), ua, method);
-            println!("{event}");
+            sink.write_str(&event);
+            sink.write_str("\n");
         }
     } else if cli.text_dump {
         // Raw SIP message text dump
         let raw = String::from_utf8_lossy(&msg.raw);
-        println!("{raw}");
+        sink.write_str(&raw);
+        sink.write_str("\n");
     } else {
-        output::print_sip_message(msg, opts, prev_timestamp);
+        let text = output::cli_print::format_sip_message(msg, opts, prev_timestamp);
+        sink.write_str(&text);
     }
 
     // Flush if --line-buffer is set
-    if cli.line_buffer {
-        use std::io::Write;
-        let _ = std::io::stdout().flush();
-    }
+    sink.end_message();
 }
 
 // ── Report generation ────────────────────────────────────────────────
@@ -1681,35 +1704,66 @@ mod tests {
             TransportProto::Udp,
         )
         .expect("invite should parse");
-        let opts = OutputOptions::default();
+        // Force color OFF so the expected text output is deterministic even
+        // when the test runner is attached to a TTY.
+        let opts = OutputOptions {
+            color: output::ColorMode::Never,
+            ..Default::default()
+        };
+        let sink_bytes = |cli: &Cli, prev: Option<chrono::DateTime<chrono::Utc>>| {
+            let mut sink = output::BatchSink::new(Vec::new(), cli.line_buffer);
+            dispatch_sip_output(&msg, &opts, cli, prev, &mut sink);
+            sink.into_inner()
+        };
 
-        // Default pretty print.
-        dispatch_sip_output(&msg, &opts, &base_cli(), None);
+        // Default sipgrep-style print: byte-identical to format_sip_message.
+        let out = sink_bytes(&base_cli(), None);
+        assert_eq!(
+            String::from_utf8(out).expect("utf8"),
+            crate::output::cli_print::format_sip_message(&msg, &opts, None),
+        );
 
-        // JSON.
+        // JSON: byte-identical to message_to_json (NDJSON line + newline).
         let mut cli = base_cli();
         cli.json = true;
-        dispatch_sip_output(&msg, &opts, &cli, None);
+        assert_eq!(
+            String::from_utf8(sink_bytes(&cli, None)).expect("utf8"),
+            output::json::message_to_json(&msg),
+        );
 
-        // fail2ban (request path).
+        // Pretty JSON: byte-identical to message_to_json_pretty.
+        let mut cli = base_cli();
+        cli.json_pretty = true;
+        assert_eq!(
+            String::from_utf8(sink_bytes(&cli, None)).expect("utf8"),
+            output::json::message_to_json_pretty(&msg),
+        );
+
+        // fail2ban (request path): one event line.
         let mut cli = base_cli();
         cli.fail2ban = true;
-        dispatch_sip_output(&msg, &opts, &cli, None);
+        let out = String::from_utf8(sink_bytes(&cli, None)).expect("utf8");
+        assert!(
+            out.contains("10.0.0.1") && out.ends_with('\n'),
+            "fail2ban event line expected, got {out:?}"
+        );
 
-        // raw text dump.
+        // raw text dump: raw message + newline.
         let mut cli = base_cli();
         cli.text_dump = true;
-        dispatch_sip_output(&msg, &opts, &cli, None);
+        let out = String::from_utf8(sink_bytes(&cli, None)).expect("utf8");
+        assert!(out.starts_with("INVITE sip:bob@example.com SIP/2.0"));
+        assert!(out.ends_with('\n'));
 
         // suppressed entirely.
         let mut cli = base_cli();
         cli.no_cli_print = true;
-        dispatch_sip_output(&msg, &opts, &cli, None);
+        assert!(sink_bytes(&cli, None).is_empty());
 
-        // line-buffer flush branch.
+        // line-buffer flush branch still writes the message.
         let mut cli = base_cli();
         cli.line_buffer = true;
-        dispatch_sip_output(&msg, &opts, &cli, Some(chrono::Utc::now()));
+        assert!(!sink_bytes(&cli, Some(chrono::Utc::now())).is_empty());
     }
 
     // ── generate_reports ───────────────────────────────────────────────
@@ -1806,7 +1860,14 @@ mod tests {
             dtls: None,
         };
 
-        process_parsed_packet(pp, &ctx, &mut state, &mut engines, &mut counters);
+        process_parsed_packet(
+            pp,
+            &ctx,
+            &mut state,
+            &mut engines,
+            &mut counters,
+            &mut output::BatchSink::new(Vec::new(), false),
+        );
         (counters.sip_count, counters.rtp_count)
     }
 
@@ -1864,7 +1925,14 @@ mod tests {
             #[cfg(feature = "tls")]
             dtls: None,
         };
-        process_parsed_packet(pp, &ctx, &mut state, &mut engines, &mut counters);
+        process_parsed_packet(
+            pp,
+            &ctx,
+            &mut state,
+            &mut engines,
+            &mut counters,
+            &mut output::BatchSink::new(Vec::new(), false),
+        );
 
         alerts
             .read()
@@ -1964,7 +2032,14 @@ mod tests {
             srtp: Some(srtp),
             dtls: None,
         };
-        process_parsed_packet(pp, &ctx, &mut state, &mut engines, &mut counters);
+        process_parsed_packet(
+            pp,
+            &ctx,
+            &mut state,
+            &mut engines,
+            &mut counters,
+            &mut output::BatchSink::new(Vec::new(), false),
+        );
         counters.rtp_count
     }
 

--- a/src/capture/channel.rs
+++ b/src/capture/channel.rs
@@ -162,6 +162,13 @@ impl PacketRx {
     pub fn meter(&self) -> CaptureMeter {
         self.meter.clone()
     }
+
+    /// `true` when no packet is immediately available. The batch loop uses
+    /// this to flush its buffered output sink exactly when the pipeline goes
+    /// idle (lock-free peek at the underlying channel).
+    pub fn is_empty(&self) -> bool {
+        self.data_rx.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -285,6 +292,18 @@ mod tests {
         );
         rx.recv_timeout(Duration::from_secs(1)).unwrap();
         assert!(h.join().unwrap().is_ok());
+    }
+
+    #[test]
+    fn is_empty_tracks_pending_packets() {
+        let (tx, rx) = packet_channel(2);
+        assert!(rx.is_empty(), "fresh channel starts empty");
+        tx.send(pkt(8)).unwrap();
+        assert!(!rx.is_empty(), "a sent packet must be visible");
+        rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(rx.is_empty(), "drained channel is empty again");
+        drop(tx);
+        assert!(rx.is_empty(), "disconnected channel reads as empty");
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -492,11 +492,7 @@ impl SipnabMcp {
             } else {
                 dialog.messages[cursor..end]
                     .iter()
-                    .map(|m| {
-                        let line = crate::output::json::message_to_json(m);
-                        serde_json::from_str::<serde_json::Value>(line.trim_end())
-                            .unwrap_or(serde_json::Value::String(line))
-                    })
+                    .map(crate::output::json::message_to_json_value)
                     .collect()
             };
             let summary = DialogSummary::from(dialog);
@@ -525,7 +521,7 @@ impl SipnabMcp {
         &self,
         Parameters(params): Parameters<GetMessageParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        let line: String = {
+        let parsed: serde_json::Value = {
             let ds = self.dialog_store.read();
             let dialog = ds.get(&params.call_id).ok_or_else(|| {
                 rmcp::ErrorData::invalid_params(
@@ -543,10 +539,8 @@ impl SipnabMcp {
                     None,
                 )
             })?;
-            crate::output::json::message_to_json(msg)
+            crate::output::json::message_to_json_value(msg)
         };
-        let parsed: serde_json::Value =
-            serde_json::from_str(line.trim_end()).unwrap_or(serde_json::Value::String(line));
         Ok(CallToolResult::success(vec![ContentBlock::json(parsed)?]))
     }
 

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -170,11 +170,9 @@ struct DialogJson {
 
 // ── Public API ──────────────────────────────────────────────────────
 
-/// Serialize a SIP message as NDJSON (one JSON object per line).
-///
-/// Returns a single JSON line with a trailing newline, suitable for
-/// piping to `jq` or other stream processors.
-pub fn message_to_json(msg: &SipMessage) -> String {
+/// Build the borrowed [`MessageJson`] projection of a SIP message — the
+/// single source of truth for the NDJSON, writer, and `Value` variants.
+fn build_message_json(msg: &SipMessage) -> MessageJson<'_> {
     let cseq = msg
         .cseq()
         .map(|(number, method)| CSeqJson { number, method });
@@ -196,7 +194,7 @@ pub fn message_to_json(msg: &SipMessage) -> String {
         None
     };
 
-    let json = MessageJson {
+    MessageJson {
         schema_version: 1,
         timestamp: msg.timestamp.to_rfc3339(),
         src: msg.src_addr.to_string(),
@@ -217,13 +215,48 @@ pub fn message_to_json(msg: &SipMessage) -> String {
         cseq,
         response_context,
         malformed: msg.malformations(),
-    };
+    }
+}
 
-    // serde_json::to_string should not fail on these well-typed fields
-    let mut line = serde_json::to_string(&json)
-        .unwrap_or_else(|e| format!("{{\"error\":\"serialization failed: {e}\"}}"));
-    line.push('\n');
-    line
+/// Serialize a SIP message as NDJSON (one JSON object per line).
+///
+/// Returns a single JSON line with a trailing newline, suitable for
+/// piping to `jq` or other stream processors.
+pub fn message_to_json(msg: &SipMessage) -> String {
+    let mut buf = Vec::with_capacity(512);
+    // The Vec writer cannot fail; write_message_json handles serializer
+    // errors internally, so the buffer always holds a complete line.
+    let _ = write_message_json(msg, &mut buf);
+    // build_message_json emits only valid UTF-8 (strings are checked or
+    // escaped by serde_json).
+    String::from_utf8(buf).unwrap_or_default()
+}
+
+/// Serialize a SIP message as one NDJSON line (trailing newline included)
+/// directly into `w` — the batch `-N --json` hot path, which avoids the
+/// per-message intermediate `String` of [`message_to_json`].
+///
+/// Output is byte-identical to [`message_to_json`].
+pub fn write_message_json<W: std::io::Write>(msg: &SipMessage, w: &mut W) -> std::io::Result<()> {
+    let json = build_message_json(msg);
+    // serde_json::to_writer should not fail on these well-typed fields; an
+    // I/O error propagates, a pure serialization error falls back to the
+    // same error object message_to_json historically produced.
+    match serde_json::to_writer(&mut *w, &json) {
+        Ok(()) => {}
+        Err(e) if e.is_io() => return Err(e.into()),
+        Err(e) => write!(w, "{{\"error\":\"serialization failed: {e}\"}}")?,
+    }
+    w.write_all(b"\n")
+}
+
+/// Serialize a SIP message directly to a [`serde_json::Value`] — for
+/// callers that need a structured object (MCP tool responses). Equal to
+/// parsing the [`message_to_json`] line, without the print→re-parse
+/// round-trip.
+pub fn message_to_json_value(msg: &SipMessage) -> serde_json::Value {
+    serde_json::to_value(build_message_json(msg))
+        .unwrap_or_else(|e| serde_json::json!({"error": format!("serialization failed: {e}")}))
 }
 
 /// Pretty-printed variant of [`message_to_json`] for `--json-pretty`:
@@ -434,6 +467,84 @@ mod tests {
             payload_offset: 12,
         };
         RtpStream::new(key, &hdr, ts())
+    }
+
+    // Perf path (batch `-N --json`): the writer variant must produce bytes
+    // identical to `message_to_json` — same NDJSON line, same trailing
+    // newline — so switching the batch loop to it cannot change output.
+    #[test]
+    fn write_message_json_matches_message_to_json() {
+        let body = b"v=0\r\nc=IN IP4 127.0.0.1\r\nm=audio 6000 RTP/AVP 8\r\na=label:a\\b\"c\r\n";
+        let cl = format!("Content-Length: {}", body.len());
+        let with_sdp = parse_sip(
+            &build_sip(
+                "INVITE sip:bob@example.com SIP/2.0",
+                &[
+                    "From: \"Alice\" <sip:1001@example.com>;tag=t1",
+                    "To: <sip:1002@example.com>",
+                    "Call-ID: writer-eq@example.com",
+                    "CSeq: 1 INVITE",
+                    "Content-Type: application/sdp",
+                    &cl,
+                ],
+                body,
+            ),
+            ts(),
+            localhost(),
+            localhost(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("should parse");
+        // A malformed message (missing mandatory headers) exercises the
+        // `malformed` array path.
+        let malformed = req_with_headers(&["CSeq: 1 REGISTER", "Content-Length: 0"]);
+        for msg in [make_invite(), with_sdp, malformed] {
+            let mut buf = Vec::new();
+            write_message_json(&msg, &mut buf).expect("write should succeed");
+            assert_eq!(
+                String::from_utf8(buf).expect("utf8"),
+                message_to_json(&msg),
+                "writer variant must be byte-identical"
+            );
+        }
+    }
+
+    // Perf path (MCP get_dialog/get_message): the Value variant must equal
+    // parse(message_to_json) so replacing the to_string→from_str round-trip
+    // cannot change any MCP response.
+    #[test]
+    fn message_to_json_value_matches_parsed_string() {
+        let resp = parse_sip(
+            &build_sip(
+                "SIP/2.0 200 OK",
+                &[
+                    "From: <sip:alice@example.com>;tag=t1",
+                    "To: <sip:bob@example.com>;tag=t2",
+                    "Call-ID: value-eq@example.com",
+                    "CSeq: 7 INVITE",
+                    "Content-Length: 0",
+                ],
+                b"",
+            ),
+            ts(),
+            localhost(),
+            localhost(),
+            5060,
+            5060,
+            TransportProto::Udp,
+        )
+        .expect("should parse");
+        for msg in [make_invite(), resp] {
+            let via_string: serde_json::Value =
+                serde_json::from_str(message_to_json(&msg).trim_end()).expect("valid JSON");
+            assert_eq!(
+                message_to_json_value(&msg),
+                via_string,
+                "Value variant must match the parsed NDJSON line"
+            );
+        }
     }
 
     #[test]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -24,6 +24,7 @@ pub mod model;
 pub mod prometheus;
 #[cfg(feature = "api")]
 pub mod prometheus_server;
+pub mod sink;
 pub mod synthetic;
 pub mod wireshark;
 
@@ -34,3 +35,4 @@ pub use event_exec::EventExecEngine;
 pub use fail2ban::{format_reg_flood_event, format_scanner_event};
 pub use hexdump::hexdump;
 pub use json::{dialog_to_json, message_to_json, stream_to_json};
+pub use sink::BatchSink;

--- a/src/output/sink.rs
+++ b/src/output/sink.rs
@@ -1,0 +1,196 @@
+//! Buffered stdout sink for batch-mode per-message output.
+//!
+//! The batch receive loop used to emit every SIP message through `print!` /
+//! `println!`: Rust's stdout is line-buffered, so a 70k-message offline run
+//! paid 70k `write(2)` syscalls plus a stdout lock/unlock per message —
+//! measured at ~40% of the wall time of `sipnab -N --json -I file.pcap`.
+//!
+//! [`BatchSink`] wraps one writer (a 64 KiB `BufWriter<Stdout>` in
+//! production) that every per-message emitter in the batch loop shares, so
+//! output ordering is preserved while syscalls collapse to one per buffer
+//! fill. The receive loop flushes it whenever the packet channel goes idle
+//! (live capture stays real-time) and at end of capture; `--line-buffer`
+//! keeps its contract by flushing after every message.
+//!
+//! Writes are best-effort, matching the existing text path
+//! (`print_sip_message`): a broken pipe (e.g. `sipnab ... | head`) must not
+//! panic the capture process.
+
+use std::io::Write;
+
+/// Shared buffered writer for every per-message emitter in the batch loop.
+///
+/// All writes are best-effort: errors (broken pipe) are swallowed so a
+/// downstream `| head` never panics the capture process. `line_buffer`
+/// preserves the `--line-buffer` contract of one flush per message.
+pub struct BatchSink<W: Write> {
+    w: W,
+    line_buffer: bool,
+}
+
+impl BatchSink<std::io::BufWriter<std::io::Stdout>> {
+    /// Production sink: a 64 KiB buffer in front of stdout. Stdout's own
+    /// line buffering only sees whole buffer fills, so per-message
+    /// `write(2)` syscalls collapse to a couple per 64 KiB.
+    pub fn stdout(line_buffer: bool) -> Self {
+        Self::new(
+            std::io::BufWriter::with_capacity(64 * 1024, std::io::stdout()),
+            line_buffer,
+        )
+    }
+}
+
+impl<W: Write> BatchSink<W> {
+    /// Wrap `w`; `line_buffer` mirrors the CLI's `--line-buffer` flag.
+    pub fn new(w: W, line_buffer: bool) -> Self {
+        Self { w, line_buffer }
+    }
+
+    /// Write a string, best-effort.
+    pub fn write_str(&mut self, s: &str) {
+        let _ = self.w.write_all(s.as_bytes());
+    }
+
+    /// Write formatted output, best-effort (enables `write!(sink, ...)`).
+    pub fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) {
+        let _ = self.w.write_fmt(args);
+    }
+
+    /// Direct access to the underlying writer, for zero-copy serializers
+    /// (`serde_json::to_writer`). Callers must treat errors as best-effort.
+    pub fn writer(&mut self) -> &mut W {
+        &mut self.w
+    }
+
+    /// Mark the end of one message: flushes only under `--line-buffer`.
+    pub fn end_message(&mut self) {
+        if self.line_buffer {
+            self.flush();
+        }
+    }
+
+    /// Flush the buffer, best-effort. The batch loop calls this when the
+    /// packet channel goes idle and at end of capture.
+    pub fn flush(&mut self) {
+        let _ = self.w.flush();
+    }
+
+    /// Consume the sink and return the underlying writer (test helper).
+    pub fn into_inner(self) -> W {
+        self.w
+    }
+
+    /// Borrow the underlying writer (test helper).
+    pub fn get_ref(&self) -> &W {
+        &self.w
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A writer that records flush calls and can be told to fail writes.
+    struct Probe {
+        buf: Vec<u8>,
+        flushes: usize,
+        fail_writes: bool,
+    }
+
+    impl Probe {
+        fn new() -> Self {
+            Self {
+                buf: Vec::new(),
+                flushes: 0,
+                fail_writes: false,
+            }
+        }
+    }
+
+    impl Write for Probe {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            if self.fail_writes {
+                return Err(std::io::Error::from(std::io::ErrorKind::BrokenPipe));
+            }
+            self.buf.extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.flushes += 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_str_passes_bytes_through() {
+        let mut sink = BatchSink::new(Probe::new(), false);
+        sink.write_str("hello ");
+        sink.write_str("world\n");
+        assert_eq!(sink.get_ref().buf, b"hello world\n");
+    }
+
+    #[test]
+    fn write_fmt_formats_into_sink() {
+        let mut sink = BatchSink::new(Probe::new(), false);
+        let (a, b) = ("a", "b");
+        write!(sink, "{a} {b}:{}", 42);
+        assert_eq!(sink.get_ref().buf, b"a b:42");
+    }
+
+    #[test]
+    fn end_message_flushes_only_in_line_buffer_mode() {
+        let mut sink = BatchSink::new(Probe::new(), false);
+        sink.write_str("x");
+        sink.end_message();
+        assert_eq!(
+            sink.get_ref().flushes,
+            0,
+            "no per-message flush without --line-buffer"
+        );
+
+        let mut sink = BatchSink::new(Probe::new(), true);
+        sink.write_str("x");
+        sink.end_message();
+        assert_eq!(
+            sink.get_ref().flushes,
+            1,
+            "--line-buffer must flush after every message"
+        );
+    }
+
+    #[test]
+    fn flush_is_forwarded() {
+        let mut sink = BatchSink::new(Probe::new(), false);
+        sink.write_str("x");
+        sink.flush();
+        assert_eq!(sink.get_ref().flushes, 1);
+    }
+
+    #[test]
+    fn broken_pipe_does_not_panic() {
+        // Adversarial: downstream `| head` closes the pipe mid-stream. The
+        // sink must swallow the error (matching print_sip_message's
+        // best-effort contract), not panic the capture process.
+        let mut probe = Probe::new();
+        probe.fail_writes = true;
+        let mut sink = BatchSink::new(probe, true);
+        sink.write_str("dropped");
+        let also_dropped = "dropped too";
+        write!(sink, "{also_dropped}");
+        sink.end_message();
+        sink.flush();
+        assert!(sink.get_ref().buf.is_empty());
+    }
+
+    #[test]
+    fn empty_and_special_bytes_round_trip() {
+        // Boundary/adversarial: empty writes, embedded NUL, backslashes and
+        // multi-byte UTF-8 must pass through unmodified.
+        let mut sink = BatchSink::new(Probe::new(), false);
+        sink.write_str("");
+        sink.write_str("a\\b\"c\u{0}d\u{00e9}");
+        assert_eq!(sink.get_ref().buf, "a\\b\"c\u{0}d\u{00e9}".as_bytes());
+    }
+}

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -59,7 +59,7 @@
       </div>
       <div class="demo-panel" data-demo="4" role="tabpanel" id="demo-panel-4" aria-labelledby="demo-tab-4">
         <p class="demo-desc">Follow a B2BUA call end to end — press <kbd>x</kbd> for extended flow to stitch the correlated back-to-back-UA legs into one ladder.</p>
-        <img src="{{ get_url(path='demos/10-multileg.gif') }}?v=11" alt="sipnab multi-leg B2BUA extended-flow demo" loading="lazy">
+        <img src="{{ get_url(path='demos/10-multileg.gif') }}?v=10" alt="sipnab multi-leg B2BUA extended-flow demo" loading="lazy">
       </div>
       <div class="demo-panel" data-demo="5" role="tabpanel" id="demo-panel-5" aria-labelledby="demo-tab-5">
         <p class="demo-desc">Press <kbd>Tab</kbd> for <strong>RTP Streams</strong>, then drill into per-stream detail — SSRC, codec, jitter, loss, and MOS with quality over time.</p>
@@ -164,7 +164,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2586 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2587 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -235,7 +235,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.5.18)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2586" data-suffix="">2586</span>
+        <span class="arch-stat" data-count="2587" data-suffix="">2587</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

`-N` batch mode emitted every SIP message through `print!`/`println!`: Rust's stdout is line-buffered, so every message paid one `write(2)` syscall plus a stdout lock/unlock — and the `--json` path additionally built a fresh `String` per message before pushing it through the `fmt` machinery. On a 70k-message offline run that was exactly 70,000 `write()` calls (41% of syscall time) and ~40% of wall time attributable to the output path (measured by `--no-cli-print` ablation).

Changes:

- **`output::BatchSink`** (new): one shared 64 KiB `BufWriter<Stdout>` for every per-message emitter in the batch loop (JSON, pretty JSON, sipgrep-style text, `-T` raw dump, fail2ban events, `--hexdump`). Output ordering is preserved because all emitters share the single sink. Flushed whenever the packet channel goes idle (live output stays real-time), at end of capture (before reports print), and after every message under `--line-buffer` (contract unchanged). Writes are best-effort, matching the existing `print_sip_message` broken-pipe behavior.
- **`output::json::write_message_json`** (new): serializes the NDJSON line straight into the sink via `serde_json::to_writer` — no per-message intermediate `String`. `message_to_json` is now a thin wrapper over it (byte-identical, enforced by test).
- **`output::json::message_to_json_value`** (new): direct `serde_json::to_value` serialization for MCP `get_dialog`/`get_message`, replacing the previous serialize→`from_str` re-parse round-trip per message (equivalence enforced by test).
- `PacketRx::is_empty` (new): lock-free idle probe the batch loop uses to decide when to flush.

## Measurements

Host: 4-core x86_64 (Debian 13), shared/noisy box. Same build profile for both sides (release + thin-LTO/debug-symbol overrides, identical for before/after). Input: synthetic 70,000-message pcap (10,000 calls × 7 messages, 28.8 MB, example.com / RFC 5737 addresses, generated programmatically). hyperfine, 10 runs (5 for the file case), warmup runs included.

| case | before | after | change |
|---|---|---|---|
| `-N --json -I bench.pcap \| wc -c` (pipe consumer) | 741.1 ± 42.8 ms | 523.0 ± 16.8 ms | **−29.4%** (94.5k → 133.8k msg/s) |
| `-N --color never -I bench.pcap \| wc -c` | 589.4 ± 15.2 ms | 427.8 ± 29.9 ms | **−27.4%** |
| `-N --json -I bench.pcap > file` | 671.9 ± 48.6 ms | 552.9 ± 40.6 ms | **−17.7%** |
| `-N --json -I bench.pcap > /dev/null` | 535.8 ± 17.5 ms | 525.5 ± 30.3 ms | −1.9% (within noise) |
| `write(2)` count (strace -c, full run) | 70,000 | 1,027 | **−98.5%** |
| Max RSS | ~133 MB | ~134 MB | unchanged (+64 KiB buffer) |
| MCP `get_dialog` (500-message dialog, stdio round-trip, 30 reps × 3 rounds) | p50 4.71–5.22 ms, max 6.6–38.4 ms | p50 4.23–4.66 ms, max 5.6–5.9 ms | **p50 −10–14%, tail −25%+** |

The `/dev/null` row is the honest null case: writes to `/dev/null` are nearly free, so buffering barely matters there. Any real consumer — a pipe (`jq`), a file, a terminal — sees the 18–29% win. System time drops ~55–65% in the pipe/file cases (422 → 172 ms on the JSON pipe run).

## Byte-identity verification

47 output captures MD5-compared before vs after: 9 modes on the 70k pcap (`--json`, text, text+color+`--show-empty`+`--delta-time`+`--proto-number`, `--json-pretty`, `-T`, `--hexdump`, `--fail2ban`, `--json --line-buffer`, `--json --report`) plus `--json` and text over every pcap in `tests/pcap-samples/`. All identical. The one initial mismatch (`--fail2ban`) is inherent: those lines embed wall-clock time and PID; normalizing the stamp makes before/after identical. The file-output case was additionally `cmp`-verified on the full 34 MB output.

## Measured but deliberately left alone

- **Dialog tracking** costs ~345 ms of the 683 ms full run (store insert incl. per-message clone, state machine, SDP tracking). It feeds `--report`/`--call-report`/MCP/API state; auto-disabling it when nothing consumes it would change observable behavior, and `--no-dialog` already exists for exactly that trade. The per-message clone removal is structural (spec WS1 territory).
- **MCP `search_messages`** allocates a `format!` haystack + `to_lowercase` per message per call. A per-field rewrite changes matching semantics at field boundaries and `str::to_lowercase` is context-sensitive (final sigma), so an exact-semantics fix isn't a safe local change.
- Per-message `to_rfc3339`/`to_string` allocations in the JSON projection — micro relative to the above.

## Tests

TDD: new tests written first and shown failing (missing `BatchSink`/`write_message_json`/`message_to_json_value`, dispatch arity), then implementation to green. 9 new tests: 6 sink (including broken-pipe, NUL/multibyte/empty-write adversarial cases), 2 JSON equivalence, 1 `PacketRx::is_empty`. `dispatch_sip_output_all_modes` upgraded from "doesn't crash" to exact byte assertions per output mode. Full suite green with `--features full`; clippy `-D warnings` clean on `full`, `native`, and `mcp` feature sets.

**Test count note:** this branch updates the homepage test-count gate to **2587** (branched from main at 2578; 9 new tests here). PR #180 independently bumps its branch to 2586 — whichever merges second will need the final reconciled count.
