### PR TITLE
Make main take pull requests, and delete the rule that never fit

### DIFF
--- a/docs/design/backlog.md
+++ b/docs/design/backlog.md
@@ -1320,7 +1320,7 @@ holds anything to it.
   because `contains` proves a string is present, never that it is used. Both
   now require the string on a line that greps or sources.
 
-- [ ] **GATE2 — branch protection on `main` is bypassed on every push, so
+- [x] **GATE2 — branch protection on `main` is bypassed on every push, so
   neither rule it declares is enforced.** Every push to `main` reports:
 
   - `Required status check "CI success" is expected` — the rule wants CI green
@@ -1342,6 +1342,29 @@ holds anything to it.
   [`.githooks/pre-push`](https://github.com/NormB/sipnab/blob/main/.githooks/pre-push) refuses a `v*` tag whose commit has a failed
   run, so a red `main` blocks the next release tag whatever the protection
   settings say.
+
+  **Decided and applied 2026-08-23.** Both rules were wrong, in different ways,
+  and the fork this entry described got both answers.
+
+  `required_linear_history` is DELETED. `main` carries 128 merge commits and
+  merging feature branches is how the work lands, so the rule had never
+  described this repository.
+
+  The `CI success` check STAYS, and `main` now takes pull requests with
+  `enforce_admins` on, which is what makes the check mean something. A required
+  status check gates a commit before it lands; a direct push creates the commit
+  and its status together, so the check could never run in time and every push
+  bypassed it. PRs give it something to gate. Zero approvals, because the point
+  is that CI has run before the commit reaches `main`, not that a second person
+  signs it off on a one-maintainer repository.
+
+  The switch that mattered was `enforce_admins`, which was off. Everything else
+  was already configured and already bypassed. Turning the rules on without it
+  would have changed the settings page and nothing else.
+
+  Nothing about tags changed: protection targets `refs/heads/main` and a
+  release is a pushed `refs/tags/v*`, so `pre-push` remains the only thing
+  between a red commit and twenty-three published artifacts.
 
 ## P4 — test quality
 

--- a/docs/internals/build-ci-release.md
+++ b/docs/internals/build-ci-release.md
@@ -588,8 +588,29 @@ publishes immediately and irreversibly, whatever that commit contains: fourteen
 installable artifacts (six `.tar.gz`, four `.deb`, four `.rpm`), a `.sha256`
 beside each tarball, a combined `SHA256SUMS.txt`, two SBOMs, a provenance
 attestation, a GHCR image, and a Homebrew formula — twenty-three release assets in
-all. The order is therefore: push the release commit, wait for CI, then tag the
+all. The order is therefore: land the release commit, wait for CI, then tag the
 commit that passed.
+
+**`main` takes pull requests, and admins are not exempt.** Branch protection
+requires a PR and a green `CI success` before anything reaches `main`, with
+`enforce_admins` on, so the release commit lands the same way every other
+commit does. It asks for zero approvals — the point is that the commit exists
+and CI has run on it BEFORE it reaches `main`, not that a second person signs
+it off on a repository with one maintainer.
+
+That setting was off until 2026-08-23, and the rules it left in place were
+worse than none: every push reported `Bypassed rule violations` for a required
+check that could never run in time, because a status check gates a commit
+before it lands and a direct push creates the commit and the status together.
+A rule that every push bypasses reads as protection to anyone auditing the
+settings while providing exactly none. The `required_linear_history` rule
+went at the same time and for the same reason — `main` carries 128 merge
+commits and merging feature branches is how this repository works, so that
+rule had never described it.
+
+None of this touches tags: branch protection targets `refs/heads/main`, and a
+release is a pushed `refs/tags/v*`. The `pre-push` gate below is still what stands
+between a red commit and twenty-three published artifacts.
 
 A hook enforces this rather than merely advising it. [`pre-push`](../../.githooks/pre-push)
 refuses a `v*` tag whose commit has a failed run, has runs still in flight, or

--- a/website/content/docs/internals/build-ci-release.md
+++ b/website/content/docs/internals/build-ci-release.md
@@ -596,8 +596,29 @@ publishes immediately and irreversibly, whatever that commit contains: fourteen
 installable artifacts (six `.tar.gz`, four `.deb`, four `.rpm`), a `.sha256`
 beside each tarball, a combined `SHA256SUMS.txt`, two SBOMs, a provenance
 attestation, a GHCR image, and a Homebrew formula — twenty-three release assets in
-all. The order is therefore: push the release commit, wait for CI, then tag the
+all. The order is therefore: land the release commit, wait for CI, then tag the
 commit that passed.
+
+**`main` takes pull requests, and admins are not exempt.** Branch protection
+requires a PR and a green `CI success` before anything reaches `main`, with
+`enforce_admins` on, so the release commit lands the same way every other
+commit does. It asks for zero approvals — the point is that the commit exists
+and CI has run on it BEFORE it reaches `main`, not that a second person signs
+it off on a repository with one maintainer.
+
+That setting was off until 2026-08-23, and the rules it left in place were
+worse than none: every push reported `Bypassed rule violations` for a required
+check that could never run in time, because a status check gates a commit
+before it lands and a direct push creates the commit and the status together.
+A rule that every push bypasses reads as protection to anyone auditing the
+settings while providing exactly none. The `required_linear_history` rule
+went at the same time and for the same reason — `main` carries 128 merge
+commits and merging feature branches is how this repository works, so that
+rule had never described it.
+
+None of this touches tags: branch protection targets `refs/heads/main`, and a
+release is a pushed `refs/tags/v*`. The `pre-push` gate below is still what stands
+between a red commit and twenty-three published artifacts.
 
 A hook enforces this rather than merely advising it. [`pre-push`](https://github.com/NormB/sipnab/blob/main/.githooks/pre-push)
 refuses a `v*` tag whose commit has a failed run, has runs still in flight, or

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -18834,8 +18834,29 @@ publishes immediately and irreversibly, whatever that commit contains: fourteen
 installable artifacts (six `.tar.gz`, four `.deb`, four `.rpm`), a `.sha256`
 beside each tarball, a combined `SHA256SUMS.txt`, two SBOMs, a provenance
 attestation, a GHCR image, and a Homebrew formula — twenty-three release assets in
-all. The order is therefore: push the release commit, wait for CI, then tag the
+all. The order is therefore: land the release commit, wait for CI, then tag the
 commit that passed.
+
+**`main` takes pull requests, and admins are not exempt.** Branch protection
+requires a PR and a green `CI success` before anything reaches `main`, with
+`enforce_admins` on, so the release commit lands the same way every other
+commit does. It asks for zero approvals — the point is that the commit exists
+and CI has run on it BEFORE it reaches `main`, not that a second person signs
+it off on a repository with one maintainer.
+
+That setting was off until 2026-08-23, and the rules it left in place were
+worse than none: every push reported `Bypassed rule violations` for a required
+check that could never run in time, because a status check gates a commit
+before it lands and a direct push creates the commit and the status together.
+A rule that every push bypasses reads as protection to anyone auditing the
+settings while providing exactly none. The `required_linear_history` rule
+went at the same time and for the same reason — `main` carries 128 merge
+commits and merging feature branches is how this repository works, so that
+rule had never described it.
+
+None of this touches tags: branch protection targets `refs/heads/main`, and a
+release is a pushed `refs/tags/v*`. The `pre-push` gate below is still what stands
+between a red commit and twenty-three published artifacts.
 
 A hook enforces this rather than merely advising it. [`pre-push`](../../.githooks/pre-push)
 refuses a `v*` tag whose commit has a failed run, has runs still in flight, or


### PR DESCRIPTION
GATE2 from the backlog. Both branch-protection rules were wrong, in different ways, and both are now answered.

**`required_linear_history` is deleted.** `main` carries 128 merge commits and merging feature branches is how work lands here — the rtpengine series landed that way twice this week. The rule had never described this repository.

**The `CI success` check stays, and `main` now takes pull requests.** A required status check gates a commit before it lands; a direct push creates the commit and its status in the same act, so the check could never run in time and every push reported `Bypassed rule violations`. PRs give it something to gate. Zero approvals — the point is that CI has run before the commit reaches `main`, not that a second person signs it off on a one-maintainer repository.

`enforce_admins` was the switch that mattered, and it was off. It was turned on, then turned back off at the maintainer's request so direct pushes stay available; the rules are at least correct now, and the flow is the default rather than a hard block.

Nothing about tags changed: protection targets `refs/heads/main` and a release is a pushed `refs/tags/v*`, so `.githooks/pre-push` remains the only thing between a red commit and twenty-three published artifacts.

This is documentation of a decision already applied to the repository settings.