### PR TITLE
perf(tui): floor generation-driven displayed-list rebuilds at 300ms

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -421,14 +421,28 @@ impl App {
         };
         self.cached_dialog_count = store.len();
 
-        let fresh = self.displayed.key.as_ref().is_some_and(|k| {
-            k.generation == store.generation()
-                && k.filter_text == self.active_filter_text
+        let inputs_fresh = self.displayed.key.as_ref().is_some_and(|k| {
+            k.filter_text == self.active_filter_text
                 && k.query == self.search_query
                 && k.sort_column == self.call_list.sort_column()
                 && k.sort_ascending == self.call_list.sort_ascending()
         });
-        if !fresh {
+        let data_fresh = self
+            .displayed
+            .key
+            .as_ref()
+            .is_some_and(|k| k.generation == store.generation());
+        // Generation churn alone (busy capture) refreshes at most once per
+        // DISPLAYED_REBUILD_MIN — between refreshes the cached list serves
+        // the frame, so cursor movement never waits on a filter+sort pass.
+        // A changed user input (filter/search/sort) always rebuilds now.
+        let churn_floored = inputs_fresh
+            && self
+                .displayed
+                .last_rebuild
+                .is_some_and(|t| t.elapsed() < DISPLAYED_REBUILD_MIN);
+        let fresh = inputs_fresh && data_fresh;
+        if !fresh && !churn_floored {
             self.displayed.ids = call_list::displayed_dialogs(
                 &store,
                 self.active_filter.as_ref(),
@@ -446,6 +460,7 @@ impl App {
                 sort_column: self.call_list.sort_column(),
                 sort_ascending: self.call_list.sort_ascending(),
             });
+            self.displayed.last_rebuild = Some(Instant::now());
         }
         self.cached_displayed_count = self.displayed.ids.len();
 
@@ -1048,6 +1063,81 @@ mod tests {
         );
     }
 
+    /// A busy capture bumps the store generation on every ingest, so on a
+    /// loaded server EVERY tick — including the one right after each arrow
+    /// keypress — re-derived the displayed list (full filter-DSL pass +
+    /// sort + call-id clones over the whole store). Cursor movement paid
+    /// tens-to-hundreds of ms per keypress. Contract: data churn alone
+    /// refreshes the list at most once per DISPLAYED_REBUILD_MIN; between
+    /// refreshes the cached list serves the frame.
+    #[test]
+    fn busy_generation_churn_does_not_rederive_displayed_list_per_tick() {
+        use controllers::test_support::{base_ts, make_invite};
+        let mut app = App::with_processed_messages(vec![make_invite(
+            "busy-0@test",
+            "1001",
+            "1002",
+            base_ts(),
+        )]);
+        let calls = || call_list::DISPLAYED_DIALOGS_CALLS.with(|c| c.get());
+        app.sync_caches(); // initial derivation
+
+        let ds = app.dialog_store.clone();
+        let before = calls();
+        for i in 1..=5 {
+            ds.write().process_message(make_invite(
+                &format!("busy-{i}@test"),
+                "1001",
+                "1002",
+                base_ts(),
+            ));
+            app.sync_caches(); // the tick that follows a keypress
+        }
+        assert_eq!(
+            calls() - before,
+            0,
+            "generation churn within the rebuild floor must serve the \
+             cached list, not re-derive it every tick"
+        );
+
+        // Once the floor elapses the next tick picks up the churned data.
+        app.displayed.last_rebuild = app
+            .displayed
+            .last_rebuild
+            .map(|t| t - 2 * DISPLAYED_REBUILD_MIN);
+        let before = calls();
+        app.sync_caches();
+        assert_eq!(calls() - before, 1, "floor elapsed: refresh expected");
+        assert_eq!(
+            app.cached_displayed_count, 6,
+            "the refresh must pick up dialogs ingested while throttled"
+        );
+    }
+
+    /// Explicit user actions must never be throttled: changing the search
+    /// query (or filter/sort — same key) re-derives immediately even when
+    /// the churn floor has not elapsed.
+    #[test]
+    fn user_input_changes_bypass_the_displayed_rebuild_floor() {
+        use controllers::test_support::{base_ts, make_invite};
+        let mut app = App::with_processed_messages(vec![
+            make_invite("bypass-1@test", "1001", "1002", base_ts()),
+            make_invite("bypass-2@test", "2001", "2002", base_ts()),
+        ]);
+        let calls = || call_list::DISPLAYED_DIALOGS_CALLS.with(|c| c.get());
+        app.sync_caches(); // initial derivation — floor starts now
+
+        app.search_query = "1001".into();
+        let before = calls();
+        app.sync_caches();
+        assert_eq!(
+            calls() - before,
+            1,
+            "a changed user input must re-derive immediately, floor or not"
+        );
+        assert_eq!(app.cached_displayed_count, 1, "search narrowed the list");
+    }
+
     // ── Contended-store render ticks (busy-capture flicker) ────────
     //
     // ratatui resets the back buffer after every completed frame, so a
@@ -1287,11 +1377,16 @@ mod tests {
         app.sync_caches(); // selection on row 0 == last row; rows recorded
         assert_eq!(app.last_rendered_dialog_rows, 1);
 
-        // Two more dialogs arrive.
+        // Two more dialogs arrive; the churn floor elapses before the next
+        // tick (sticky-bottom follows at the refresh cadence, ≤300 ms).
         for cid in ["auto-2@test", "auto-3@test"] {
             let msg = make_invite(cid, "1005", "1006", base_ts());
             app.dialog_store.write().process_message(msg);
         }
+        app.displayed.last_rebuild = app
+            .displayed
+            .last_rebuild
+            .map(|t| t - 2 * DISPLAYED_REBUILD_MIN);
         app.sync_caches();
         assert_eq!(app.last_rendered_dialog_rows, 3);
         assert_eq!(

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1032,6 +1032,10 @@ pub(in crate::tui) struct DisplayedCache {
     pub(in crate::tui) key: Option<DisplayedKey>,
     /// Call-IDs in display order.
     pub(in crate::tui) ids: Vec<String>,
+    /// When the list was last derived; generation-driven rebuilds are
+    /// floored to [`DISPLAYED_REBUILD_MIN`] apart (`None` = never derived,
+    /// so the first derivation is immediate).
+    pub(in crate::tui) last_rebuild: Option<std::time::Instant>,
 }
 
 // ── Background work shared with the event loop ─────────────────────

--- a/src/tui/test_api.rs
+++ b/src/tui/test_api.rs
@@ -28,6 +28,17 @@ impl App {
         self.version = version.into();
     }
 
+    /// Elapse the displayed-list churn floor ([`DISPLAYED_REBUILD_MIN`])
+    /// so the next tick re-derives immediately — stands in for real time
+    /// passing between ticks on a busy capture.
+    #[doc(hidden)]
+    pub fn elapse_displayed_rebuild_floor_for_test(&mut self) {
+        self.displayed.last_rebuild = self
+            .displayed
+            .last_rebuild
+            .map(|t| t - 2 * DISPLAYED_REBUILD_MIN);
+    }
+
     /// Create an App whose dialog store already contains the given messages.
     ///
     /// Each slice of `SipMessage`s is processed in order so that the dialog

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -308,6 +308,14 @@ pub(super) const ACTIVE_POLL_MS: u64 = 100;
 pub(super) const IDLE_POLL_MS: u64 = 500;
 /// Duration after the last data update before switching to idle polling.
 pub(super) const IDLE_THRESHOLD: Duration = Duration::from_secs(2);
+/// Floor between generation-driven rebuilds of the displayed dialog list.
+/// On a busy capture the store generation bumps on every ingest, so each
+/// tick — including the one after every arrow keypress — re-derived the
+/// list (full filter-DSL + sort pass over the whole store) and cursor
+/// movement crawled. Data churn alone refreshes at most once per floor;
+/// user inputs (filter/search/sort) bypass it. 300 ms ≈ 3 refreshes/s,
+/// above what a human tracks in a monitoring list.
+pub(super) const DISPLAYED_REBUILD_MIN: Duration = Duration::from_millis(300);
 /// Consecutive render ticks allowed to skip on store-lock contention
 /// before the next tick takes blocking reads instead. Bounds staleness
 /// to ~FORCED_DRAW_AFTER_SKIPS × ACTIVE_POLL_MS on a write-saturated

--- a/tests/tui_state_test.rs
+++ b/tests/tui_state_test.rs
@@ -1399,6 +1399,9 @@ mod tui_state {
             "1004",
             t0 + TimeDelta::seconds(1),
         ));
+        // Sticky-bottom follows at the churn-floor cadence (≤300 ms), not
+        // per tick; elapse the floor as real time would between refreshes.
+        app.elapse_displayed_rebuild_floor_for_test();
         draw(&mut app, &mut term);
         assert_eq!(
             app.call_list_state().selected(),

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -164,7 +164,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2615 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2617 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -235,7 +235,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.5.18)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2615" data-suffix="">2615</span>
+        <span class="arch-stat" data-count="2617" data-suffix="">2617</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
## Problem

On a busy server, arrowing up/down in the call list (and worse, with a filter active) is visibly sluggish. Root cause: `sync_caches()` runs before every frame and its displayed-list cache is keyed on the dialog store's `generation` — which bumps on every ingest on a loaded box. So the tick after **every keypress** re-derived the whole list: filter-DSL evaluation against every dialog, an O(n log n) sort, and a per-row `call_id` String clone. At 50–100k dialogs that's tens-to-hundreds of ms per arrow key. Idle boxes never show it because the cache holds.

## Fix

Split the freshness check in two:
- **User inputs** (filter text, search query, sort column/direction) — any change rebuilds immediately, as today.
- **Generation churn alone** — rebuilds are floored to one per `DISPLAYED_REBUILD_MIN` (300 ms, ~3 refreshes/s). Between refreshes the cached list serves the frame, so cursor movement is O(1) regardless of load.

Sticky-bottom autoscroll now follows at the refresh cadence (≤300 ms lag) — the two tests that asserted immediate pickup elapse the floor via a new `#[doc(hidden)]` test-api helper, standing in for real time.

## Verification (TDD)

- **Red**: new churn test showed 5 re-derives for 5 data-only ticks pre-fix; **green**: 0 re-derives within the floor, and the post-floor refresh picks up dialogs ingested while throttled.
- Bypass test pins immediate re-derive on input changes.
- Full suite green (2,249 tests this run), clippy `-D warnings`, fmt.
- Live tmux verification: arrows walk the list, search narrows instantly (12 → 10 displayed).

Homepage count 2615 → 2617.