### PR TITLE
ops(csp): refresh the Cloudflare CSP rule automatically after every deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,11 +8,13 @@ on:
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 
-# Allow the GITHUB_TOKEN to deploy to Pages and verify the deployment origin.
+# Allow the GITHUB_TOKEN to deploy to Pages and verify the deployment origin;
+# actions:read lets the csp job download the deployed pages artifact.
 permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read
 
 # One concurrent deploy; let an in-progress run finish to avoid half-published state.
 concurrency:
@@ -64,3 +66,30 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  # The production CSP is a Cloudflare transform rule pinning inline-script
+  # hashes (GitHub Pages cannot set response headers). A deploy that changes
+  # an inline <script> without refreshing the rule ships pages whose scripts
+  # browsers silently block — the homepage demos and feature tabs died this
+  # way on 2026-07-22. Hash the exact artifact that was deployed, not the
+  # live CDN, which can serve stale (even version-mixed) pages for ~10
+  # minutes after a deploy.
+  csp:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: ops/cloudflare
+
+      - name: Download deployed site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages
+
+      - name: Refresh Cloudflare CSP hashes from the deployed HTML
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          mkdir site && tar -xf artifact.tar -C site
+          python3 ops/cloudflare/refresh_csp_hashes.py --site-dir site

--- a/ops/cloudflare/refresh_csp_hashes.py
+++ b/ops/cloudflare/refresh_csp_hashes.py
@@ -6,14 +6,18 @@ The site is served by GitHub Pages (which cannot set response headers), so
 security headers are injected at the Cloudflare edge. The CSP's script-src
 whitelists inline <script> blocks by hash instead of 'unsafe-inline'.
 
-RUN THIS AFTER EVERY DEPLOY THAT CHANGES AN INLINE <script> in
-website/templates/ — otherwise the header CSP blocks the changed script.
+Runs automatically after every Pages deploy (the `csp` job in
+.github/workflows/pages.yml) with --site-dir pointed at the deployed
+artifact — hashing the exact HTML that shipped, not the live CDN, which can
+serve stale (even version-mixed) pages for ~10 minutes after a deploy.
+Without --site-dir it crawls the live sitemap instead; that mode remains for
+manual runs and verification.
 
 Auth: CLOUDFLARE_DNS_TOKEN (or CLOUDFLARE_API_TOKEN) in the environment or
 ~/.env. The token needs Zone->DNS->Edit, Zone->Zone Settings->Edit and
 Zone->Transform Rules->Edit on the zone.
 
-Usage: python3 refresh_csp_hashes.py [--dry-run]
+Usage: python3 refresh_csp_hashes.py [--site-dir DIR] [--dry-run]
 """
 import base64
 import hashlib
@@ -98,6 +102,25 @@ def collect_hashes():
     return tokens
 
 
+def collect_hashes_from_dir(root):
+    """Hash inline scripts of every .html file under root (a built site)."""
+    tokens = {}
+    seen_html = False
+    for dirpath, _dirs, files in sorted(os.walk(root)):
+        for name in sorted(files):
+            if not name.endswith(".html"):
+                continue
+            seen_html = True
+            path = os.path.join(dirpath, name)
+            with open(path, "rb") as f:
+                html = f.read().decode("utf-8", "replace")
+            for body in extract_inline_scripts(html):
+                tokens.setdefault(sha256_token(body), []).append(path)
+    if not seen_html:
+        sys.exit("no .html files under %s — refusing to publish an empty CSP" % root)
+    return tokens
+
+
 def csp(script_hashes):
     return (
         "default-src 'self'; "
@@ -124,8 +147,19 @@ def headers(script_hashes):
 
 
 def main():
-    dry = "--dry-run" in sys.argv
-    tokens = collect_hashes()
+    argv = sys.argv[1:]
+    dry = "--dry-run" in argv
+    site_dir = None
+    if "--site-dir" in argv:
+        i = argv.index("--site-dir")
+        if i + 1 >= len(argv):
+            sys.exit("--site-dir requires a directory argument")
+        site_dir = argv[i + 1]
+        del argv[i : i + 2]
+    unknown = [a for a in argv if a != "--dry-run"]
+    if unknown:
+        sys.exit("unknown arguments: %s" % " ".join(unknown))
+    tokens = collect_hashes_from_dir(site_dir) if site_dir else collect_hashes()
     print("distinct inline-script hashes: %d" % len(tokens))
     for t, pages in sorted(tokens.items()):
         print("  %s  (%d pages)" % (t, len(pages)))

--- a/tests/site_journey_test.rs
+++ b/tests/site_journey_test.rs
@@ -878,9 +878,10 @@ fn download_page_msrv_matches_cargo() {
 // sha256 hash, NOT 'unsafe-inline'. Editing an inline script without
 // refreshing the rule ships a page whose script the browser silently blocks —
 // the download page's platform tabs were dead in production for a day this
-// way. This pin list makes the refresh step unforgettable: any inline-script
-// edit fails here until the dev (a) deploys, (b) runs
-// `python3 ops/cloudflare/refresh_csp_hashes.py`, and (c) re-pins.
+// way, and the homepage demos/feature tabs for a morning on 2026-07-22.
+// Since then pages.yml's `csp` job refreshes the rule automatically after
+// every deploy (from the deployed artifact, via --site-dir); this pin list
+// remains so an inline-script edit is a conscious, reviewed act.
 //
 // Pins are computed over the RAW TEMPLATE script bodies; where a script has
 // no Tera syntax the pin equals the deployed CSP token exactly (all except
@@ -949,11 +950,118 @@ fn inline_script_edits_require_csp_hash_refresh() {
     assert_eq!(
         found, pinned,
         "an inline <script> in website/templates/ changed. The production CSP \
-         only allows inline scripts by sha256 hash — the edited script will be \
-         SILENTLY BLOCKED in production until the Cloudflare rule is updated. \
-         After this change deploys, run \
-         `python3 ops/cloudflare/refresh_csp_hashes.py`, then update PINNED in \
-         this test to the computed list above."
+         only allows inline scripts by sha256 hash. The pages.yml csp job \
+         refreshes the Cloudflare rule automatically on deploy; update PINNED \
+         in this test to the computed list above to acknowledge the change."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CSP refresh --site-dir journey: pages.yml's post-deploy `csp` job runs
+// refresh_csp_hashes.py against the BUILT site (the pages artifact) instead
+// of fetching the live CDN, which can serve stale HTML for ~10 minutes after
+// a deploy. These guards run the real script in --site-dir --dry-run mode
+// against a fixture tree and pin the extraction semantics: executable inline
+// scripts hashed recursively, src=/data blocks skipped, and an empty tree a
+// hard error — a silently empty hash set would strip every pin from the
+// production CSP.
+// ---------------------------------------------------------------------------
+
+fn csp_token(body: &str) -> String {
+    use base64::Engine as _;
+    use sha2::Digest as _;
+    format!(
+        "'sha256-{}'",
+        base64::engine::general_purpose::STANDARD.encode(sha2::Sha256::digest(body.as_bytes()))
+    )
+}
+
+fn run_csp_refresh(args: &[&str]) -> std::process::Output {
+    std::process::Command::new("python3")
+        .arg(repo().join("ops/cloudflare/refresh_csp_hashes.py"))
+        .args(args)
+        .output()
+        .expect("run refresh_csp_hashes.py")
+}
+
+#[test]
+fn csp_refresh_site_dir_hashes_executable_inline_scripts() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Adversarial bodies: backslashes, quotes, an embedded NUL, multibyte.
+    let root_body = "var s = \"back\\\\slash \\\"quoted\\\" \u{0} caf\u{e9} \u{1F600}\";";
+    let sub_body = "console.log('nested page');";
+    let module_body = "export const x = 1;";
+    let data_body = "{\"@type\": \"SoftwareApplication\"}";
+    std::fs::write(
+        dir.path().join("index.html"),
+        format!(
+            "<html><body>\
+             <script>{root_body}</script>\
+             <script src=\"/app.js\"></script>\
+             <script type=\"application/ld+json\">{data_body}</script>\
+             </body></html>"
+        ),
+    )
+    .expect("write index.html");
+    std::fs::create_dir(dir.path().join("docs")).expect("mkdir docs");
+    std::fs::write(
+        dir.path().join("docs/index.html"),
+        format!(
+            "<html><body>\
+             <script type=\"module\">{module_body}</script>\
+             <script>{sub_body}</script>\
+             </body></html>"
+        ),
+    )
+    .expect("write docs/index.html");
+    std::fs::write(dir.path().join("style.css"), "body {}").expect("write non-html");
+
+    let out = run_csp_refresh(&["--site-dir", dir.path().to_str().unwrap(), "--dry-run"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "--site-dir --dry-run failed\nstdout: {stdout}\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    for (what, body) in [
+        ("root inline", root_body),
+        ("nested inline", sub_body),
+        ("module", module_body),
+    ] {
+        assert!(
+            stdout.contains(&csp_token(body)),
+            "{what} script hash missing from output:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains(&csp_token(data_body)),
+        "ld+json data block must not be hashed:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("distinct inline-script hashes: 3"),
+        "expected exactly 3 hashes (src= and ld+json excluded):\n{stdout}"
+    );
+    // Dry run must print the CSP that would ship, with the hashes in place.
+    assert!(
+        stdout.contains("script-src 'self' 'wasm-unsafe-eval'")
+            && stdout.contains(&csp_token(root_body)),
+        "dry run should print the resulting CSP:\n{stdout}"
+    );
+}
+
+#[test]
+fn csp_refresh_site_dir_empty_tree_is_an_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = run_csp_refresh(&["--site-dir", dir.path().to_str().unwrap(), "--dry-run"]);
+    assert!(
+        !out.status.success(),
+        "an html-free --site-dir must fail loudly, not publish an empty CSP"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(".html"),
+        "error should say no .html files were found: {stderr}"
     );
 }
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -164,7 +164,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2612 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2614 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -235,7 +235,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.5.18)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2612" data-suffix="">2612</span>
+        <span class="arch-stat" data-count="2614" data-suffix="">2614</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
## Why

The 2026-07-22 WebP deploy (#186) went out with the Cloudflare edge CSP still pinning the old homepage inline-script hash, so browsers silently blocked the page's JS: the demo animations never loaded and the feature tabs were dead. The `inline_script_edits_require_csp_hash_refresh` drift test only compares templates against pins stored in the repo — it stays green while the edge rule goes stale, because the actual refresh was a manual post-deploy step.

## What

- **`pages.yml`: new `csp` job after `deploy`** — downloads the exact pages artifact that was deployed and runs `refresh_csp_hashes.py --site-dir` against it, updating the Cloudflare transform rule on every site deploy. Auth via the new `CLOUDFLARE_API_TOKEN` repo secret (already set).
- **`refresh_csp_hashes.py`: new `--site-dir` mode** — hashes inline scripts from built HTML on disk instead of crawling the live CDN. Crawling live turned out doubly wrong: the CDN can serve stale (even version-mixed) pages for ~10 minutes after a deploy, and Cloudflare injects per-request inline challenge scripts into curl-like fetches — a live crawl picked up ~21 ephemeral hashes that polluted the rule. An html-free `--site-dir` is a hard error so a misconfigured path can't publish an empty CSP; unknown arguments now error instead of being silently ignored.
- **Tests (TDD, red→green)**: two new `site_journey_test` cases run the real script in `--site-dir --dry-run` mode against a fixture tree — recursive traversal, `src=`/`ld+json` exclusion, adversarial script bodies (backslashes, quotes, embedded NUL, multibyte), exact hash count, and the empty-tree hard error. Drift-test comments updated to describe the automated flow (the pin list stays as the conscious-review tripwire). Homepage test count bumped 2612 → 2614 (pre-commit gate).

## Production state

The live rule has already been repaired by hand from a local `zola build` via the new `--site-dir` mode (5 hashes, matching the pinned set) — the site is working now; this PR prevents the recurrence.