### PR TITLE
perf(tui): extend the churn-rebuild floor to every store-derived view

### DIFF
--- a/src/tui/controllers/file_open.rs
+++ b/src/tui/controllers/file_open.rs
@@ -541,6 +541,9 @@ pub(in crate::tui) fn poll_pcap_load(app: &mut App) {
         if let Some(outcome) = progress.result.lock().take() {
             app.status_error = Some(outcome.message.clone());
             apply_load_outcome(app, outcome);
+            // A completed load is a discrete event, not churn: every view
+            // must reflect the new stores on the next tick, floor or not.
+            app.clear_churn_floors();
         }
     } else {
         let packets = progress.packets.load(std::sync::atomic::Ordering::Relaxed);

--- a/src/tui/controllers/stream.rs
+++ b/src/tui/controllers/stream.rs
@@ -57,18 +57,10 @@ pub(in crate::tui) fn handle_stream_list_key(app: &mut App, key: KeyEvent) {
 
 /// Apply one [`StreamListAction`] to the application state.
 fn execute_stream_list_action(app: &mut App, action: StreamListAction) {
-    // Navigate over exactly the rows the table displays (search + filter).
-    let stream_count = {
-        let ss = app.stream_store.read();
-        let ds = app.dialog_store.try_read();
-        crate::tui::stream_list::displayed_streams(
-            ss.iter(),
-            ds.as_deref(),
-            app.active_filter.as_ref(),
-            &app.search_query,
-        )
-        .len()
-    };
+    // Navigate over exactly the rows the table displays (search + filter):
+    // the list is derived once per tick in sync_caches — a keypress must
+    // never re-filter the store (it used to, under a blocking read).
+    let stream_count = app.stream_displayed.keys.len();
 
     match action {
         StreamListAction::Quit => app.should_quit = true,
@@ -219,16 +211,12 @@ pub(in crate::tui) fn handle_stream_detail_play(app: &mut App) {
 
 /// Get the StreamKey for the currently selected row in the stream list.
 pub(in crate::tui) fn get_selected_stream_key(app: &App) -> Option<crate::rtp::stream::StreamKey> {
-    let store = app.stream_store.read();
-    let ds = app.dialog_store.try_read();
-    let streams = crate::tui::stream_list::displayed_streams(
-        store.iter(),
-        ds.as_deref(),
-        app.active_filter.as_ref(),
-        &app.search_query,
-    );
-    let idx = app.stream_list.selected();
-    streams.get(idx).map(|s| s.key.clone())
+    // The displayed order lives in the sync_caches-derived cache; resolving
+    // the selection is an index lookup, not a store re-filter.
+    app.stream_displayed
+        .keys
+        .get(app.stream_list.selected())
+        .cloned()
 }
 
 #[cfg(test)]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -143,6 +143,14 @@ pub struct App {
     displayed: DisplayedCache,
     /// Cached displayed dialog count (updated when lock is available).
     cached_displayed_count: usize,
+    /// Displayed stream list cache (search+filter, derived per tick).
+    stream_displayed: StreamDisplayedCache,
+    /// Statistics view aggregate-text cache.
+    stats: StatsCache,
+    /// Stream-store generation the dashboard snapshot was derived from.
+    dashboard_generation: Option<u64>,
+    /// Floors churn-driven dashboard snapshot rebuilds.
+    dashboard_floor: ChurnFloor,
     /// Save dialog popup state (path/format survive reopening).
     save: SaveDialogState,
     /// File-open dialog state (last-browsed directory survives reopening).
@@ -240,6 +248,10 @@ impl App {
             help_scroll: 0,
             stats_scroll: 0,
             dashboard_selected: 0,
+            stream_displayed: StreamDisplayedCache::default(),
+            stats: StatsCache::default(),
+            dashboard_generation: None,
+            dashboard_floor: ChurnFloor::default(),
             dashboard_return_view: None,
             dashboard_snapshot: None,
             last_rendered_dialog_rows: 0,
@@ -409,11 +421,19 @@ impl App {
         if matches!(self.current_view, View::QualityDashboard)
             && let Some(ss) = self.stream_store.try_read()
         {
-            let snap = dashboard::DashboardSnapshot::from_streams(&ss);
-            self.dashboard_selected = self
-                .dashboard_selected
-                .min(snap.rows.len().saturating_sub(1));
-            self.dashboard_snapshot = Some(snap);
+            let g = ss.generation();
+            // First snapshot immediately; churn refreshes at the floor.
+            let force = self.dashboard_snapshot.is_none();
+            let stale = self.dashboard_generation != Some(g);
+            if force || (stale && self.dashboard_floor.ready()) {
+                let snap = dashboard::DashboardSnapshot::from_streams(&ss);
+                self.dashboard_selected = self
+                    .dashboard_selected
+                    .min(snap.rows.len().saturating_sub(1));
+                self.dashboard_snapshot = Some(snap);
+                self.dashboard_generation = Some(g);
+                self.dashboard_floor.mark();
+            }
         }
 
         let Some(store) = self.dialog_store.try_read() else {
@@ -433,14 +453,10 @@ impl App {
             .as_ref()
             .is_some_and(|k| k.generation == store.generation());
         // Generation churn alone (busy capture) refreshes at most once per
-        // DISPLAYED_REBUILD_MIN — between refreshes the cached list serves
+        // CHURN_REBUILD_MIN — between refreshes the cached list serves
         // the frame, so cursor movement never waits on a filter+sort pass.
         // A changed user input (filter/search/sort) always rebuilds now.
-        let churn_floored = inputs_fresh
-            && self
-                .displayed
-                .last_rebuild
-                .is_some_and(|t| t.elapsed() < DISPLAYED_REBUILD_MIN);
+        let churn_floored = inputs_fresh && !self.displayed.floor.ready();
         let fresh = inputs_fresh && data_fresh;
         if !fresh && !churn_floored {
             self.displayed.ids = call_list::displayed_dialogs(
@@ -460,7 +476,7 @@ impl App {
                 sort_column: self.call_list.sort_column(),
                 sort_ascending: self.call_list.sort_ascending(),
             });
-            self.displayed.last_rebuild = Some(Instant::now());
+            self.displayed.floor.mark();
         }
         self.cached_displayed_count = self.displayed.ids.len();
 
@@ -482,6 +498,59 @@ impl App {
             self.last_rendered_dialog_rows = displayed_len;
         }
 
+        // Stream-list rows (search + filter): derived here at most once
+        // per churn floor. The render and every navigation clamp
+        // previously re-filtered the whole stream store — under a
+        // BLOCKING read — on each keypress.
+        if self.current_view == View::StreamList
+            && let Some(ss) = self.stream_store.try_read()
+        {
+            // The display filter matches through the associated dialog,
+            // so dialog churn reshapes the list only when a filter is on.
+            let dialog_generation = self.active_filter.as_ref().map(|_| store.generation());
+            let inputs_fresh = self.stream_displayed.key.as_ref().is_some_and(|k| {
+                k.filter_text == self.active_filter_text && k.query == self.search_query
+            });
+            let data_fresh = self.stream_displayed.key.as_ref().is_some_and(|k| {
+                k.stream_generation == ss.generation() && k.dialog_generation == dialog_generation
+            });
+            let churn_floored = inputs_fresh && !self.stream_displayed.floor.ready();
+            let fresh = inputs_fresh && data_fresh;
+            if !fresh && !churn_floored {
+                self.stream_displayed.keys = stream_list::displayed_streams(
+                    ss.iter(),
+                    Some(&store),
+                    self.active_filter.as_ref(),
+                    &self.search_query,
+                )
+                .iter()
+                .map(|s| s.key.clone())
+                .collect();
+                self.stream_displayed.key = Some(StreamDisplayedKey {
+                    stream_generation: ss.generation(),
+                    dialog_generation,
+                    filter_text: self.active_filter_text.clone(),
+                    query: self.search_query.clone(),
+                });
+                self.stream_displayed.floor.mark();
+            }
+        }
+
+        // Statistics text: a full-store aggregation, previously recomputed
+        // on every frame while the view was open.
+        if self.current_view == View::Statistics
+            && let Some(ss) = self.stream_store.try_read()
+        {
+            let key = (store.generation(), ss.generation());
+            let force = self.stats.key.is_none();
+            let stale = self.stats.key != Some(key);
+            if force || (stale && self.stats.floor.ready()) {
+                self.stats.text = render::statistics_text(&store, &ss);
+                self.stats.key = Some(key);
+                self.stats.floor.mark();
+            }
+        }
+
         // CallFlow ladder cache (WS4.3c): the theme-free layout half is
         // derived at most once here, keyed on everything that shapes it
         // ([`LadderKey`]); the render pass only re-styles the cached rows.
@@ -495,8 +564,22 @@ impl App {
             if self.flow.show_rtp && !self.flow.extended {
                 if let Some(ss) = self.stream_store.try_read() {
                     let g = ss.generation();
-                    let seg_key = (cid.clone(), g);
-                    if self.flow.ladder.segs_key.as_ref() != Some(&seg_key) {
+                    let same_cid = self
+                        .flow
+                        .ladder
+                        .segs_key
+                        .as_ref()
+                        .is_some_and(|(c, _)| c == &cid);
+                    let same = self
+                        .flow
+                        .ladder
+                        .segs_key
+                        .as_ref()
+                        .is_some_and(|(c, gg)| c == &cid && *gg == g);
+                    // Same dialog + stream churn only: adopt the new
+                    // generation at the churn floor. A different dialog
+                    // (user navigation) refreshes immediately.
+                    if !same && (!same_cid || self.flow.ladder.churn.ready()) {
                         let mut segs: Vec<call_flow::RtpCodecSegment> = ss
                             .streams_for(&cid)
                             .filter_map(|s| {
@@ -509,9 +592,10 @@ impl App {
                             .collect();
                         segs.sort_by_key(|s| s.start);
                         self.flow.ladder.rtp_segs = segs;
-                        self.flow.ladder.segs_key = Some(seg_key);
+                        self.flow.ladder.segs_key = Some((cid.clone(), g));
+                        self.flow.ladder.churn.mark();
                     }
-                    stream_generation = Some(g);
+                    stream_generation = self.flow.ladder.segs_key.as_ref().map(|(_, g)| *g);
                 } else {
                     // Contended: reuse the segments (and their generation)
                     // the cache already holds so the ladder key still hits.
@@ -521,8 +605,24 @@ impl App {
 
             let source = if self.flow.extended || !self.flow.merged_calls.is_empty() {
                 // Extended legs / merged multi-selection can span the whole
-                // store, so any store change must re-derive.
-                LadderSource::ExtendedStore(store.generation())
+                // store, so store changes must re-derive — but a busy store
+                // bumps its generation every tick, which forced a full
+                // multi-leg relayout per tick. Adopt a new generation at
+                // most once per churn floor; between adoptions the held
+                // generation keeps the ladder key (and layout) stable.
+                let g_now = store.generation();
+                let held = match &self.flow.ladder.key {
+                    Some(k) if k.call_id == cid => match &k.source {
+                        LadderSource::ExtendedStore(g) => Some(*g),
+                        LadderSource::Dialog(..) => None,
+                    },
+                    _ => None,
+                };
+                let g = match held {
+                    Some(h) if h != g_now && !self.flow.ladder.churn.ready() => h,
+                    _ => g_now,
+                };
+                LadderSource::ExtendedStore(g)
             } else {
                 match store.get(&cid) {
                     Some(d) => LadderSource::Dialog(d.messages.len(), d.updated_at),
@@ -683,6 +783,7 @@ impl App {
                 self.flow.ladder.participants = participants;
                 self.flow.ladder.rows = rows;
                 self.flow.ladder.key = Some(key);
+                self.flow.ladder.churn.mark();
             }
         }
     }
@@ -750,6 +851,17 @@ impl App {
             .collect();
         segs.sort_by_key(|s| s.start);
         segs
+    }
+
+    /// Reset every UI-cache churn floor: called on discrete completion
+    /// events (background pcap load landing) so the next tick re-derives
+    /// everything immediately instead of up to a floor later.
+    pub(in crate::tui) fn clear_churn_floors(&mut self) {
+        self.displayed.floor.clear();
+        self.stream_displayed.floor.clear();
+        self.stats.floor.clear();
+        self.dashboard_floor.clear();
+        self.flow.ladder.churn.clear();
     }
 
     /// Compute the poll timeout based on how recently data was updated.
@@ -1101,10 +1213,7 @@ mod tests {
         );
 
         // Once the floor elapses the next tick picks up the churned data.
-        app.displayed.last_rebuild = app
-            .displayed
-            .last_rebuild
-            .map(|t| t - 2 * DISPLAYED_REBUILD_MIN);
+        app.elapse_churn_floors_for_test();
         let before = calls();
         app.sync_caches();
         assert_eq!(calls() - before, 1, "floor elapsed: refresh expected");
@@ -1136,6 +1245,284 @@ mod tests {
             "a changed user input must re-derive immediately, floor or not"
         );
         assert_eq!(app.cached_displayed_count, 1, "search narrowed the list");
+    }
+
+    /// Insert one synthetic RTP stream (unique SSRC/ports per `i`).
+    fn push_rtp_stream(ss: &mut crate::rtp::stream_store::StreamStore, i: u16) {
+        let ts = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let parsed = crate::capture::ParsedPacket {
+            timestamp: ts,
+            src_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
+            dst_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 2)),
+            src_port: 20000 + i * 2,
+            dst_port: 30000 + i * 2,
+            transport: crate::capture::parse::TransportProto::Udp,
+            payload: vec![0u8; 172].into(),
+            ip_id: None,
+            tcp_seq: None,
+            tcp_flags: None,
+            fragment_offset: None,
+            more_fragments: false,
+            ip_protocol: 17,
+        };
+        let rtp = crate::rtp::parser::RtpHeader {
+            version: 2,
+            padding: false,
+            extension: false,
+            csrc_count: 0,
+            marker: false,
+            payload_type: 0,
+            sequence: 1,
+            timestamp: 0,
+            ssrc: 0xBBBB_0000 + u32::from(i),
+            payload_offset: 12,
+        };
+        ss.process_rtp(&parsed, &rtp, ts);
+    }
+
+    /// Stream list, same contract as the call list: stream-store churn
+    /// alone must not re-filter the store per tick, keypresses must
+    /// navigate the cached rows (they used to re-filter under a BLOCKING
+    /// read per keypress), and a user input change bypasses the floor.
+    #[test]
+    fn stream_list_churn_and_keypresses_do_not_rederive_displayed() {
+        use crossterm::event::KeyCode;
+        let mut app = App::new_test();
+        {
+            let ss = app.stream_store.clone();
+            let mut ss = ss.write();
+            push_rtp_stream(&mut ss, 0);
+            push_rtp_stream(&mut ss, 1);
+            push_rtp_stream(&mut ss, 2);
+        }
+        app.current_view = View::StreamList;
+        let calls = || stream_list::DISPLAYED_STREAMS_CALLS.with(|c| c.get());
+        app.sync_caches(); // initial derivation
+        assert_eq!(app.stream_displayed.keys.len(), 3);
+
+        let before = calls();
+        for i in 3..6 {
+            app.stream_store.clone().write().process_rtp(
+                &crate::capture::ParsedPacket {
+                    timestamp: chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+                    src_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
+                    dst_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 2)),
+                    src_port: 20000 + i * 2,
+                    dst_port: 30000 + i * 2,
+                    transport: crate::capture::parse::TransportProto::Udp,
+                    payload: vec![0u8; 172].into(),
+                    ip_id: None,
+                    tcp_seq: None,
+                    tcp_flags: None,
+                    fragment_offset: None,
+                    more_fragments: false,
+                    ip_protocol: 17,
+                },
+                &crate::rtp::parser::RtpHeader {
+                    version: 2,
+                    padding: false,
+                    extension: false,
+                    csrc_count: 0,
+                    marker: false,
+                    payload_type: 0,
+                    sequence: 1,
+                    timestamp: 0,
+                    ssrc: 0xBBBB_0000 + u32::from(i),
+                    payload_offset: 12,
+                },
+                chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            );
+            app.handle_key(KeyCode::Down); // navigates + settles a tick
+            app.sync_caches();
+        }
+        assert_eq!(
+            calls() - before,
+            0,
+            "stream churn within the floor (and keypresses) must not \
+             re-filter the store"
+        );
+        assert_eq!(
+            app.stream_list.selected(),
+            2,
+            "keypresses must navigate the cached rows"
+        );
+
+        // Floor elapses: next tick picks up the churned streams.
+        app.elapse_churn_floors_for_test();
+        let before = calls();
+        app.sync_caches();
+        assert_eq!(calls() - before, 1, "floor elapsed: refresh expected");
+        assert_eq!(app.stream_displayed.keys.len(), 6);
+
+        // A user input (search) bypasses the floor immediately.
+        {
+            let ss = app.stream_store.clone();
+            let mut ss = ss.write();
+            push_rtp_stream(&mut ss, 7);
+        }
+        app.search_query = "bbbb0000".into();
+        let before = calls();
+        app.sync_caches();
+        assert_eq!(calls() - before, 1, "changed search must re-derive now");
+        assert_eq!(
+            app.stream_displayed.keys.len(),
+            1,
+            "search narrowed to SSRC BBBB0000"
+        );
+    }
+
+    /// Selection resolution (Enter → stream detail, naming) must resolve
+    /// from the cached display order, lock-free — index into the cache.
+    #[test]
+    fn stream_selection_resolves_from_cached_order() {
+        let mut app = App::new_test();
+        {
+            let ss = app.stream_store.clone();
+            let mut ss = ss.write();
+            push_rtp_stream(&mut ss, 0);
+            push_rtp_stream(&mut ss, 1);
+        }
+        app.current_view = View::StreamList;
+        app.sync_caches();
+        app.stream_list.move_down(app.stream_displayed.keys.len());
+        let key = controllers::get_selected_stream_key(&app).expect("selected stream");
+        assert_eq!(key, app.stream_displayed.keys[1]);
+        // Selection past the cached end (evicted rows): no panic, None.
+        app.stream_list.move_to_bottom(100);
+        assert_eq!(controllers::get_selected_stream_key(&app), None);
+    }
+
+    /// Quality dashboard: stream churn refreshes the snapshot at the
+    /// floor, never per tick; the first snapshot after opening the view
+    /// is immediate.
+    #[test]
+    fn dashboard_snapshot_churn_is_floored() {
+        let mut app = App::new_test();
+        {
+            let ss = app.stream_store.clone();
+            let mut ss = ss.write();
+            push_rtp_stream(&mut ss, 0);
+        }
+        app.current_view = View::QualityDashboard;
+        app.sync_caches(); // first snapshot: immediate
+        let rows = app
+            .dashboard_snapshot
+            .as_ref()
+            .expect("snapshot")
+            .rows
+            .len();
+        assert_eq!(rows, 1);
+
+        {
+            let ss = app.stream_store.clone();
+            let mut ss = ss.write();
+            push_rtp_stream(&mut ss, 1);
+        }
+        app.sync_caches();
+        assert_eq!(
+            app.dashboard_snapshot.as_ref().unwrap().rows.len(),
+            1,
+            "churn within the floor must keep serving the cached snapshot"
+        );
+
+        app.elapse_churn_floors_for_test();
+        app.sync_caches();
+        assert_eq!(
+            app.dashboard_snapshot.as_ref().unwrap().rows.len(),
+            2,
+            "floor elapsed: snapshot must pick up the new stream"
+        );
+    }
+
+    /// Statistics view: the aggregate text is derived at the floor, not
+    /// per tick (it walks every dialog).
+    #[test]
+    fn statistics_text_churn_is_floored() {
+        use controllers::test_support::{base_ts, make_invite};
+        let mut app = App::with_processed_messages(vec![make_invite(
+            "stats-1@test",
+            "1001",
+            "1002",
+            base_ts(),
+        )]);
+        app.current_view = View::Statistics;
+        app.sync_caches();
+        assert!(
+            app.stats.text.contains("Dialogs:           1"),
+            "first derivation is immediate: {}",
+            app.stats.text
+        );
+
+        app.dialog_store
+            .clone()
+            .write()
+            .process_message(make_invite("stats-2@test", "1003", "1004", base_ts()));
+        app.sync_caches();
+        assert!(
+            app.stats.text.contains("Dialogs:           1"),
+            "churn within the floor must keep the cached text"
+        );
+
+        app.elapse_churn_floors_for_test();
+        app.sync_caches();
+        assert!(
+            app.stats.text.contains("Dialogs:           2"),
+            "floor elapsed: text must pick up the new dialog: {}",
+            app.stats.text
+        );
+    }
+
+    /// Extended/merged call-flow: a busy store must not force a full
+    /// multi-leg relayout every tick — the ladder key holds the adopted
+    /// store generation until the churn floor elapses.
+    #[test]
+    fn extended_ladder_holds_store_generation_under_churn() {
+        use controllers::test_support::{base_ts, make_invite};
+        let mut app = App::with_processed_messages(vec![make_invite(
+            "ext-1@test",
+            "1001",
+            "1002",
+            base_ts(),
+        )]);
+        app.current_view = View::CallFlow("ext-1@test".to_string());
+        app.flow.extended = true;
+        app.sync_caches();
+        let g0 = match &app.flow.ladder.key {
+            Some(LadderKey {
+                source: LadderSource::ExtendedStore(g),
+                ..
+            }) => *g,
+            other => panic!("expected extended ladder key, got {other:?}"),
+        };
+
+        app.dialog_store
+            .clone()
+            .write()
+            .process_message(make_invite("ext-2@test", "1003", "1004", base_ts()));
+        app.sync_caches();
+        match &app.flow.ladder.key {
+            Some(LadderKey {
+                source: LadderSource::ExtendedStore(g),
+                ..
+            }) => assert_eq!(
+                *g, g0,
+                "store churn within the floor must hold the adopted generation"
+            ),
+            other => panic!("expected extended ladder key, got {other:?}"),
+        }
+
+        app.elapse_churn_floors_for_test();
+        app.sync_caches();
+        match &app.flow.ladder.key {
+            Some(LadderKey {
+                source: LadderSource::ExtendedStore(g),
+                ..
+            }) => assert!(
+                *g > g0,
+                "floor elapsed: the new store generation must be adopted"
+            ),
+            other => panic!("expected extended ladder key, got {other:?}"),
+        }
     }
 
     // ── Contended-store render ticks (busy-capture flicker) ────────
@@ -1383,10 +1770,7 @@ mod tests {
             let msg = make_invite(cid, "1005", "1006", base_ts());
             app.dialog_store.write().process_message(msg);
         }
-        app.displayed.last_rebuild = app
-            .displayed
-            .last_rebuild
-            .map(|t| t - 2 * DISPLAYED_REBUILD_MIN);
+        app.elapse_churn_floors_for_test();
         app.sync_caches();
         assert_eq!(app.last_rendered_dialog_rows, 3);
         assert_eq!(

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -114,19 +114,16 @@ pub(in crate::tui) fn render_app(
         }
         View::StreamList => {
             let store = ss;
-            let dialog_store = Some(ds);
             stream_list::render_stream_list(
                 frame,
                 main_area,
                 &mut app.stream_list,
                 store,
-                dialog_store,
                 &stream_list::StreamListDisplay {
-                    filter: app.active_filter.as_ref(),
-                    search_query: &app.search_query,
                     theme: &app.theme,
                     resolver: app.resolver.as_ref(),
                     name_mode: app.name_mode,
+                    displayed: &app.stream_displayed.keys,
                 },
             );
         }
@@ -623,13 +620,10 @@ pub(in crate::tui) fn render_dashboard(
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
-pub(in crate::tui) fn render_statistics(
-    frame: &mut ratatui::Frame,
-    area: ratatui::layout::Rect,
-    app: &App,
-    ds: &DialogStore,
-    ss: &StreamStore,
-) -> u16 {
+/// Compose the statistics view's aggregate text — a full pass over every
+/// dialog, so it is derived in `App::sync_caches` (churn-floored) and
+/// cached, never recomputed per frame.
+pub(in crate::tui) fn statistics_text(ds: &DialogStore, ss: &StreamStore) -> String {
     use crate::sip::dialog::DialogState;
     use std::collections::HashMap;
 
@@ -695,6 +689,25 @@ pub(in crate::tui) fn render_statistics(
     }
 
     text.push_str("\nPress Esc to return.");
+    text
+}
+
+pub(in crate::tui) fn render_statistics(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    app: &App,
+    ds: &DialogStore,
+    ss: &StreamStore,
+) -> u16 {
+    // Serve the sync_caches-derived text; fall back to a direct pass only
+    // when no cache exists yet (first frame lost the sync try_read race).
+    let fallback;
+    let text: &str = if app.stats.text.is_empty() {
+        fallback = statistics_text(ds, ss);
+        &fallback
+    } else {
+        &app.stats.text
+    };
 
     // Clamp the scroll to the content height (End jumps to the last page).
     let total_rows = text.lines().count() as u16;

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -598,6 +598,10 @@ pub(in crate::tui) struct LadderCache {
     /// dialogs); empty for single-dialog ladders, where the position IS
     /// the index into the anchor dialog.
     pub(in crate::tui) index_map: Vec<(String, usize)>,
+    /// Floors churn-driven relayouts: store/stream generation advances
+    /// are adopted at most once per floor while every other key change
+    /// (user input, dialog's own messages) still relays out immediately.
+    pub(in crate::tui) churn: ChurnFloor,
 }
 
 impl NameDialogState {
@@ -1032,10 +1036,71 @@ pub(in crate::tui) struct DisplayedCache {
     pub(in crate::tui) key: Option<DisplayedKey>,
     /// Call-IDs in display order.
     pub(in crate::tui) ids: Vec<String>,
-    /// When the list was last derived; generation-driven rebuilds are
-    /// floored to [`DISPLAYED_REBUILD_MIN`] apart (`None` = never derived,
-    /// so the first derivation is immediate).
-    pub(in crate::tui) last_rebuild: Option<std::time::Instant>,
+    /// Floors generation-driven rebuilds (user inputs bypass it).
+    pub(in crate::tui) floor: ChurnFloor,
+}
+
+/// Rate limiter for generation-driven cache rebuilds: `ready()` is true
+/// when at least [`CHURN_REBUILD_MIN`] has passed since the last `mark()`
+/// (or nothing was ever marked, so first derivations are immediate).
+#[derive(Debug, Clone, Default)]
+pub(in crate::tui) struct ChurnFloor(Option<std::time::Instant>);
+
+impl ChurnFloor {
+    pub(in crate::tui) fn ready(&self) -> bool {
+        self.0.is_none_or(|t| t.elapsed() >= CHURN_REBUILD_MIN)
+    }
+
+    pub(in crate::tui) fn mark(&mut self) {
+        self.0 = Some(std::time::Instant::now());
+    }
+
+    /// Reset the floor so the next `ready()` is immediately true. Used on
+    /// discrete completion events (a background pcap load landing) — the
+    /// UI must reflect those on the very next tick, not a floor later.
+    pub(in crate::tui) fn clear(&mut self) {
+        self.0 = None;
+    }
+
+    /// Backdate the floor so the next `ready()` is true — stands in for
+    /// real time passing between ticks (test helper).
+    pub(in crate::tui) fn elapse_for_test(&mut self) {
+        self.0 = self.0.map(|t| t - 2 * CHURN_REBUILD_MIN);
+    }
+}
+
+/// Everything that shaped the cached stream-list rows.
+#[derive(Debug, PartialEq)]
+pub(in crate::tui) struct StreamDisplayedKey {
+    pub(in crate::tui) stream_generation: u64,
+    /// Dialog-store generation — the display filter matches through the
+    /// associated dialog, so dialog changes reshape the list too. `None`
+    /// when no filter was active (dialogs then don't participate).
+    pub(in crate::tui) dialog_generation: Option<u64>,
+    pub(in crate::tui) filter_text: String,
+    pub(in crate::tui) query: String,
+}
+
+/// Cross-tick cache of the displayed stream list (search + filter):
+/// derived in `App::sync_caches`, consumed by the stream-list render and
+/// the navigation clamps — which previously re-filtered the whole store
+/// under a blocking read lock on every keypress.
+#[derive(Debug, Default)]
+pub(in crate::tui) struct StreamDisplayedCache {
+    pub(in crate::tui) key: Option<StreamDisplayedKey>,
+    /// Stream keys in display order.
+    pub(in crate::tui) keys: Vec<crate::rtp::stream::StreamKey>,
+    pub(in crate::tui) floor: ChurnFloor,
+}
+
+/// Cross-tick cache of the statistics view's aggregate text, previously
+/// recomputed from every dialog on every frame.
+#[derive(Debug, Default)]
+pub(in crate::tui) struct StatsCache {
+    /// (dialog generation, stream generation) the text was derived from.
+    pub(in crate::tui) key: Option<(u64, u64)>,
+    pub(in crate::tui) text: String,
+    pub(in crate::tui) floor: ChurnFloor,
 }
 
 // ── Background work shared with the event loop ─────────────────────

--- a/src/tui/stream_list.rs
+++ b/src/tui/stream_list.rs
@@ -141,11 +141,20 @@ impl Default for StreamListState {
 /// Display parameters for the stream list view (mirrors
 /// [`crate::tui::call_list::CallListDisplay`]).
 pub struct StreamListDisplay<'a> {
-    pub filter: Option<&'a FilterExpr>,
-    pub search_query: &'a str,
     pub theme: &'a super::Theme,
     pub resolver: &'a crate::names::NameResolver,
     pub name_mode: crate::names::NameMode,
+    /// Stream keys in display order, derived once per tick by
+    /// `App::sync_caches` — the render must not re-filter the store.
+    pub displayed: &'a [crate::rtp::stream::StreamKey],
+}
+
+// Same "derived once per tick" property as the call list (thread-local so
+// the parallel test runner cannot cross-talk).
+#[cfg(test)]
+thread_local! {
+    pub(crate) static DISPLAYED_STREAMS_CALLS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
 }
 
 /// Render the RTP stream list table into the given area.
@@ -202,6 +211,8 @@ pub fn displayed_streams<'a>(
     filter: Option<&FilterExpr>,
     search_query: &str,
 ) -> Vec<&'a RtpStream> {
+    #[cfg(test)]
+    DISPLAYED_STREAMS_CALLS.with(|c| c.set(c.get() + 1));
     let q = search_query.to_ascii_lowercase();
     streams
         .into_iter()
@@ -228,15 +239,13 @@ pub fn render_stream_list(
     area: Rect,
     state: &mut StreamListState,
     store: &StreamStore,
-    dialog_store: Option<&DialogStore>,
     display: &StreamListDisplay,
 ) {
     let StreamListDisplay {
-        filter,
-        search_query,
         theme,
         resolver,
         name_mode,
+        displayed,
     } = *display;
     // The entire area is used for the table (no title line)
     let table_area = area;
@@ -261,9 +270,9 @@ pub fn render_stream_list(
     .style(header_style)
     .bottom_margin(0);
 
-    // Same displayed list the navigation and selection resolution use.
-    let streams = displayed_streams(store.iter(), dialog_store, filter, search_query);
-    let total_streams = streams.len();
+    // Same displayed list the navigation and selection resolution use,
+    // derived once per tick in sync_caches — resolve keys, don't re-filter.
+    let total_streams = displayed.len();
 
     // Viewport windowing: only format visible rows to avoid O(N) formatting
     // at 50K streams. Compute scroll offset from table state.
@@ -279,7 +288,11 @@ pub fn render_stream_list(
     }
     .min(total_streams.saturating_sub(1));
     let visible_end = (scroll_offset + visible_height).min(total_streams);
-    let visible_streams = &streams[scroll_offset..visible_end];
+    // Resolve only the visible window's keys (evicted keys drop out).
+    let visible_streams: Vec<&RtpStream> = displayed[scroll_offset..visible_end]
+        .iter()
+        .filter_map(|k| store.get(k))
+        .collect();
 
     // Build placeholder rows for items above the viewport (needed for
     // ratatui's StatefulWidget to keep selection index correct)

--- a/src/tui/test_api.rs
+++ b/src/tui/test_api.rs
@@ -28,15 +28,16 @@ impl App {
         self.version = version.into();
     }
 
-    /// Elapse the displayed-list churn floor ([`DISPLAYED_REBUILD_MIN`])
-    /// so the next tick re-derives immediately — stands in for real time
-    /// passing between ticks on a busy capture.
+    /// Elapse every UI-cache churn floor ([`CHURN_REBUILD_MIN`]) so the
+    /// next tick re-derives immediately — stands in for real time passing
+    /// between ticks on a busy capture.
     #[doc(hidden)]
-    pub fn elapse_displayed_rebuild_floor_for_test(&mut self) {
-        self.displayed.last_rebuild = self
-            .displayed
-            .last_rebuild
-            .map(|t| t - 2 * DISPLAYED_REBUILD_MIN);
+    pub fn elapse_churn_floors_for_test(&mut self) {
+        self.displayed.floor.elapse_for_test();
+        self.stream_displayed.floor.elapse_for_test();
+        self.stats.floor.elapse_for_test();
+        self.dashboard_floor.elapse_for_test();
+        self.flow.ladder.churn.elapse_for_test();
     }
 
     /// Create an App whose dialog store already contains the given messages.
@@ -59,6 +60,9 @@ impl App {
     /// real event loop ticks between key events, so tests keep synchronous
     /// load/save semantics.
     pub fn handle_key(&mut self, code: KeyCode) {
+        // The real event loop ticks (sync_caches + render) between key
+        // events; sync first so keys act on current caches, as in prod.
+        self.sync_caches();
         let key = KeyEvent::new(code, KeyModifiers::NONE);
         handle_key_event(self, key);
         self.settle_background_work();
@@ -134,6 +138,7 @@ impl App {
     /// Simulate a keypress with modifiers (settles background work like
     /// [`Self::handle_key`]).
     pub fn handle_key_with_modifiers(&mut self, code: KeyCode, modifiers: KeyModifiers) {
+        self.sync_caches();
         let key = KeyEvent::new(code, modifiers);
         handle_key_event(self, key);
         self.settle_background_work();

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -308,14 +308,17 @@ pub(super) const ACTIVE_POLL_MS: u64 = 100;
 pub(super) const IDLE_POLL_MS: u64 = 500;
 /// Duration after the last data update before switching to idle polling.
 pub(super) const IDLE_THRESHOLD: Duration = Duration::from_secs(2);
-/// Floor between generation-driven rebuilds of the displayed dialog list.
-/// On a busy capture the store generation bumps on every ingest, so each
-/// tick — including the one after every arrow keypress — re-derived the
-/// list (full filter-DSL + sort pass over the whole store) and cursor
-/// movement crawled. Data churn alone refreshes at most once per floor;
-/// user inputs (filter/search/sort) bypass it. 300 ms ≈ 3 refreshes/s,
-/// above what a human tracks in a monitoring list.
-pub(super) const DISPLAYED_REBUILD_MIN: Duration = Duration::from_millis(300);
+/// Floor between generation-driven rebuilds of the per-view UI caches
+/// (call-list displayed rows, stream-list displayed rows, statistics
+/// text, dashboard snapshot, call-flow ladder generations). On a busy
+/// capture the store generations bump on every ingest, so each tick —
+/// including the one after every arrow keypress — re-derived these from
+/// scratch (filter-DSL passes, sorts, full-store aggregation) and the UI
+/// crawled. Data churn alone refreshes each cache at most once per
+/// floor; user inputs (filter/search/sort/view changes) bypass it.
+/// 300 ms ≈ 3 refreshes/s, above what a human tracks in a monitoring
+/// view.
+pub(super) const CHURN_REBUILD_MIN: Duration = Duration::from_millis(300);
 /// Consecutive render ticks allowed to skip on store-lock contention
 /// before the next tick takes blocking reads instead. Bounds staleness
 /// to ~FORCED_DRAW_AFTER_SKIPS × ACTIVE_POLL_MS on a write-saturated

--- a/tests/tui_state_test.rs
+++ b/tests/tui_state_test.rs
@@ -1401,7 +1401,7 @@ mod tui_state {
         ));
         // Sticky-bottom follows at the churn-floor cadence (≤300 ms), not
         // per tick; elapse the floor as real time would between refreshes.
-        app.elapse_displayed_rebuild_floor_for_test();
+        app.elapse_churn_floors_for_test();
         draw(&mut app, &mut term);
         assert_eq!(
             app.call_list_state().selected(),

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -164,7 +164,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td>REST API + Prometheus</td><td>Query dialogs, streams, stats via HTTP. Prometheus metrics endpoint.</td></tr>
           <tr><td>MCP server</td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. Eleven read-only tools cover dialogs, RTP, diagnostics, and security findings.</td></tr>
           <tr><td>Browser analysis</td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2617 automated tests. 5 MB static binary.</td></tr>
+          <tr><td>Built in Rust</td><td>Memory-safe by construction. 2622 automated tests. 5 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -235,7 +235,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label"><a href="{{ get_url(path='@/docs/benchmarks.md') }}">Offline reconstruction, multi-core (measured v0.5.18)</a></span>
       </div>
       <div class="arch-item fade-in-up">
-        <span class="arch-stat" data-count="2617" data-suffix="">2617</span>
+        <span class="arch-stat" data-count="2622" data-suffix="">2622</span>
         <span class="arch-label"><a href="{{ config.extra.github_url }}/actions/workflows/ci.yml">Automated tests</a></span>
       </div>
     </div>


### PR DESCRIPTION
Completes what #194 started for the call list: **every** per-tick, store-churn-driven derivation in the TUI now refreshes at the 300 ms churn floor instead of on every tick/keypress, while user actions always refresh immediately.

## The cases

| View | Before | After |
|---|---|---|
| **Stream list** | Full store re-filter per frame **and per keypress** (navigation clamp + selection resolution each ran `displayed_streams` under a **blocking** read) | Rows derived once per tick into a keyed cache (stream+dialog generations, filter, query); render resolves only the visible window's keys; keypresses index the cache lock-free |
| **Quality dashboard** | Snapshot rebuilt unconditionally every tick while open | Keyed on stream generation + floored; first snapshot after opening immediate |
| **Statistics** | Full every-dialog aggregation per frame | Derived in sync_caches keyed on both generations, floored; direct-compute fallback if the first frame lost the sync race |
| **Call-flow ladder** | Raw store/stream generations in the ladder key forced full relayouts per tick (extended/merged flows, RTP codec segments) | Generations adopted at most once per floor; any user-input key change relays out immediately |

## Design

Shared `ChurnFloor` (300 ms) replaces #194's ad-hoc Instant. A completed background pcap load **clears** all floors — a discrete event must show on the next tick, not a floor later. The multileg demo drift tests caught exactly that gap during development (a `Dialogs: 12 (0 displayed)` screen for the floor window after load) — fixed, and those tests now double as regression cover. Test-api `handle_key` now syncs caches before each key, matching the real loop's tick-then-poll order.

## Verification

- **Red→green**: with `ChurnFloor::ready()` force-disabled, all five churn tests fail (one per view); enabled, the full suite is green (2,254 tests), clippy `-D warnings`, fmt.
- **Live tmux**: stream-list arrows navigate cached rows, Enter opens the exact selected stream's detail (cached-order resolution), dashboard renders with correct aggregates.
- Homepage count 2617 → 2622.