### PR TITLE
release 0.5.26: filtered-transaction counter fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to sipnab will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.26] - 2026-07-22
+
+### Fixed
+- TUI: on a call-flow page filtered to one transaction (`f`), the
+  detail-pane header counted position/total over the whole dialog, so a
+  short transaction late in a long dialog rendered a 3-row ladder titled
+  `[12/13]` — a counter that looked stuck and read as broken arrow keys
+  (the arrows worked). The header now counts within the filtered
+  transaction (`[1/3]`..`[3/3]`); unfiltered pages keep whole-dialog
+  counts.
+
 ## [0.5.25] - 2026-07-22
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.5.25"
+version = "0.5.26"
 dependencies = [
  "aes",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 
 [package]
 name = "sipnab"
-version = "0.5.25"
+version = "0.5.26"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Norm Brandinger"]

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ curl -fsSL https://www.sipnab.com/install.sh | sh
 ```
 
 Prefer to read it first: <https://www.sipnab.com/install.sh>. Pin a version
-with `SIPNAB_VERSION=0.5.25`, change the destination with `SIPNAB_INSTALL_DIR`.
+with `SIPNAB_VERSION=0.5.26`, change the destination with `SIPNAB_INSTALL_DIR`.
 
 ## Pre-built Binaries
 
@@ -27,7 +27,7 @@ you which one you are.
 
 ```bash
 # Linux x86_64 (static musl -- runs on any distro, any glibc, Alpine included)
-# Replace <version> with the latest, e.g. 0.5.25
+# Replace <version> with the latest, e.g. 0.5.26
 curl -LO https://github.com/NormB/sipnab/releases/download/v<version>/sipnab-<version>-x86_64-unknown-linux-musl.tar.gz
 tar xzf sipnab-<version>-x86_64-unknown-linux-musl.tar.gz
 sudo install -m 755 sipnab-<version>-x86_64-unknown-linux-musl/sipnab /usr/local/bin/sipnab
@@ -56,7 +56,7 @@ cargo install sipnab --features full
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install with `apt` (it resolves the `libpcap0.8` runtime dependency). The `.deb` needs glibc >= 2.39, i.e. Debian 13+ / Ubuntu 24.04+ -- on older releases use the static musl tarball above:
 
 ```bash
-# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.25
+# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.26
 curl -LO https://github.com/NormB/sipnab/releases/latest/download/sipnab_<version>_amd64.deb
 sudo apt install ./sipnab_<version>_amd64.deb
 
@@ -96,11 +96,11 @@ standard and a `-noaudio` variant (no audio plugin, no `alsa-lib` weak
 dependency — for headless servers, mirroring the `.deb` variants):
 
 ```bash
-sudo rpm -i sipnab-0.5.25-1.x86_64.rpm
+sudo rpm -i sipnab-0.5.26-1.x86_64.rpm
 # headless / no-ALSA variant:
-sudo rpm -i sipnab-0.5.25-1.x86_64-noaudio.rpm
+sudo rpm -i sipnab-0.5.26-1.x86_64-noaudio.rpm
 # arm64 hosts:
-sudo rpm -i sipnab-0.5.25-1.aarch64.rpm
+sudo rpm -i sipnab-0.5.26-1.aarch64.rpm
 ```
 
 ### Homebrew (macOS)
@@ -282,7 +282,7 @@ sipnab --help
 `--version` lists the Cargo features compiled into the binary, e.g.
 
 ```
-sipnab 0.5.25 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+sipnab 0.5.26 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 ```
 
 This is the fastest way to confirm a build was produced with the feature set

--- a/docs/mcp-walkthrough.md
+++ b/docs/mcp-walkthrough.md
@@ -62,7 +62,7 @@ itself):
 
    ```bash
    sipnab --version
-   # sipnab 0.5.25 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+   # sipnab 0.5.26 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http
    ```
 
    If `mcp` is missing you have a source build without features — rebuild

--- a/man/sipnab.1
+++ b/man/sipnab.1
@@ -1,7 +1,7 @@
 .\" sipnab.1 -- man page for sipnab
 .\" Copyright 2024-2026 Norm Brandinger
 .\" License: MIT OR Apache-2.0
-.TH SIPNAB 1 "2026-07-22" "sipnab 0.5.25" "User Commands"
+.TH SIPNAB 1 "2026-07-22" "sipnab 0.5.26" "User Commands"
 .SH NAME
 sipnab \- SIP & RTP capture, analysis, and security tool
 .SH SYNOPSIS

--- a/website/config.toml
+++ b/website/config.toml
@@ -26,7 +26,7 @@ theme = "ayu-dark"
 # overwrites this from Cargo.toml at build time (single source of truth), and a
 # pre-commit hook fails if the two drift — so the homepage version badge and the
 # download links always match the released crate. Update Cargo.toml, not this.
-version = "0.5.25"
+version = "0.5.26"
 # Release date of the current `version` above. Shown on /download next to the
 # version. Update alongside Cargo.toml/version when cutting a release.
 release_date = "2026-07-21"

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -754,7 +754,7 @@ Metric names emitted by `src/output/prometheus.rs`:
 | `sipnab_jitter_ms` | histogram | RTP jitter distribution (buckets at 5/10/20/50/100/200ms). |
 | `sipnab_loss_percent` | histogram | RTP packet-loss distribution (buckets at 0.1/0.5/1/2/5/10%). |
 
-The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.25 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
+The following metric *names* are declared in source (and will be formatted when the underlying maps have entries) but are not yet wired to the data plane as of 0.5.26 — they will appear empty in Prometheus until the upstream counters get populated: `sipnab_responses_total{code}`, `sipnab_security_alerts_total{type}`, `sipnab_diagnosis_total{kind}`, `sipnab_capture_packets_total`, `sipnab_reassembly_timeouts_total`. Track-via PR / dashboard authors: don't depend on these in alerts yet.
 
 ## Security Model
 

--- a/website/content/docs/benchmarks.md
+++ b/website/content/docs/benchmarks.md
@@ -13,8 +13,8 @@ capture/packet path below unchanged (its numbers carry over), but rewrote
 the `-N --json` export sink: buffered batch writes plus direct JSON
 serialization cut wall-clock time ~29% and `write()` syscalls 98.5% on that
 path (same-toolchain A/B on this branch, byte-identical output; not yet
-re-measured on a released artifact). The current release 0.5.25 (churn-rebuild floors across all TUI
-views — event-loop cache policy, not packet-path changes) changes neither path. The comparison
+re-measured on a released artifact). The current release 0.5.26 (filtered-transaction counter fix —
+a TUI display change, not a packet-path change) changes neither path. The comparison
 tools' numbers come from the 2026-06-24 session — same host, corpus, and
 method, and their versions are unchanged. Versus the 0.4.16 session, 0.5.18
 measures faster at every multi-core operating point (+9–16%) and across the

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -40,7 +40,7 @@ Every [GitHub release](https://github.com/NormB/sipnab/releases) ships versioned
 - `sipnab-<version>-aarch64-unknown-linux-musl.tar.gz` — same, for arm64
 - `sipnab-<version>-x86_64-apple-darwin.tar.gz` / `sipnab-<version>-aarch64-apple-darwin.tar.gz` — macOS
 
-Manual download with checksum verification (replace `<version>` with the latest, e.g. 0.5.25):
+Manual download with checksum verification (replace `<version>` with the latest, e.g. 0.5.26):
 
 ```bash
 V=<version> T=x86_64-unknown-linux-gnu
@@ -89,7 +89,7 @@ For build prerequisites, the full feature-flag matrix, release profile, and cros
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install it with `apt`, which resolves the `libpcap0.8` runtime dependency automatically:
 
 ```bash
-# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.25
+# amd64 (x86_64) -- replace <version> with the latest, e.g. 0.5.26
 curl -LO https://github.com/NormB/sipnab/releases/latest/download/sipnab_<version>_amd64.deb
 sudo apt install ./sipnab_<version>_amd64.deb
 
@@ -121,7 +121,7 @@ standard and a `-noaudio` variant (no audio plugin, no `alsa-lib` weak
 dependency — for headless servers, mirroring the `.deb` variants):
 
 ```bash
-sudo rpm -i sipnab-<version>-1.x86_64.rpm  # replace <version> with the latest, e.g. 0.5.25
+sudo rpm -i sipnab-<version>-1.x86_64.rpm  # replace <version> with the latest, e.g. 0.5.26
 # headless / no-ALSA variant:
 sudo rpm -i sipnab-<version>-1.x86_64-noaudio.rpm
 # arm64 hosts:
@@ -179,7 +179,7 @@ sipnab -D
 <span class="terminal-title">Verify Installation</span>
 </div>
 <pre class="terminal-body"><span class="t-muted">$</span> sipnab --version
-sipnab 0.5.25 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+sipnab 0.5.26 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http
 
 <span class="t-muted">$</span> sipnab -N -I demo.pcap | head -3
 <span class="t-accent">INVITE</span> alice -> bob  192.0.2.1:5060 -> 192.0.2.2:5060 <span class="t-good">InCall</span> PDD=847ms

--- a/website/content/docs/mcp-walkthrough.md
+++ b/website/content/docs/mcp-walkthrough.md
@@ -66,7 +66,7 @@ itself):
 
    ```bash
    sipnab --version
-   # sipnab 0.5.25 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http
+   # sipnab 0.5.26 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http
    ```
 
    If `mcp` is missing you have a source build without features — rebuild


### PR DESCRIPTION
Version bump to 0.5.26 — TUI display fix, no packet-path or runtime code changes.

Since 0.5.25:
- **fix(tui)** (#198) — on a call-flow page filtered to one transaction, the detail-pane header now counts within the filtered transaction (`[1/3]`..`[3/3]`) instead of over the whole dialog. The whole-dialog counter looked stuck on a filtered page and read as broken arrow keys (navigation always worked).

Standard bump set; pre-commit version-sync gates green.

After merge: tag `v0.5.26` to trigger the release build.