### PR TITLE
release 0.5.22: MCP deployment walkthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.22] - 2026-07-22
+
+### Added
+- Docs: step-by-step MCP deployment walkthrough (`docs/mcp-walkthrough.md`,
+  website, wiki) — same-box stdio, the three remote wirings (SSH-launched
+  stdio, HTTP + bearer token, SSH tunnel to a loopback bind), a central HEP
+  capture host with OpenSIPS/Kamailio mirror config and Homer coexistence,
+  nginx-TLS exposure, fleets, and headless automation, plus sizing, security,
+  and troubleshooting guidance. Every step tagged by the host it runs on.
+
+### Changed
+- Homepage media ships as lossless animated WebP (4.86 MB → 3.23 MB,
+  pixel-identical); `demos/Makefile` converts each VHS render and drops the
+  intermediate GIF.
+- ops: the Cloudflare CSP transform rule refreshes automatically after every
+  Pages deploy, hashed from the exact deployed artifact
+  (`refresh_csp_hashes.py --site-dir`); stale-rule outages (dead homepage
+  JS after an inline-script change) can no longer recur.
+
 ## [0.5.21] - 2026-07-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.5.21"
+version = "0.5.22"
 dependencies = [
  "aes",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 
 [package]
 name = "sipnab"
-version = "0.5.21"
+version = "0.5.22"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Norm Brandinger"]

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ curl -fsSL https://www.sipnab.com/install.sh | sh
 ```
 
 Prefer to read it first: <https://www.sipnab.com/install.sh>. Pin a version
-with `SIPNAB_VERSION=0.5.21`, change the destination with `SIPNAB_INSTALL_DIR`.
+with `SIPNAB_VERSION=0.5.22`, change the destination with `SIPNAB_INSTALL_DIR`.
 
 ## Pre-built Binaries
 
@@ -27,7 +27,7 @@ you which one you are.
 
 ```bash
 # Linux x86_64 (static musl -- runs on any distro, any glibc, Alpine included)
-# Replace <version> with the latest, e.g. 0.5.21
+# Replace <version> with the latest, e.g. 0.5.22
 curl -LO https://github.com/NormB/sipnab/releases/download/v<version>/sipnab-<version>-x86_64-unknown-linux-musl.tar.gz
 tar xzf sipnab-<version>-x86_64-unknown-linux-musl.tar.gz
 sudo install -m 755 sipnab-<version>-x86_64-unknown-linux-musl/sipnab /usr/local/bin/sipnab
@@ -56,7 +56,7 @@ cargo install sipnab --features full
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install with `apt` (it resolves the `libpcap0.8` runtime dependency). The `.deb` needs glibc >= 2.39, i.e. Debian 13+ / Ubuntu 24.04+ -- on older releases use the static musl tarball above:
 
 ```bash
-# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.21
+# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.22
 curl -LO https://github.com/NormB/sipnab/releases/latest/download/sipnab_<version>_amd64.deb
 sudo apt install ./sipnab_<version>_amd64.deb
 
@@ -96,11 +96,11 @@ standard and a `-noaudio` variant (no audio plugin, no `alsa-lib` weak
 dependency — for headless servers, mirroring the `.deb` variants):
 
 ```bash
-sudo rpm -i sipnab-0.5.21-1.x86_64.rpm
+sudo rpm -i sipnab-0.5.22-1.x86_64.rpm
 # headless / no-ALSA variant:
-sudo rpm -i sipnab-0.5.21-1.x86_64-noaudio.rpm
+sudo rpm -i sipnab-0.5.22-1.x86_64-noaudio.rpm
 # arm64 hosts:
-sudo rpm -i sipnab-0.5.21-1.aarch64.rpm
+sudo rpm -i sipnab-0.5.22-1.aarch64.rpm
 ```
 
 ### Homebrew (macOS)
@@ -282,7 +282,7 @@ sipnab --help
 `--version` lists the Cargo features compiled into the binary, e.g.
 
 ```
-sipnab 0.5.21 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+sipnab 0.5.22 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 ```
 
 This is the fastest way to confirm a build was produced with the feature set

--- a/docs/mcp-walkthrough.md
+++ b/docs/mcp-walkthrough.md
@@ -56,7 +56,7 @@ itself):
 
    ```bash
    sipnab --version
-   # sipnab 0.5.21 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+   # sipnab 0.5.22 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http
    ```
 
    If `mcp` is missing you have a source build without features — rebuild

--- a/man/sipnab.1
+++ b/man/sipnab.1
@@ -1,7 +1,7 @@
 .\" sipnab.1 -- man page for sipnab
 .\" Copyright 2024-2026 Norm Brandinger
 .\" License: MIT OR Apache-2.0
-.TH SIPNAB 1 "2026-07-22" "sipnab 0.5.21" "User Commands"
+.TH SIPNAB 1 "2026-07-22" "sipnab 0.5.22" "User Commands"
 .SH NAME
 sipnab \- SIP & RTP capture, analysis, and security tool
 .SH SYNOPSIS

--- a/website/config.toml
+++ b/website/config.toml
@@ -26,7 +26,7 @@ theme = "ayu-dark"
 # overwrites this from Cargo.toml at build time (single source of truth), and a
 # pre-commit hook fails if the two drift — so the homepage version badge and the
 # download links always match the released crate. Update Cargo.toml, not this.
-version = "0.5.21"
+version = "0.5.22"
 # Release date of the current `version` above. Shown on /download next to the
 # version. Update alongside Cargo.toml/version when cutting a release.
 release_date = "2026-07-21"

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -754,7 +754,7 @@ Metric names emitted by `src/output/prometheus.rs`:
 | `sipnab_jitter_ms` | histogram | RTP jitter distribution (buckets at 5/10/20/50/100/200ms). |
 | `sipnab_loss_percent` | histogram | RTP packet-loss distribution (buckets at 0.1/0.5/1/2/5/10%). |
 
-The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.21 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
+The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.22 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
 
 ## Security Model
 

--- a/website/content/docs/benchmarks.md
+++ b/website/content/docs/benchmarks.md
@@ -13,8 +13,8 @@ capture/packet path below unchanged (its numbers carry over), but rewrote
 the `-N --json` export sink: buffered batch writes plus direct JSON
 serialization cut wall-clock time ~29% and `write()` syscalls 98.5% on that
 path (same-toolchain A/B on this branch, byte-identical output; not yet
-re-measured on a released artifact). The current release 0.5.21 (TUI
-call-quality dashboard) changes neither path. The comparison
+re-measured on a released artifact). The current release 0.5.22 (MCP deployment
+walkthrough docs and site work) changes neither path. The comparison
 tools' numbers come from the 2026-06-24 session — same host, corpus, and
 method, and their versions are unchanged. Versus the 0.4.16 session, 0.5.18
 measures faster at every multi-core operating point (+9–16%) and across the

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -40,7 +40,7 @@ Every [GitHub release](https://github.com/NormB/sipnab/releases) ships versioned
 - `sipnab-<version>-aarch64-unknown-linux-musl.tar.gz` — same, for arm64
 - `sipnab-<version>-x86_64-apple-darwin.tar.gz` / `sipnab-<version>-aarch64-apple-darwin.tar.gz` — macOS
 
-Manual download with checksum verification (replace `<version>` with the latest, e.g. 0.5.21):
+Manual download with checksum verification (replace `<version>` with the latest, e.g. 0.5.22):
 
 ```bash
 V=<version> T=x86_64-unknown-linux-gnu
@@ -89,7 +89,7 @@ For build prerequisites, the full feature-flag matrix, release profile, and cros
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install it with `apt`, which resolves the `libpcap0.8` runtime dependency automatically:
 
 ```bash
-# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.21
+# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.22
 curl -LO https://github.com/NormB/sipnab/releases/latest/download/sipnab_<version>_amd64.deb
 sudo apt install ./sipnab_<version>_amd64.deb
 
@@ -121,7 +121,7 @@ standard and a `-noaudio` variant (no audio plugin, no `alsa-lib` weak
 dependency — for headless servers, mirroring the `.deb` variants):
 
 ```bash
-sudo rpm -i sipnab-<version>-1.x86_64.rpm  # replace <version> with the latest, e.g. 0.5.21
+sudo rpm -i sipnab-<version>-1.x86_64.rpm  # replace <version> with the latest, e.g. 0.5.22
 # headless / no-ALSA variant:
 sudo rpm -i sipnab-<version>-1.x86_64-noaudio.rpm
 # arm64 hosts:
@@ -179,7 +179,7 @@ sipnab -D
 <span class="terminal-title">Verify Installation</span>
 </div>
 <pre class="terminal-body"><span class="t-muted">$</span> sipnab --version
-sipnab 0.5.21 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+sipnab 0.5.22 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 
 <span class="t-muted">$</span> sipnab -N -I demo.pcap | head -3
 <span class="t-accent">INVITE</span> alice -> bob  192.0.2.1:5060 -> 192.0.2.2:5060 <span class="t-good">InCall</span> PDD=847ms

--- a/website/content/docs/mcp-walkthrough.md
+++ b/website/content/docs/mcp-walkthrough.md
@@ -60,7 +60,7 @@ itself):
 
    ```bash
    sipnab --version
-   # sipnab 0.5.21 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+   # sipnab 0.5.22 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http
    ```
 
    If `mcp` is missing you have a source build without features — rebuild


### PR DESCRIPTION
Version bump to 0.5.22 — a docs/site/ops release, no packet-path or runtime code changes (same pattern as 0.5.19).

Since 0.5.21:
- **MCP deployment walkthrough** (#188) — step-by-step scenarios across docs, wiki, and website.
- **Homepage media as lossless WebP** (#186) — 4.86 MB → 3.23 MB, pixel-identical.
- **Automated post-deploy CSP refresh** (#187) — the Cloudflare rule is rebuilt from each deployed artifact; stale-pin outages can't recur.

Standard bump set: Cargo.toml/lock, CHANGELOG, install.md markers (both copies), man page, website config.toml, api.md/benchmarks.md current-version prose. All pre-commit version-sync gates green.

After merge: tag `v0.5.22` on the squash commit to trigger the release build.