### PR TITLE
fix(site): add MCP Walkthrough to the docs sidebar and header dropdown

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -113,6 +113,7 @@
             <a href="{{ get_url(path='@/docs/api-clients.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/api-clients/" %}class="active"{% endif %}>API Clients</a>
             <a href="{{ get_url(path='@/docs/integrations.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/integrations/" %}class="active"{% endif %}>Integrations</a>
             <a href="{{ get_url(path='@/docs/mcp.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/mcp/" %}class="active"{% endif %}>MCP</a>
+            <a href="{{ get_url(path='@/docs/mcp-walkthrough.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/mcp-walkthrough/" %}class="active"{% endif %}>MCP Walkthrough</a>
             <a href="{{ get_url(path='@/docs/build.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/build/" %}class="active"{% endif %}>Build from Source</a>
             <a href="{{ get_url(path='@/docs/benchmarks.md') }}" role="menuitem" {% if current_path is defined and current_path == "/docs/benchmarks/" %}class="active"{% endif %}>Benchmarks</a>
           </div>

--- a/website/templates/page.html
+++ b/website/templates/page.html
@@ -14,7 +14,7 @@
       {{ macros::nav_group(title="Using the TUI", paths=["tui.md", "keybindings.md", "theme.md"], current_url=page.permalink) }}
       {{ macros::nav_group(title="CLI & automation", paths=["cli.md", "filter-dsl.md", "output-formats.md"], current_url=page.permalink) }}
       {{ macros::nav_group(title="Configuration", paths=["config.md"], current_url=page.permalink) }}
-      {{ macros::nav_group(title="API & integrations", paths=["api.md", "api-clients.md", "integrations.md", "mcp.md"], current_url=page.permalink) }}
+      {{ macros::nav_group(title="API & integrations", paths=["api.md", "api-clients.md", "integrations.md", "mcp.md", "mcp-walkthrough.md"], current_url=page.permalink) }}
       {{ macros::nav_group(title="Build & benchmarks", paths=["build.md", "benchmarks.md"], current_url=page.permalink) }}
     </nav>
   </aside>

--- a/website/templates/section.html
+++ b/website/templates/section.html
@@ -14,7 +14,7 @@
       {{ macros::nav_group(title="Using the TUI", paths=["tui.md", "keybindings.md", "theme.md"], current_url=section.permalink) }}
       {{ macros::nav_group(title="CLI & automation", paths=["cli.md", "filter-dsl.md", "output-formats.md"], current_url=section.permalink) }}
       {{ macros::nav_group(title="Configuration", paths=["config.md"], current_url=section.permalink) }}
-      {{ macros::nav_group(title="API & integrations", paths=["api.md", "api-clients.md", "integrations.md", "mcp.md"], current_url=section.permalink) }}
+      {{ macros::nav_group(title="API & integrations", paths=["api.md", "api-clients.md", "integrations.md", "mcp.md", "mcp-walkthrough.md"], current_url=section.permalink) }}
       {{ macros::nav_group(title="Build & benchmarks", paths=["build.md", "benchmarks.md"], current_url=section.permalink) }}
     </nav>
   </aside>


### PR DESCRIPTION
The walkthrough page was reachable only from the /docs/ index cards — the docs sidebar groups (`page.html`, `section.html`) and the header dropdown (`base.html`) are hardcoded page lists that weren't updated when the page landed. Adds it to the **API & integrations** group and the dropdown, directly after MCP Server; the hamburger nav on mobile inherits the dropdown fix. Prev/next pagination was already correct (weight-driven).

Verified on a local zola build: link present in sidebar, dropdown, and mobile panel; MCP Server's Next now points at the walkthrough; all 22 site-journey tests green. No inline scripts touched (no CSP re-pin needed — and the post-deploy csp job covers it regardless).