### PR TITLE
tui: live call-quality dashboard (D) — worst-first MOS/jitter/loss with trends

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -43,6 +43,7 @@ Keys marked with **(configurable)** can be remapped via the `[keybindings]` conf
 | u | Cycle From/To column display (default / host:port / user / user@host:port) |
 | r / F6 | Show raw SIP message for selected dialog |
 | s | Switch to Statistics view |
+| D | Open the Quality Dashboard (live MOS/jitter/loss) |
 | O | Open pcap file (File Open dialog) |
 | F8 | Open Settings popup **(configurable: `settings`)** |
 | Tab | Switch to RTP Streams view |
@@ -161,6 +162,7 @@ message of the selection rendered as one scrollable document.
 | End | Jump to last stream |
 | / | Search streams (SSRC, codec, addresses, dialog) **(configurable: `search`)** — while typing, ↑/↓/PgUp/PgDn/Home/End move the highlight in the narrowed list and Enter commits the query and opens the highlighted stream |
 | Enter | Open stream detail |
+| D | Open the Quality Dashboard (live MOS/jitter/loss) |
 | Tab | Switch to Call List |
 | Esc | Back to Call List |
 | N | Name the selected stream's source address (map IP → host/FQDN) |
@@ -180,6 +182,20 @@ message of the selection rendered as one scrollable document.
 | F1 / ? | Help **(configurable: `help`)** |
 | F2 | Save the stream's audio as WAV **(configurable: `save`)** |
 | Esc | Back to RTP Streams |
+
+## Quality Dashboard
+
+Live call-quality overview: aggregate MOS/jitter/loss with the worst
+streams ranked first and per-stream trend sparklines. Open with `D` from
+the Call List or RTP Streams view.
+
+| Key | Action |
+|-----|--------|
+| Up / k, Down / j | Select stream (worst first) |
+| PgUp / PgDn | Page through streams |
+| Home / End | Jump to best/worst |
+| Enter | Open stream detail for the selection |
+| Esc / q / D | Close (returns to the opening view) |
 
 ## Statistics
 

--- a/src/rtp/quality.rs
+++ b/src/rtp/quality.rs
@@ -108,7 +108,10 @@ fn r_to_mos(r: f64) -> f64 {
     } else if r > 100.0 {
         4.5
     } else {
-        1.0 + 0.035 * r + r * (r - 60.0) * (100.0 - r) * 7e-6
+        // The cubic dips below 1.0 for small positive R (e.g. R≈4.4 at
+        // 100% loss on G.711), so the documented floor must be enforced
+        // inside the branch too, not only at its edges.
+        (1.0 + 0.035 * r + r * (r - 60.0) * (100.0 - r) * 7e-6).clamp(1.0, 4.5)
     }
 }
 
@@ -263,6 +266,27 @@ mod tests {
     use super::*;
 
     // ── MOS estimation tests ─────────────────────────────────────────
+
+    #[test]
+    fn mos_never_dips_below_documented_floor() {
+        // 100% loss on G.711 lands R ≈ 4.4, where the raw G.107 cubic
+        // evaluates to ~0.99 — the [1.0, 4.5] contract must hold anyway.
+        let mos = estimate_mos(0.0, 100.0, Some("PCMU"));
+        assert!(
+            (1.0..=4.5).contains(&mos),
+            "Expected clamped MOS at total loss, got {mos}"
+        );
+        // sweep the small-R region for any other dip
+        for loss in [80.0, 90.0, 95.0, 99.0, 100.0] {
+            for jitter in [0.0, 40.0, 200.0] {
+                let m = estimate_mos(jitter, loss, Some("PCMU"));
+                assert!(
+                    (1.0..=4.5).contains(&m),
+                    "loss={loss} jitter={jitter} mos={m}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn mos_g711_perfect_conditions() {

--- a/src/rtp/stream.rs
+++ b/src/rtp/stream.rs
@@ -16,6 +16,12 @@ use super::parser::RtpHeader;
 /// How often to snapshot quality metrics into a [`QualityInterval`].
 const QUALITY_INTERVAL_SECS: i64 = 5;
 
+/// Cap on the per-stream quality trend history. One interval per
+/// `QUALITY_INTERVAL_SECS` means 720 entries cover a full hour of call
+/// time; without a cap a day-long stream would hold ~17k entries.
+/// Oldest-out when full.
+const MAX_QUALITY_INTERVALS: usize = 720;
+
 // ── Public types ─────────────────────────────────────────────────────
 
 /// Unique key for an RTP stream: SSRC combined with the 5-tuple direction.
@@ -247,6 +253,9 @@ impl RtpStream {
             0.0
         };
 
+        if self.quality_intervals.len() >= MAX_QUALITY_INTERVALS {
+            self.quality_intervals.remove(0);
+        }
         self.quality_intervals.push(QualityInterval {
             timestamp,
             jitter_ms: self.jitter,
@@ -364,6 +373,38 @@ mod tests {
             ssrc: 0x12345678,
             payload_offset: 12,
         }
+    }
+
+    #[test]
+    fn quality_intervals_are_bounded_oldest_out() {
+        // A long-lived stream must not grow its trend history without
+        // bound: one interval per 5 s means a day-long call is 17k
+        // entries per stream. The history is a ring capped at
+        // MAX_QUALITY_INTERVALS with the oldest entry evicted first.
+        let mut s = RtpStream::new(make_key(), &make_header(0, 0, 0), ts(0));
+        let n = MAX_QUALITY_INTERVALS + 10;
+        for i in 1..=n {
+            // one packet every QUALITY_INTERVAL_SECS closes an interval
+            s.update(
+                &make_header(i as u16, i as u32 * 160, 0),
+                ts(i as i64 * QUALITY_INTERVAL_SECS),
+                160,
+            );
+        }
+        assert_eq!(
+            s.quality_intervals.len(),
+            MAX_QUALITY_INTERVALS,
+            "history must be capped at MAX_QUALITY_INTERVALS"
+        );
+        // oldest evicted: the first surviving interval is the 11th
+        // recorded one, and order stays oldest-first.
+        let first = s.quality_intervals.first().expect("non-empty");
+        let last = s.quality_intervals.last().expect("non-empty");
+        assert!(first.timestamp < last.timestamp, "oldest-first order");
+        assert!(
+            first.timestamp >= ts(10 * QUALITY_INTERVAL_SECS),
+            "the ten oldest intervals were evicted"
+        );
     }
 
     fn ts(secs: i64) -> DateTime<Utc> {

--- a/src/rtp/stream_store.rs
+++ b/src/rtp/stream_store.rs
@@ -426,6 +426,18 @@ impl StreamStore {
         self.streams.get(key)
     }
 
+    /// Insert a pre-built stream directly (unit tests only) — bypasses
+    /// packet processing but keeps the SSRC index and generation honest.
+    #[cfg(test)]
+    pub(crate) fn insert_for_test(&mut self, s: RtpStream) {
+        self.ssrc_index
+            .entry(s.key.ssrc)
+            .or_default()
+            .push(s.key.clone());
+        self.streams.insert(s.key.clone(), s);
+        self.generation += 1;
+    }
+
     /// Iterate over all tracked streams.
     pub fn iter(&self) -> impl Iterator<Item = &RtpStream> {
         self.streams.values()

--- a/src/rtp/stream_store.rs
+++ b/src/rtp/stream_store.rs
@@ -428,7 +428,9 @@ impl StreamStore {
 
     /// Insert a pre-built stream directly (unit tests only) — bypasses
     /// packet processing but keeps the SSRC index and generation honest.
-    #[cfg(test)]
+    /// Gated on `tui` alongside its only consumer (the dashboard tests),
+    /// so no-`tui` test builds don't see it as dead code.
+    #[cfg(all(test, feature = "tui"))]
     pub(crate) fn insert_for_test(&mut self, s: RtpStream) {
         self.ssrc_index
             .entry(s.key.ssrc)

--- a/src/tui/controllers/call_list.rs
+++ b/src/tui/controllers/call_list.rs
@@ -42,6 +42,7 @@ pub enum CallListAction {
     OpenFileDialog,
     NameEndpoints,
     OpenStatistics,
+    OpenDashboard,
 }
 
 /// Pure key→action mapping for the call list view (keymap-aware).
@@ -90,6 +91,7 @@ pub fn call_list_action(km: &Keymap, key: KeyEvent) -> Option<CallListAction> {
         KeyCode::Char('O') => OpenFileDialog,
         KeyCode::Char('N') => NameEndpoints,
         KeyCode::Char('s') => OpenStatistics,
+        KeyCode::Char('D') => OpenDashboard,
         _ => return None,
     })
 }
@@ -221,6 +223,11 @@ fn execute_call_list_action(app: &mut App, action: CallListAction) {
         CallListAction::OpenStatistics => {
             app.stats_scroll = 0;
             app.current_view = View::Statistics;
+        }
+        CallListAction::OpenDashboard => {
+            app.dashboard_selected = 0;
+            app.dashboard_return_view = Some(View::CallList);
+            app.current_view = View::QualityDashboard;
         }
     }
 }

--- a/src/tui/controllers/mod.rs
+++ b/src/tui/controllers/mod.rs
@@ -108,6 +108,7 @@ fn dispatch_view_key(app: &mut App, key: KeyEvent) {
         View::CombinedDetail { .. } => handle_combined_detail_key(app, key),
         View::Help => handle_help_key(app, key),
         View::Statistics => handle_statistics_key(app, key),
+        View::QualityDashboard => handle_dashboard_key(app, key),
     }
 }
 
@@ -278,6 +279,77 @@ pub fn statistics_action(km: &Keymap, key: KeyEvent) -> Option<StatisticsAction>
     })
 }
 
+/// Everything the quality dashboard view can do for a single key press.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DashboardAction {
+    Close,
+    Up,
+    Down,
+    PageUp,
+    PageDown,
+    Top,
+    Bottom,
+    OpenStreamDetail,
+}
+
+/// Pure key→action mapping for the quality dashboard (keymap-aware).
+pub fn dashboard_action(km: &Keymap, key: KeyEvent) -> Option<DashboardAction> {
+    use DashboardAction::*;
+    Some(match key.code {
+        k if k == KeyCode::Esc || k == km.quit || k == KeyCode::Char('D') => Close,
+        KeyCode::Up | KeyCode::Char('k') => Up,
+        KeyCode::Down | KeyCode::Char('j') => Down,
+        KeyCode::PageUp => PageUp,
+        KeyCode::PageDown => PageDown,
+        KeyCode::Home => Top,
+        KeyCode::End => Bottom,
+        KeyCode::Enter => OpenStreamDetail,
+        _ => return None,
+    })
+}
+
+/// Handle keys in the quality dashboard: map, then execute.
+pub(in crate::tui) fn handle_dashboard_key(app: &mut App, key: KeyEvent) {
+    let Some(action) = dashboard_action(&app.keymap, key) else {
+        return;
+    };
+    let rows = app.dashboard_snapshot.as_ref().map_or(0, |s| s.rows.len());
+    let clamp = |i: usize| if rows > 0 { i.min(rows - 1) } else { 0 };
+    match action {
+        DashboardAction::Close => {
+            app.current_view = app.dashboard_return_view.take().unwrap_or(View::CallList);
+        }
+        DashboardAction::Up => {
+            app.dashboard_selected = app.dashboard_selected.saturating_sub(1);
+        }
+        DashboardAction::Down => {
+            app.dashboard_selected = clamp(app.dashboard_selected + 1);
+        }
+        DashboardAction::PageUp => {
+            app.dashboard_selected = app.dashboard_selected.saturating_sub(10);
+        }
+        DashboardAction::PageDown => {
+            app.dashboard_selected = clamp(app.dashboard_selected + 10);
+        }
+        DashboardAction::Top => app.dashboard_selected = 0,
+        DashboardAction::Bottom => {
+            app.dashboard_selected = rows.saturating_sub(1);
+        }
+        DashboardAction::OpenStreamDetail => {
+            let key = app
+                .dashboard_snapshot
+                .as_ref()
+                .and_then(|s| s.rows.get(app.dashboard_selected))
+                .map(|r| r.key.clone());
+            if let Some(k) = key {
+                app.stream_detail_scroll = 0;
+                app.stream_detail_return_view = Some(View::QualityDashboard);
+                app.current_view = View::StreamDetail(k);
+            }
+        }
+    }
+}
+
 /// Handle keys in the statistics view: map, then execute.
 pub(in crate::tui) fn handle_statistics_key(app: &mut App, key: KeyEvent) {
     let Some(action) = statistics_action(&app.keymap, key) else {
@@ -323,6 +395,16 @@ pub(in crate::tui) fn handle_mouse_event(app: &mut App, kind: crossterm::event::
                 app.call_list.move_down(count);
             } else {
                 app.call_list.move_up();
+            }
+        }
+        View::QualityDashboard => {
+            let rows = app.dashboard_snapshot.as_ref().map_or(0, |s| s.rows.len());
+            if down {
+                if rows > 0 {
+                    app.dashboard_selected = (app.dashboard_selected + 1).min(rows - 1);
+                }
+            } else {
+                app.dashboard_selected = app.dashboard_selected.saturating_sub(1);
             }
         }
         View::StreamList => {
@@ -646,6 +728,57 @@ mod tests {
         );
         assert_eq!(help_action(&km, key(KeyCode::Char('q'))), None);
         assert_eq!(help_action(&km, key(KeyCode::Esc)), Some(HelpAction::Close));
+    }
+
+    #[test]
+    fn dashboard_action_maps_nav_and_close() {
+        let km = Keymap::default();
+        use DashboardAction::*;
+        assert_eq!(dashboard_action(&km, key(KeyCode::Esc)), Some(Close));
+        assert_eq!(dashboard_action(&km, key(KeyCode::Char('D'))), Some(Close));
+        assert_eq!(dashboard_action(&km, key(KeyCode::Up)), Some(Up));
+        assert_eq!(dashboard_action(&km, key(KeyCode::Char('k'))), Some(Up));
+        assert_eq!(dashboard_action(&km, key(KeyCode::Down)), Some(Down));
+        assert_eq!(dashboard_action(&km, key(KeyCode::Char('j'))), Some(Down));
+        assert_eq!(dashboard_action(&km, key(KeyCode::Home)), Some(Top));
+        assert_eq!(dashboard_action(&km, key(KeyCode::End)), Some(Bottom));
+        assert_eq!(
+            dashboard_action(&km, key(KeyCode::Enter)),
+            Some(OpenStreamDetail)
+        );
+        assert_eq!(dashboard_action(&km, key(KeyCode::Char('z'))), None);
+    }
+
+    #[test]
+    fn dashboard_action_honors_remapped_quit() {
+        let km = Keymap {
+            quit: KeyCode::Char('x'),
+            ..Default::default()
+        };
+        assert_eq!(
+            dashboard_action(&km, key(KeyCode::Char('x'))),
+            Some(DashboardAction::Close)
+        );
+        assert_eq!(dashboard_action(&km, key(KeyCode::Char('q'))), None);
+    }
+
+    #[test]
+    fn dashboard_opens_from_call_list_and_returns_on_close() {
+        let mut app = App::new_test();
+        app.handle_key(KeyCode::Char('D'));
+        assert_eq!(app.current_view, View::QualityDashboard);
+        app.handle_key(KeyCode::Esc);
+        assert_eq!(app.current_view, View::CallList);
+    }
+
+    #[test]
+    fn dashboard_opens_from_stream_list_and_returns_there() {
+        let mut app = App::new_test();
+        app.current_view = View::StreamList;
+        app.handle_key(KeyCode::Char('D'));
+        assert_eq!(app.current_view, View::QualityDashboard);
+        app.handle_key(KeyCode::Char('D'));
+        assert_eq!(app.current_view, View::StreamList);
     }
 
     #[test]

--- a/src/tui/controllers/stream.rs
+++ b/src/tui/controllers/stream.rs
@@ -20,6 +20,7 @@ pub enum StreamListAction {
     OpenDetail,
     NameEndpoints,
     BackToCallList,
+    OpenDashboard,
 }
 
 /// Pure key→action mapping for the stream list (keymap-aware); arm order
@@ -41,6 +42,7 @@ pub fn stream_list_action(km: &Keymap, key: KeyEvent) -> Option<StreamListAction
         k if k == km.filter => OpenFilterDialog,
         KeyCode::Enter => OpenDetail,
         KeyCode::Char('N') => NameEndpoints,
+        KeyCode::Char('D') => OpenDashboard,
         KeyCode::Esc => BackToCallList,
         _ => return None,
     })
@@ -105,6 +107,11 @@ fn execute_stream_list_action(app: &mut App, action: StreamListAction) {
             }
         }
         StreamListAction::BackToCallList => app.current_view = View::CallList,
+        StreamListAction::OpenDashboard => {
+            app.dashboard_selected = 0;
+            app.dashboard_return_view = Some(View::StreamList);
+            app.current_view = View::QualityDashboard;
+        }
     }
 }
 

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -1,0 +1,320 @@
+//! Aggregation core for the live call-quality dashboard.
+//!
+//! Pure data layer: ranks every tracked RTP stream by current MOS and
+//! precomputes the per-stream trend series the dashboard view draws.
+//! No locking and no rendering here — the renderer receives an
+//! already-built [`DashboardSnapshot`] so the draw pass stays read-only
+//! (skip-tick contract).
+
+use crate::rtp::quality::estimate_mos;
+use crate::rtp::stream::{RtpStream, StreamKey};
+use crate::rtp::stream_store::StreamStore;
+
+/// One point of a per-stream quality trend (one 5 s quality interval).
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrendPoint {
+    /// Estimated MOS for the interval.
+    pub mos: f64,
+    /// Average jitter during the interval (milliseconds).
+    pub jitter_ms: f64,
+    /// Packet loss percentage during the interval.
+    pub loss_pct: f64,
+}
+
+/// Current health of a single RTP stream, ready for table display.
+#[derive(Debug, Clone)]
+pub struct StreamHealth {
+    /// Identity of the stream.
+    pub key: StreamKey,
+    /// SIP Call-ID when the stream is linked to a dialog.
+    pub call_id: Option<String>,
+    /// Codec name, if known.
+    pub codec: Option<String>,
+    /// Current estimated MOS from running jitter/loss.
+    pub mos: f64,
+    /// Running RFC 3550 jitter (milliseconds).
+    pub jitter_ms: f64,
+    /// Cumulative packet loss percentage.
+    pub loss_pct: f64,
+    /// Total packets received.
+    pub packets: u64,
+    /// `true` if the stream saw traffic in the last 30 s.
+    pub active: bool,
+    /// Per-interval trend, oldest first.
+    pub trend: Vec<TrendPoint>,
+}
+
+/// Aggregate view over every stream in the store, worst quality first.
+#[derive(Debug, Clone, Default)]
+pub struct DashboardSnapshot {
+    /// Total streams tracked.
+    pub total_streams: usize,
+    /// Streams active within the last 30 s.
+    pub active_streams: usize,
+    /// Mean MOS across all streams (`None` when empty).
+    pub avg_mos: Option<f64>,
+    /// Lowest MOS across all streams (`None` when empty).
+    pub worst_mos: Option<f64>,
+    /// Streams with any recorded packet loss.
+    pub streams_with_loss: usize,
+    /// Per-stream health rows, ascending MOS (worst first); ties broken
+    /// by higher loss first, then by stream key for determinism.
+    pub rows: Vec<StreamHealth>,
+}
+
+/// Cumulative loss percentage of a stream; `0.0` for an empty stream.
+fn stream_loss_pct(s: &RtpStream) -> f64 {
+    let total = s.packet_count + s.lost_packets;
+    if total > 0 {
+        (s.lost_packets as f64 / total as f64) * 100.0
+    } else {
+        0.0
+    }
+}
+
+impl DashboardSnapshot {
+    /// Build a snapshot from the stream store.
+    ///
+    /// Runs under the store read guard on the render path — O(streams)
+    /// with no allocation beyond the output itself.
+    pub fn from_streams(store: &StreamStore) -> Self {
+        let mut rows: Vec<StreamHealth> = store
+            .iter()
+            .map(|s| {
+                let loss_pct = stream_loss_pct(s);
+                let codec = s.codec.clone();
+                let mos = estimate_mos(s.jitter, loss_pct, codec.as_deref());
+                let trend = s
+                    .quality_intervals
+                    .iter()
+                    .map(|qi| TrendPoint {
+                        mos: estimate_mos(qi.jitter_ms, qi.loss_pct, codec.as_deref()),
+                        jitter_ms: qi.jitter_ms,
+                        loss_pct: qi.loss_pct,
+                    })
+                    .collect();
+                StreamHealth {
+                    key: s.key.clone(),
+                    call_id: s.associated_dialog.clone(),
+                    codec,
+                    mos,
+                    jitter_ms: s.jitter,
+                    loss_pct,
+                    packets: s.packet_count,
+                    active: s.is_active(),
+                    trend,
+                }
+            })
+            .collect();
+
+        rows.sort_by(|a, b| {
+            a.mos
+                .total_cmp(&b.mos)
+                .then(b.loss_pct.total_cmp(&a.loss_pct))
+                .then_with(|| {
+                    (a.key.ssrc, a.key.src, a.key.dst).cmp(&(b.key.ssrc, b.key.src, b.key.dst))
+                })
+        });
+
+        let total_streams = rows.len();
+        let active_streams = rows.iter().filter(|r| r.active).count();
+        let streams_with_loss = rows.iter().filter(|r| r.loss_pct > 0.0).count();
+        let avg_mos = (total_streams > 0)
+            .then(|| rows.iter().map(|r| r.mos).sum::<f64>() / total_streams as f64);
+        let worst_mos = rows.first().map(|r| r.mos);
+
+        Self {
+            total_streams,
+            active_streams,
+            avg_mos,
+            worst_mos,
+            streams_with_loss,
+            rows,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rtp::parser::RtpHeader;
+    use chrono::{Duration, Utc};
+    use std::net::SocketAddr;
+
+    fn header(seq: u16, ts: u32) -> RtpHeader {
+        RtpHeader {
+            version: 2,
+            padding: false,
+            extension: false,
+            csrc_count: 0,
+            marker: false,
+            payload_type: 0, // PCMU
+            sequence: seq,
+            timestamp: ts,
+            ssrc: 0xABCD,
+            payload_offset: 12,
+        }
+    }
+
+    fn addr(port: u16) -> SocketAddr {
+        format!("192.0.2.10:{port}").parse().unwrap()
+    }
+
+    /// A stream with `n` clean packets ending "now" (active).
+    fn clean_stream(ssrc: u32, n: u16) -> RtpStream {
+        let start = Utc::now();
+        let key = StreamKey {
+            ssrc,
+            src: addr(10000),
+            dst: addr(20000),
+        };
+        let mut s = RtpStream::new(key, &header(0, 0), start);
+        for i in 1..n {
+            s.update(
+                &header(i, u32::from(i) * 160),
+                start + Duration::milliseconds(i64::from(i) * 20),
+                160,
+            );
+        }
+        s
+    }
+
+    fn store_with(streams: Vec<RtpStream>) -> StreamStore {
+        let mut store = StreamStore::new(64);
+        for s in streams {
+            store.insert_for_test(s);
+        }
+        store
+    }
+
+    #[test]
+    fn empty_store_yields_empty_snapshot() {
+        let snap = DashboardSnapshot::from_streams(&StreamStore::new(64));
+        assert_eq!(snap.total_streams, 0);
+        assert_eq!(snap.active_streams, 0);
+        assert_eq!(snap.avg_mos, None);
+        assert_eq!(snap.worst_mos, None);
+        assert_eq!(snap.streams_with_loss, 0);
+        assert!(snap.rows.is_empty());
+    }
+
+    #[test]
+    fn single_clean_stream_scores_high_and_matches_aggregates() {
+        let snap = DashboardSnapshot::from_streams(&store_with(vec![clean_stream(1, 50)]));
+        assert_eq!(snap.total_streams, 1);
+        assert_eq!(snap.active_streams, 1);
+        assert_eq!(snap.streams_with_loss, 0);
+        assert_eq!(snap.rows.len(), 1);
+        let row = &snap.rows[0];
+        assert!(
+            row.mos > 4.0,
+            "clean PCMU stream must score >4.0, got {}",
+            row.mos
+        );
+        assert_eq!(row.loss_pct, 0.0);
+        assert_eq!(snap.avg_mos, Some(row.mos));
+        assert_eq!(snap.worst_mos, Some(row.mos));
+        assert!(row.active);
+        assert_eq!(row.call_id, None);
+    }
+
+    #[test]
+    fn lossy_stream_ranks_first_and_is_counted() {
+        let clean = clean_stream(1, 50);
+        let mut lossy = clean_stream(2, 50);
+        lossy.lost_packets = 25; // ~33% loss
+        let snap = DashboardSnapshot::from_streams(&store_with(vec![clean, lossy]));
+        assert_eq!(snap.total_streams, 2);
+        assert_eq!(snap.streams_with_loss, 1);
+        assert_eq!(snap.rows.len(), 2);
+        assert_eq!(
+            snap.rows[0].key.ssrc, 2,
+            "worst (lossy) stream must rank first"
+        );
+        assert!(snap.rows[0].mos < snap.rows[1].mos);
+        assert!(snap.rows[0].loss_pct > 30.0 && snap.rows[0].loss_pct < 35.0);
+        assert_eq!(snap.worst_mos, Some(snap.rows[0].mos));
+        let avg = (snap.rows[0].mos + snap.rows[1].mos) / 2.0;
+        assert!((snap.avg_mos.unwrap() - avg).abs() < 1e-9);
+    }
+
+    #[test]
+    fn all_lost_stream_reports_full_loss_without_panicking() {
+        // adversarial: every packet after the first was lost
+        let mut s = clean_stream(3, 1);
+        s.packet_count = 0; // hypothetical: nothing received
+        s.lost_packets = 100;
+        let snap = DashboardSnapshot::from_streams(&store_with(vec![s]));
+        assert_eq!(snap.rows[0].loss_pct, 100.0);
+        assert!(snap.rows[0].mos >= 1.0, "MOS stays clamped at >=1.0");
+    }
+
+    #[test]
+    fn zero_packet_stream_is_handled() {
+        // adversarial: a stream object with no traffic at all
+        let mut s = clean_stream(4, 1);
+        s.packet_count = 0;
+        s.lost_packets = 0;
+        let snap = DashboardSnapshot::from_streams(&store_with(vec![s]));
+        assert_eq!(snap.total_streams, 1);
+        assert_eq!(snap.rows[0].loss_pct, 0.0);
+    }
+
+    #[test]
+    fn associated_dialog_and_orphan_flow_through() {
+        let mut linked = clean_stream(5, 10);
+        linked.associated_dialog = Some("call-1@example.com".into());
+        let mut orphan = clean_stream(6, 10);
+        orphan.orphaned = true;
+        let snap = DashboardSnapshot::from_streams(&store_with(vec![linked, orphan]));
+        let linked_row = snap.rows.iter().find(|r| r.key.ssrc == 5).unwrap();
+        let orphan_row = snap.rows.iter().find(|r| r.key.ssrc == 6).unwrap();
+        assert_eq!(linked_row.call_id.as_deref(), Some("call-1@example.com"));
+        assert_eq!(orphan_row.call_id, None);
+    }
+
+    #[test]
+    fn inactive_stream_is_counted_but_not_active() {
+        let mut old = clean_stream(7, 10);
+        old.last_seen = Utc::now() - Duration::seconds(120);
+        let snap = DashboardSnapshot::from_streams(&store_with(vec![old]));
+        assert_eq!(snap.total_streams, 1);
+        assert_eq!(snap.active_streams, 0);
+        assert!(!snap.rows[0].active);
+    }
+
+    #[test]
+    fn trend_is_built_from_quality_intervals_oldest_first() {
+        let start = Utc::now();
+        let mut s = clean_stream(8, 2);
+        // two intervals: first clean, second degraded
+        s.quality_intervals.clear();
+        s.quality_intervals
+            .push(crate::rtp::stream::QualityInterval {
+                timestamp: start,
+                jitter_ms: 1.0,
+                loss_pct: 0.0,
+                packets: 250,
+            });
+        s.quality_intervals
+            .push(crate::rtp::stream::QualityInterval {
+                timestamp: start + Duration::seconds(5),
+                jitter_ms: 80.0,
+                loss_pct: 20.0,
+                packets: 200,
+            });
+        let snap = DashboardSnapshot::from_streams(&store_with(vec![s]));
+        let trend = &snap.rows[0].trend;
+        assert_eq!(trend.len(), 2);
+        assert!(
+            trend[0].mos > trend[1].mos,
+            "clean interval first, degraded second"
+        );
+        assert_eq!(trend[0].loss_pct, 0.0);
+        assert_eq!(trend[1].jitter_ms, 80.0);
+        assert_eq!(trend[1].loss_pct, 20.0);
+        // trend MOS must agree with the canonical estimator
+        let expect = estimate_mos(80.0, 20.0, snap.rows[0].codec.as_deref());
+        assert!((trend[1].mos - expect).abs() < 1e-9);
+    }
+}

--- a/src/tui/help.rs
+++ b/src/tui/help.rs
@@ -40,6 +40,7 @@ CALL LIST:
   N                Name selected address (IP -> host / FQDN)
   O                Open pcap file
   s                Statistics view
+  D                Quality dashboard (live MOS/jitter/loss)
   F9               Clear active filter
   F10              Column selector
   Tab              Switch to RTP Streams
@@ -93,11 +94,19 @@ MESSAGE DIFF / COMBINED DETAIL / STATISTICS:
   Esc              Back
   q, s             Close statistics (Statistics view)
 
+QUALITY DASHBOARD:
+  \u{2191}/\u{2193}, j/k       Select stream (worst quality first)
+  PgUp/PgDn       Page through streams
+  Home/End         Jump to best/worst
+  Enter            Open stream detail
+  Esc, q, D        Close dashboard
+
 RTP STREAMS (Tab):
   \u{2191}/\u{2193}             Navigate streams
   PgUp/PgDn       Page scroll
   /                Search streams (arrows work while typing; Enter opens)
   Enter            Stream detail
+  D                Quality dashboard (live MOS/jitter/loss)
   Tab              Switch to Call List
   F1               Help
   F7               Filter

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod call_flow;
 pub mod call_list;
+pub mod dashboard;
 pub mod header_form;
 pub mod help;
 pub mod msg_raw;
@@ -54,8 +55,8 @@ use controllers::*;
 pub use controllers::{
     CallFlowAction, CallListAction, CombinedDetailAction, HelpAction, MessageDiffAction,
     RawMessageAction, StatisticsAction, StreamDetailAction, StreamListAction, call_flow_action,
-    call_list_action, combined_detail_action, help_action, message_diff_action, raw_message_action,
-    statistics_action, stream_detail_action, stream_list_action,
+    call_list_action, combined_detail_action, dashboard_action, help_action, message_diff_action,
+    raw_message_action, statistics_action, stream_detail_action, stream_list_action,
 };
 use render::*;
 use save::*;
@@ -115,6 +116,14 @@ pub struct App {
     help_scroll: u16,
     /// Scroll offset for the statistics view (clamped to content in render).
     stats_scroll: u16,
+    /// Selected row in the quality dashboard's worst-streams table.
+    dashboard_selected: usize,
+    /// View to return to when closing the quality dashboard.
+    dashboard_return_view: Option<View>,
+    /// Snapshot the quality dashboard renders from; rebuilt in
+    /// `sync_caches` while the dashboard is open so the draw pass stays
+    /// read-only (skip-tick contract).
+    dashboard_snapshot: Option<dashboard::DashboardSnapshot>,
     /// Displayed dialog-row count at the previous render (autoscroll's
     /// sticky-bottom reference point).
     last_rendered_dialog_rows: usize,
@@ -230,6 +239,9 @@ impl App {
             raw_msg_scroll: 0,
             help_scroll: 0,
             stats_scroll: 0,
+            dashboard_selected: 0,
+            dashboard_return_view: None,
+            dashboard_snapshot: None,
             last_rendered_dialog_rows: 0,
             diff_scroll: 0,
             search_query: String::new(),
@@ -391,6 +403,19 @@ impl App {
     /// previous values until the next tick, matching the render pass's
     /// skip-on-contention behavior.
     fn sync_caches(&mut self) {
+        // Quality dashboard: rebuild the snapshot outside the render pass
+        // (render is read-only under the skip-tick contract). try_read so
+        // a write-saturated capture skips the refresh, not the frame.
+        if matches!(self.current_view, View::QualityDashboard)
+            && let Some(ss) = self.stream_store.try_read()
+        {
+            let snap = dashboard::DashboardSnapshot::from_streams(&ss);
+            self.dashboard_selected = self
+                .dashboard_selected
+                .min(snap.rows.len().saturating_sub(1));
+            self.dashboard_snapshot = Some(snap);
+        }
+
         let Some(store) = self.dialog_store.try_read() else {
             return;
         };

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -436,6 +436,9 @@ pub(in crate::tui) fn render_app(
         View::Statistics => {
             fb.stats_scroll = Some(render_statistics(frame, main_area, app, ds, ss));
         }
+        View::QualityDashboard => {
+            render_dashboard(frame, main_area, app);
+        }
     }
 
     // F-key bar (sngrep-style, context-sensitive) at bottom
@@ -477,6 +480,149 @@ pub(in crate::tui) fn render_app(
 }
 
 /// Render the statistics summary view with real data from stores.
+/// Render the live call-quality dashboard from the snapshot cached by
+/// `sync_caches` (read-only pass — no store access, no locking).
+pub(in crate::tui) fn render_dashboard(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    app: &App,
+) {
+    use crate::tui::stream_detail::{jitter_to_block, mos_to_block};
+    use ratatui::style::{Modifier, Style};
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::{Block, Borders, Paragraph};
+
+    let theme = &app.theme;
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    let Some(snap) = app.dashboard_snapshot.as_ref() else {
+        lines.push(Line::raw(""));
+        lines.push(Line::raw("  Gathering stream quality data..."));
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(" Quality Dashboard ");
+        frame.render_widget(Paragraph::new(lines).block(block), area);
+        return;
+    };
+
+    let mos_style = |m: f64| {
+        if m >= 4.0 {
+            Style::default().fg(theme.good)
+        } else if m >= 3.0 {
+            Style::default().fg(theme.warning)
+        } else {
+            Style::default().fg(theme.bad)
+        }
+    };
+
+    // ── summary strip ───────────────────────────────────────────────
+    let mut summary = vec![Span::raw(format!(
+        "  Streams: {} ({} active)   ",
+        snap.total_streams, snap.active_streams
+    ))];
+    match (snap.avg_mos, snap.worst_mos) {
+        (Some(avg), Some(worst)) => {
+            summary.push(Span::raw("Avg MOS: "));
+            summary.push(Span::styled(format!("{avg:.1}"), mos_style(avg)));
+            summary.push(Span::raw("   Worst: "));
+            summary.push(Span::styled(format!("{worst:.1}"), mos_style(worst)));
+        }
+        _ => summary.push(Span::styled(
+            "No RTP streams yet",
+            Style::default().fg(theme.muted),
+        )),
+    }
+    summary.push(Span::raw(format!(
+        "   With loss: {}",
+        snap.streams_with_loss
+    )));
+    lines.push(Line::raw(""));
+    lines.push(Line::from(summary));
+    lines.push(Line::raw(""));
+
+    // ── worst-streams table ─────────────────────────────────────────
+    lines.push(Line::styled(
+        format!(
+            "    {:<5} {:>8} {:>7} {:>9}  {:<8} {}",
+            "MOS", "Jitter", "Loss%", "Packets", "Codec", "Stream"
+        ),
+        Style::default().fg(theme.muted),
+    ));
+
+    // Fixed overhead: 4 lines above + 5 trend lines below + borders.
+    let visible = (area.height as usize).saturating_sub(11).max(1);
+    let first = app
+        .dashboard_selected
+        .saturating_sub(visible.saturating_sub(1));
+    for (i, row) in snap.rows.iter().enumerate().skip(first).take(visible) {
+        let selected = i == app.dashboard_selected;
+        let marker = if selected { "▶ " } else { "  " };
+        let activity = if row.active { "●" } else { "·" };
+        let who = row
+            .call_id
+            .clone()
+            .unwrap_or_else(|| format!("{} → {}", row.key.src, row.key.dst));
+        let text = format!(
+            "{marker}{activity} {:<5.1} {:>6.1}ms {:>6.2} {:>9}  {:<8} {}",
+            row.mos,
+            row.jitter_ms,
+            row.loss_pct,
+            row.packets,
+            row.codec.as_deref().unwrap_or("?"),
+            who,
+        );
+        let style = if selected {
+            mos_style(row.mos).add_modifier(Modifier::REVERSED)
+        } else {
+            mos_style(row.mos)
+        };
+        lines.push(Line::styled(text, style));
+    }
+
+    // ── trend for the selected stream ───────────────────────────────
+    if let Some(row) = snap.rows.get(app.dashboard_selected) {
+        lines.push(Line::raw(""));
+        lines.push(Line::styled(
+            "  Trend (selected, 5s intervals, oldest → newest)",
+            Style::default().fg(theme.muted),
+        ));
+        let mut mos_spans = vec![Span::styled("  MOS:    ", Style::default().fg(theme.muted))];
+        let mut jit_spans = vec![Span::styled("  Jitter: ", Style::default().fg(theme.muted))];
+        for p in &row.trend {
+            mos_spans.push(Span::styled(
+                String::from(mos_to_block(p.mos)),
+                mos_style(p.mos),
+            ));
+            let jcolor = if p.jitter_ms < 20.0 {
+                theme.good
+            } else if p.jitter_ms < 50.0 {
+                theme.warning
+            } else {
+                theme.bad
+            };
+            jit_spans.push(Span::styled(
+                String::from(jitter_to_block(p.jitter_ms)),
+                Style::default().fg(jcolor),
+            ));
+        }
+        if row.trend.is_empty() {
+            let none = Span::styled(
+                "(no completed intervals yet)",
+                Style::default().fg(theme.muted),
+            );
+            mos_spans.push(none.clone());
+            jit_spans.push(none);
+        }
+        lines.push(Line::from(mos_spans));
+        lines.push(Line::from(jit_spans));
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Quality Dashboard ");
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
 pub(in crate::tui) fn render_statistics(
     frame: &mut ratatui::Frame,
     area: ratatui::layout::Rect,

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -989,6 +989,8 @@ pub enum View {
     Help,
     /// Statistics summary view.
     Statistics,
+    /// Live call-quality dashboard (aggregate MOS/jitter/loss, worst first).
+    QualityDashboard,
     /// RTP stream detail (by StreamKey).
     StreamDetail(crate::rtp::stream::StreamKey),
 }

--- a/src/tui/stream_detail.rs
+++ b/src/tui/stream_detail.rs
@@ -403,7 +403,7 @@ fn loss_style(loss_pct: f64, theme: &Theme) -> Style {
 }
 
 /// Map a MOS value (1.0–4.5) to a Unicode block character.
-fn mos_to_block(mos: f64) -> char {
+pub(in crate::tui) fn mos_to_block(mos: f64) -> char {
     match mos {
         m if m >= 4.3 => '\u{2588}', // █
         m if m >= 4.0 => '\u{2587}', // ▇
@@ -419,7 +419,7 @@ fn mos_to_block(mos: f64) -> char {
 /// Map a jitter value (ms) to a Unicode block character.
 /// Scale: 0–5ms = ▁, 5–10 = ▂, 10–15 = ▃, 15–20 = ▄,
 ///        20–25 = ▅, 25–30 = ▆, 30–35 = ▇, 35+ = █
-fn jitter_to_block(jitter_ms: f64) -> char {
+pub(in crate::tui) fn jitter_to_block(jitter_ms: f64) -> char {
     match jitter_ms {
         j if j >= 35.0 => '\u{2588}', // █
         j if j >= 30.0 => '\u{2587}', // ▇

--- a/tests/keybinding_drift_test.rs
+++ b/tests/keybinding_drift_test.rs
@@ -14,8 +14,8 @@ use std::collections::HashSet;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use sipnab::tui::help::HELP_TEXT;
 use sipnab::tui::{
-    Keymap, call_flow_action, call_list_action, combined_detail_action, help_action,
-    message_diff_action, raw_message_action, statistics_action, stream_detail_action,
+    Keymap, call_flow_action, call_list_action, combined_detail_action, dashboard_action,
+    help_action, message_diff_action, raw_message_action, statistics_action, stream_detail_action,
     stream_list_action,
 };
 
@@ -172,7 +172,7 @@ fn mapped_char_keys_are_documented_or_allowlisted() {
     let docs = documented_tokens();
     let km = Keymap::default();
     type Probe = (&'static str, fn(&Keymap, KeyEvent) -> bool);
-    let probes: [Probe; 9] = [
+    let probes: [Probe; 10] = [
         ("call_list", |km, k| call_list_action(km, k).is_some()),
         ("stream_list", |km, k| stream_list_action(km, k).is_some()),
         ("stream_detail", |km, k| {
@@ -186,6 +186,7 @@ fn mapped_char_keys_are_documented_or_allowlisted() {
         }),
         ("help", |km, k| help_action(km, k).is_some()),
         ("statistics", |km, k| statistics_action(km, k).is_some()),
+        ("dashboard", |km, k| dashboard_action(km, k).is_some()),
     ];
     let mut undocumented = Vec::new();
     for (view, probe) in probes {
@@ -259,6 +260,9 @@ fn every_documented_view_key_is_handled() {
         }),
         ("RTP STREAMS (Tab):", |km, k| {
             stream_list_action(km, k).is_some()
+        }),
+        ("QUALITY DASHBOARD:", |km, k| {
+            dashboard_action(km, k).is_some()
         }),
         ("STREAM DETAIL:", |km, k| {
             stream_detail_action(km, k).is_some()

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__help_view.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__help_view.snap
@@ -37,8 +37,8 @@ expression: output
 │  N                 Name selected address (IP -> host / FQDN)                 │
 │  O                 Open pcap file                                            │
 │  s                 Statistics view                                           │
+│  D                 Quality dashboard (live MOS/jitter/loss)                  │
 │  F9                Clear active filter                                       │
 │  F10               Column selector                                           │
-│  Tab               Switch to RTP Streams                                     │
 └──────────────────────────────────────────────────────────────────────────────┘
 Esc Back

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__quality_dashboard_no_streams.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__quality_dashboard_no_streams.snap
@@ -1,0 +1,28 @@
+---
+source: tests/tui_snapshot_test.rs
+expression: output
+---
+ Current Mode: Online (any)    Dialogs: 3 (3 displayed)  [A]
+ Match Expression:     BPF Filter:
+ Display Filter:
+┌ Quality Dashboard ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                                │
+│  Streams: 0 (0 active)   No RTP streams yet   With loss: 0                                                                     │
+│                                                                                                                                │
+│    MOS     Jitter   Loss%   Packets  Codec    Stream                                                                           │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+Esc Back

--- a/tests/snapshots/tui_snapshot_test__tui_snapshots__quality_dashboard_with_streams.snap
+++ b/tests/snapshots/tui_snapshot_test__tui_snapshots__quality_dashboard_with_streams.snap
@@ -1,0 +1,28 @@
+---
+source: tests/tui_snapshot_test.rs
+expression: output
+---
+ Current Mode: Online (any)    Dialogs: 0 (0 displayed)  [A]
+ Match Expression:     BPF Filter:
+ Display Filter:
+┌ Quality Dashboard ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                                │
+│  Streams: 2 (0 active)   Avg MOS: 4.4   Worst: 4.4   With loss: 0                                                              │
+│                                                                                                                                │
+│    MOS     Jitter   Loss%   Packets  Codec    Stream                                                                           │
+│▶ · 4.4      0.0ms   0.00         1  PCMU     call-1@test                                                                       │
+│  · 4.4      0.0ms   0.00         1  PCMA     10.0.0.3:20002 → 10.0.0.4:30002                                                   │
+│                                                                                                                                │
+│  Trend (selected, 5s intervals, oldest → newest)                                                                               │
+│  MOS:    (no completed intervals yet)                                                                                          │
+│  Jitter: (no completed intervals yet)                                                                                          │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+│                                                                                                                                │
+└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+Esc Back

--- a/tests/tui_snapshot_test.rs
+++ b/tests/tui_snapshot_test.rs
@@ -322,6 +322,42 @@ mod tui_snapshots {
     }
 
     #[test]
+    fn quality_dashboard_no_streams() {
+        let backend = TestBackend::new(130, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = test_app_with_dialogs();
+        app.handle_key(crossterm::event::KeyCode::Char('D')); // open dashboard
+
+        terminal.draw(|frame| app.render(frame)).unwrap();
+
+        let output = buffer_to_string(&terminal);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn quality_dashboard_with_streams() {
+        let backend = TestBackend::new(130, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = test_app_with_streams();
+        app.handle_key(crossterm::event::KeyCode::Char('D')); // open dashboard
+
+        terminal.draw(|frame| app.render(frame)).unwrap();
+
+        let output = buffer_to_string(&terminal);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn quality_dashboard_survives_tiny_terminal() {
+        // render-robustness: a 10x3 terminal must not panic or underflow
+        let backend = TestBackend::new(10, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = test_app_with_streams();
+        app.handle_key(crossterm::event::KeyCode::Char('D'));
+        terminal.draw(|frame| app.render(frame)).unwrap();
+    }
+
+    #[test]
     fn stream_list_with_streams() {
         let backend = TestBackend::new(130, 24);
         let mut terminal = Terminal::new(backend).unwrap();

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -164,7 +164,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2595 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2612 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -235,7 +235,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.5.18)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2595" data-suffix="">2595</span>
+        <span class="arch-stat" data-count="2612" data-suffix="">2612</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Implements the top TUI backlog item (tasks/todo.md): a live call-quality dashboard.

**View**: `D` from the Call List or RTP Streams view opens `View::QualityDashboard` (close returns to whichever view opened it). Summary strip (stream counts, avg/worst MOS, streams with loss), a worst-quality-first table of streams (MOS/jitter/loss/packets/codec, linked Call-ID or src→dst), and MOS/jitter trend sparklines for the selected stream from its 5 s quality intervals. Enter drills into the existing stream detail; `j/k`, PgUp/PgDn, Home/End, and the mouse wheel navigate.

**Architecture**: pure aggregation core (`tui::dashboard::DashboardSnapshot`) with the snapshot rebuilt in `sync_caches` under `try_read` — the render pass stays read-only per the skip-tick contract.

**Supporting fixes found by the new adversarial tests**:
- `estimate_mos` violated its documented `[1.0, 4.5]` floor (the G.107 cubic dips to ~0.99 at small positive R, e.g. 100% loss on G.711) — floor now enforced in-branch, with a sweep test.
- `quality_intervals` grew unbounded (one entry per 5 s per stream, forever) — now a 720-entry (1 h) oldest-out ring.

**TDD**: every increment red→green (aggregation core against `todo!()`, bounded-history against a missing cap, mapper tests against a missing enum, drift tests against missing docs). 17 new tests: 8 aggregation (incl. 0-packet, 100%-loss, orphan, inactive), 1 history cap, 1 MOS floor sweep, 4 controller, 3 snapshot/robustness. Help text, `docs/keybindings.md`, and the keybinding drift gates updated; homepage count 2595→2612.

**Verified live** (not just tests): replayed `g711a.pcap` in tmux — heuristic stream pickup, MOS 4.4 / 0.5 ms jitter / 5535 packets, 22-interval sparklines, full `D` → Enter → Esc → `D` round-trip. Local gates green: fmt, clippy `-D warnings`, full `--all-features` suite, native-only/wasm/mcp builds.