### PR TITLE
test(site): drift-guard the hardcoded docs nav lists

### DIFF
--- a/tests/site_journey_test.rs
+++ b/tests/site_journey_test.rs
@@ -957,6 +957,94 @@ fn inline_script_edits_require_csp_hash_refresh() {
 }
 
 // ---------------------------------------------------------------------------
+// Docs nav drift: the docs sidebar (page.html + section.html nav_group
+// lists) and the header dropdown (base.html) are HARDCODED page lists. The
+// MCP walkthrough shipped reachable only from the /docs/ index cards
+// because none of the three was updated. Every docs page must appear in
+// all three, the two sidebar templates must agree, no nav entry may point
+// at a deleted page, and page weights must be unique (prev/next order).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_docs_page_is_in_the_sidebar_and_dropdown_navs() {
+    let docs_dir = repo().join("website/content/docs");
+    let mut pages: Vec<String> = std::fs::read_dir(&docs_dir)
+        .expect("docs content dir")
+        .map(|e| e.expect("entry").file_name().to_string_lossy().to_string())
+        .filter(|n| n.ends_with(".md") && n != "_index.md")
+        .collect();
+    pages.sort();
+
+    let nav_paths = |template: &str| -> Vec<String> {
+        let text = std::fs::read_to_string(repo().join("website/templates").join(template))
+            .expect("read template");
+        let group = regex::Regex::new(r#"nav_group\([^)]*paths=\[([^\]]*)\]"#).unwrap();
+        let entry = regex::Regex::new(r#""([^"]+\.md)""#).unwrap();
+        let mut out: Vec<String> = Vec::new();
+        for c in group.captures_iter(&text) {
+            for e in entry.captures_iter(c.get(1).expect("paths list").as_str()) {
+                out.push(e[1].to_string());
+            }
+        }
+        out.sort();
+        out
+    };
+
+    let page_nav = nav_paths("page.html");
+    let section_nav = nav_paths("section.html");
+    assert_eq!(
+        page_nav, section_nav,
+        "page.html and section.html sidebar nav_group lists differ — update both"
+    );
+    assert_eq!(
+        page_nav, pages,
+        "docs sidebar (page.html/section.html nav_group paths) does not match \
+         website/content/docs/*.md — a page is missing from the sidebar or a \
+         nav entry points at a deleted page"
+    );
+
+    let base = std::fs::read_to_string(repo().join("website/templates/base.html"))
+        .expect("read base.html");
+    let dropdown =
+        regex::Regex::new(r#"get_url\(path='@/docs/([a-z0-9-]+\.md)'\)[^>]*role="menuitem""#)
+            .unwrap();
+    let mut dropdown_pages: Vec<String> = dropdown
+        .captures_iter(&base)
+        .map(|c| c[1].to_string())
+        .collect();
+    dropdown_pages.sort();
+    dropdown_pages.dedup();
+    assert_eq!(
+        dropdown_pages, pages,
+        "header dropdown (base.html role=menuitem docs links) does not match \
+         website/content/docs/*.md"
+    );
+
+    // Prev/next is weight-ordered; duplicate weights make the order arbitrary.
+    let weight = regex::Regex::new(r"(?m)^weight = (\d+)$").unwrap();
+    let mut weights: Vec<(u32, String)> = pages
+        .iter()
+        .map(|p| {
+            let text = std::fs::read_to_string(docs_dir.join(p)).expect("read page");
+            let w = weight
+                .captures(&text)
+                .unwrap_or_else(|| panic!("{p}: no `weight = N` in front matter"))[1]
+                .parse::<u32>()
+                .expect("weight parses");
+            (w, p.clone())
+        })
+        .collect();
+    weights.sort();
+    for pair in weights.windows(2) {
+        assert_ne!(
+            pair[0].0, pair[1].0,
+            "duplicate docs weight {}: {} and {} — prev/next order is arbitrary",
+            pair[0].0, pair[0].1, pair[1].1
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // CSP refresh --site-dir journey: pages.yml's post-deploy `csp` job runs
 // refresh_csp_hashes.py against the BUILT site (the pages artifact) instead
 // of fetching the live CDN, which can serve stale HTML for ~10 minutes after

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -164,7 +164,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2614 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2615 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -235,7 +235,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.5.18)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2614" data-suffix="">2614</span>
+        <span class="arch-stat" data-count="2615" data-suffix="">2615</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
The MCP walkthrough shipped invisible in the sidebar and header dropdown (#190 fixed it) because all three nav surfaces are hardcoded page lists — `page.html`, `section.html`, `base.html` — and nothing forces them to track `website/content/docs/`. Same failure class as the CSP stale-pin outage: a repo invariant with no gate.

New `site_journey_test` case pins it:
- every `website/content/docs/*.md` appears in both sidebar templates' `nav_group` lists, and the two templates agree;
- the header dropdown's `role=menuitem` docs links match the same set;
- no nav entry can point at a deleted page;
- docs page weights are unique, so prev/next order stays deterministic.

Proven red on the recreated bug (walkthrough removed from one sidebar list → "page.html and section.html sidebar nav_group lists differ"), green on current templates. Homepage count 2614 → 2615.