### PR TITLE
Keep the audio the operator asked for, and stop guessing why it is missing

### DIFF
--- a/docs/design/backlog.md
+++ b/docs/design/backlog.md
@@ -1320,7 +1320,7 @@ holds anything to it.
   because `contains` proves a string is present, never that it is used. Both
   now require the string on a line that greps or sources.
 
-- [ ] **GATE2 — branch protection on `main` is bypassed on every push, so
+- [x] **GATE2 — branch protection on `main` is bypassed on every push, so
   neither rule it declares is enforced.** Every push to `main` reports:
 
   - `Required status check "CI success" is expected` — the rule wants CI green
@@ -1342,6 +1342,29 @@ holds anything to it.
   [`.githooks/pre-push`](https://github.com/NormB/sipnab/blob/main/.githooks/pre-push) refuses a `v*` tag whose commit has a failed
   run, so a red `main` blocks the next release tag whatever the protection
   settings say.
+
+  **Decided and applied 2026-08-23.** Both rules were wrong, in different ways,
+  and the fork this entry described got both answers.
+
+  `required_linear_history` is DELETED. `main` carries 128 merge commits and
+  merging feature branches is how the work lands, so the rule had never
+  described this repository.
+
+  The `CI success` check STAYS, and `main` now takes pull requests with
+  `enforce_admins` on, which is what makes the check mean something. A required
+  status check gates a commit before it lands; a direct push creates the commit
+  and its status together, so the check could never run in time and every push
+  bypassed it. PRs give it something to gate. Zero approvals, because the point
+  is that CI has run before the commit reaches `main`, not that a second person
+  signs it off on a one-maintainer repository.
+
+  The switch that mattered was `enforce_admins`, which was off. Everything else
+  was already configured and already bypassed. Turning the rules on without it
+  would have changed the settings page and nothing else.
+
+  Nothing about tags changed: protection targets `refs/heads/main` and a
+  release is a pushed `refs/tags/v*`, so `pre-push` remains the only thing
+  between a red commit and twenty-three published artifacts.
 
 ## P4 — test quality
 

--- a/docs/internals/build-ci-release.md
+++ b/docs/internals/build-ci-release.md
@@ -588,8 +588,29 @@ publishes immediately and irreversibly, whatever that commit contains: fourteen
 installable artifacts (six `.tar.gz`, four `.deb`, four `.rpm`), a `.sha256`
 beside each tarball, a combined `SHA256SUMS.txt`, two SBOMs, a provenance
 attestation, a GHCR image, and a Homebrew formula — twenty-three release assets in
-all. The order is therefore: push the release commit, wait for CI, then tag the
+all. The order is therefore: land the release commit, wait for CI, then tag the
 commit that passed.
+
+**`main` takes pull requests, and admins are not exempt.** Branch protection
+requires a PR and a green `CI success` before anything reaches `main`, with
+`enforce_admins` on, so the release commit lands the same way every other
+commit does. It asks for zero approvals — the point is that the commit exists
+and CI has run on it BEFORE it reaches `main`, not that a second person signs
+it off on a repository with one maintainer.
+
+That setting was off until 2026-08-23, and the rules it left in place were
+worse than none: every push reported `Bypassed rule violations` for a required
+check that could never run in time, because a status check gates a commit
+before it lands and a direct push creates the commit and the status together.
+A rule that every push bypasses reads as protection to anyone auditing the
+settings while providing exactly none. The `required_linear_history` rule
+went at the same time and for the same reason — `main` carries 128 merge
+commits and merging feature branches is how this repository works, so that
+rule had never described it.
+
+None of this touches tags: branch protection targets `refs/heads/main`, and a
+release is a pushed `refs/tags/v*`. The `pre-push` gate below is still what stands
+between a red commit and twenty-three published artifacts.
 
 A hook enforces this rather than merely advising it. [`pre-push`](../../.githooks/pre-push)
 refuses a `v*` tag whose commit has a failed run, has runs still in flight, or

--- a/src/app/batch.rs
+++ b/src/app/batch.rs
@@ -642,6 +642,8 @@ fn parallel_config(
         quiet_bad_parse: cli.capture_args.quiet_bad_parse,
         xcid_headers: config.sip.xcid_headers.clone().unwrap_or_default(),
         leg_correlation_window_ms: cli.leg_correlation_window_ms(config),
+        retain_audio: audio_retention_wanted(cli),
+        max_audio_frames: config.limits.max_audio_frames.unwrap_or(1500) as usize,
         reassembly: !cli.capture_args.no_reassembly,
         parse_limit: cli.capture_args.limitlen,
     }

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -2575,7 +2575,7 @@ mod tests {
         // The fixture has to carry decodable audio, or both runs are empty and
         // the comparison below is vacuous.
         assert!(
-            kept.stream_store.len() > 0,
+            !kept.stream_store.is_empty(),
             "fixture produced no RTP streams"
         );
 

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -164,6 +164,20 @@ pub struct ParallelConfig {
     /// own store, and without it the parallel path would silently apply the
     /// shipped window the single-core path was told to replace.
     pub leg_correlation_window_ms: u64,
+    /// Keep RTP payload so `export_audio` can decode it later.
+    ///
+    /// The workers used to hard-disable this with the comment "batch mode
+    /// never reads audio buffers". That was true when it was written and
+    /// stopped being true when `--retain-audio` shipped: `--cores N` takes
+    /// this path, so an operator who asked for retention got a run that
+    /// silently kept nothing, and the export then told them retention was off.
+    /// It was -- but not because they had left it off.
+    pub retain_audio: bool,
+    /// Per-stream payload frame cap, applied per worker.
+    ///
+    /// The bound is PER WORKER, so the run's ceiling is this times `cores`
+    /// times `max_streams`. Stated rather than discovered under load.
+    pub max_audio_frames: usize,
     /// Reassemble IP fragments / TCP segments (`--no-reassembly` sets false).
     pub reassembly: bool,
     /// Cap on parsed bytes per packet (`-S`/`--limitlen`).
@@ -450,7 +464,13 @@ pub fn run_offline_parallel(rx: PacketRx, cfg: ParallelConfig) -> ReconResult {
                 .with_xcid_headers(cfg.xcid_headers.clone())
                 .with_leg_correlation_window_ms(cfg.leg_correlation_window_ms);
                 let mut ss = StreamStore::new(cfg.max_streams);
-                ss.set_audio_capture(false); // batch mode never reads audio buffers
+                // Honored rather than hard-disabled. `merge` inserts whole
+                // streams, so a worker's payload buffers survive into the
+                // merged store and `export_audio` can reach them.
+                ss.set_audio_capture(cfg.retain_audio);
+                if cfg.retain_audio {
+                    ss.set_max_audio_frames(cfg.max_audio_frames);
+                }
                 let mut heuristic = crate::rtp::heuristic::RtpHeuristic::new();
                 let (mut sip, mut rtp, mut total) = (0u64, 0u64, 0u64);
                 for mut packet in wrx.iter() {
@@ -1873,7 +1893,10 @@ pub fn run_offline_parallel_file(
                 .with_xcid_headers(cfg.xcid_headers.clone())
                 .with_leg_correlation_window_ms(cfg.leg_correlation_window_ms);
                 let mut ss = StreamStore::new(cfg.max_streams);
-                ss.set_audio_capture(false);
+                ss.set_audio_capture(cfg.retain_audio);
+                if cfg.retain_audio {
+                    ss.set_max_audio_frames(cfg.max_audio_frames);
+                }
                 let mut heuristic = crate::rtp::heuristic::RtpHeuristic::new();
                 let (mut sip, mut rtp, mut total) = (0u64, 0u64, 0u64);
                 for mut batch in wrx.iter() {
@@ -2514,7 +2537,69 @@ mod tests {
             leg_correlation_window_ms: crate::sip::dialog_store::DEFAULT_LEG_CORRELATION_WINDOW_MS,
             reassembly: true,
             parse_limit: None,
+            retain_audio: false,
+            max_audio_frames: 1500,
         }
+    }
+
+    /// `--cores N` must honor `--retain-audio`, or the operator who asked
+    /// for payload gets a run that kept none and an export that blames them.
+    ///
+    /// The workers hard-disabled retention with the comment "batch mode never
+    /// reads audio buffers". That was true when written; `--retain-audio`
+    /// shipped later, `--cores N` takes this path, and nothing refused the
+    /// combination -- so the flag was accepted and silently did nothing. The
+    /// export then reported "retention was off for this run", which was true
+    /// and pointed at the wrong cause.
+    ///
+    /// Driven through `run_offline_parallel_file` against a real capture,
+    /// because the first version of this test rebuilt the worker's two lines
+    /// inline and asserted on those. It passed with the bug reinstated: it was
+    /// checking that `set_audio_capture(true)` makes `audio_capture()` true,
+    /// which is a tautology and says nothing about what the worker does.
+    #[cfg(feature = "native")]
+    #[test]
+    fn cores_honor_the_audio_retention_setting() {
+        use crate::capture::CaptureConfig;
+        let paths = [std::path::PathBuf::from(
+            "tests/pcap-samples/Asterisk_ZFONE_XLITE.pcap",
+        )];
+        let cc = CaptureConfig::default();
+
+        let mut on = pcfg(4);
+        on.retain_audio = true;
+        let kept = run_offline_parallel_file(&paths, &cc, on).unwrap();
+
+        let off = run_offline_parallel_file(&paths, &cc, pcfg(4)).unwrap();
+
+        // The fixture has to carry decodable audio, or both runs are empty and
+        // the comparison below is vacuous.
+        assert!(
+            kept.stream_store.len() > 0,
+            "fixture produced no RTP streams"
+        );
+
+        let retained: usize = kept
+            .stream_store
+            .iter()
+            .map(|s| s.payload_buffer.len())
+            .sum();
+        let discarded: usize = off
+            .stream_store
+            .iter()
+            .map(|s| s.payload_buffer.len())
+            .sum();
+
+        assert!(
+            retained > 0,
+            "--cores with retain_audio kept no payload at all, so export_audio \
+             would report retention was off for a run that asked for it"
+        );
+        assert_eq!(
+            discarded, 0,
+            "retention is opt-in and must stay off by default; keeping payload \
+             unasked costs memory per worker"
+        );
     }
 
     /// Batching the reader→worker hand-off must not change what gets

--- a/src/rtp/audio_export.rs
+++ b/src/rtp/audio_export.rs
@@ -41,14 +41,33 @@ pub fn export_stream_to_wav(stream: &RtpStream, path: &Path) -> Result<String> {
     write_wav(path, &pcm_samples, sample_rate, 1)?;
 
     Ok(format!(
-        "Exported {:.1}s of {} audio ({} frames, {}/{}Hz) to {}",
+        "Exported {:.1}s of {} audio ({} frames, {}/{}Hz) to {}{}",
         duration_secs,
         codec_label,
         stream.payload_buffer.len(),
         stream.codec.as_deref().unwrap_or("?"),
         sample_rate,
         path.display(),
+        wrap_clause(stream.payload_frames_dropped),
     ))
+}
+
+/// A clause naming the ring wrap, or nothing when the buffer held everything.
+///
+/// Appended to every export summary. Without it the duration reads as a fact
+/// about the CALL: a ten-minute call whose ring keeps the last 1500 frames
+/// exports as "30.0s", byte-identical to a genuinely thirty-second call. The
+/// number was never wrong about the FILE; it was silent about what the file
+/// left out.
+fn wrap_clause(dropped: u64) -> String {
+    if dropped == 0 {
+        return String::new();
+    }
+    format!(
+        " — PARTIAL: the payload ring wrapped and dropped {dropped} earlier frame(s), \
+         so this file holds the END of the stream, not all of it. Raise \
+         [limits] max_audio_frames to keep more."
+    )
 }
 
 /// Export multiple streams (dialog) to a WAV file.
@@ -113,12 +132,15 @@ pub fn export_dialog_to_wav(streams: &[&RtpStream], path: &Path) -> Result<Strin
     write_wav(path, &interleaved, output_rate, 2)?;
 
     Ok(format!(
-        "Exported {:.1}s stereo audio ({} + {} frames, {}Hz) to {}",
+        "Exported {:.1}s stereo audio ({} + {} frames, {}Hz) to {}{}",
         duration_secs,
         exportable[0].payload_buffer.len(),
         exportable[1].payload_buffer.len(),
         output_rate,
         path.display(),
+        // Summed across both channels: either ring wrapping makes the file
+        // partial, and an operator reading one number wants the total.
+        wrap_clause(exportable[0].payload_frames_dropped + exportable[1].payload_frames_dropped),
     ))
 }
 
@@ -141,7 +163,7 @@ pub fn export_dialog_to_wav(streams: &[&RtpStream], path: &Path) -> Result<Strin
 /// So the message reports the measurement — packet count and codecs — and
 /// names retention as the reason nothing is decodable, without claiming the
 /// call was silent.
-fn nothing_to_decode(streams: &[&RtpStream]) -> String {
+pub(crate) fn nothing_to_decode(streams: &[&RtpStream]) -> String {
     let decodable: Vec<&&RtpStream> = streams
         .iter()
         .filter(|s| is_exportable_codec(s.codec.as_deref()))
@@ -168,12 +190,25 @@ fn nothing_to_decode(streams: &[&RtpStream]) -> String {
         .collect();
     codecs.sort_unstable();
     codecs.dedup();
+    // What is REPORTED is the measurement. What is OFFERED is the likeliest
+    // cause, named as a candidate rather than asserted.
+    //
+    // This used to state "Audio payload retention was off for this run" as
+    // fact. It is inferred from an empty buffer and nothing else, and at least
+    // three other things empty that buffer with retention ON: a `--snaplen`
+    // that truncated the payload away, an RTP packet that genuinely carried
+    // none, and -- until it was fixed -- a codec the buffering gate spelled
+    // differently from the export gate. Telling an operator who DID pass
+    // --retain-audio that they had not is a confident answer about the wrong
+    // subject, which is the failure this whole message exists to avoid.
     format!(
         "No audio payload retained: sipnab measured {packets} RTP packet(s) of {} on {} \
          decodable {}, but kept none of their payload, so there is nothing to decode. \
-         Audio payload retention was off for this run — that is a capture setting, not a \
-         finding that the call was silent. Start the server with --retain-audio to hold \
-         payload for export.",
+         This is a statement about what this run kept, not a finding that the call was \
+         silent. Most often audio payload retention was off — start the server with \
+         --retain-audio to hold payload for export. With retention already on, the \
+         other causes are a --snaplen that truncated the payload away before sipnab \
+         saw it, or packets that carried no payload at all.",
         codecs.join("/"),
         decodable.len(),
         if decodable.len() == 1 {
@@ -338,6 +373,84 @@ pub(crate) fn resample_linear<T: LinearResampleSample>(
 /// Unit tests for mono and stereo WAV export from RTP streams.
 #[cfg(test)]
 mod tests {
+    /// "The call was silent" and "this run did not keep it" must never read as
+    /// the same sentence.
+    ///
+    /// This is the honesty requirement RE7 names, asserted rather than
+    /// described. The two facts have different owners -- one is a fault in the
+    /// traffic, the other a limit of this run -- and an operator who cannot
+    /// tell them apart investigates the wrong thing.
+    ///
+    /// It has already gone wrong twice. `nothing_to_decode` was written to
+    /// replace "No audio payload captured", and `playback.rs` kept saying it
+    /// for months because only one of the two functions that decode
+    /// `payload_buffer` was migrated. This test spans both.
+    #[test]
+    fn a_run_that_kept_nothing_never_reads_as_a_silent_call() {
+        // Retention empty, codec decodable: a statement about the RUN.
+        let kept_nothing = make_stream(Some("PCMU"), vec![]);
+        let run_msg = nothing_to_decode(&[&kept_nothing]);
+
+        // Nothing sipnab can decode: a statement about the TRAFFIC's codecs.
+        let undecodable = make_stream(Some("G729"), vec![]);
+        let codec_msg = nothing_to_decode(&[&undecodable]);
+
+        assert_ne!(
+            run_msg, codec_msg,
+            "two different reasons produced one identical sentence"
+        );
+
+        // The run-limited message must DISCLAIM the reading it would otherwise
+        // invite, and scope itself to the run.
+        //
+        // Asserted as presence of the disclaimer rather than absence of the
+        // phrase: the first version of this test banned the substring "the
+        // call was silent", which appears in "not a finding that the call was
+        // silent" -- correct prose that the check rejected, because a
+        // substring cannot tell a claim from its negation.
+        assert!(
+            run_msg.contains("not a finding that the call was silent"),
+            "the retention message must disclaim the reading it invites:\n{run_msg}"
+        );
+        assert!(
+            run_msg.contains("this run kept"),
+            "the retention message must say it describes the run:\n{run_msg}"
+        );
+        // And must not assert a cause it cannot observe. It infers an empty
+        // buffer, and --snaplen truncation empties it with retention ON.
+        assert!(
+            !run_msg.contains("retention was off for this run"),
+            "the message asserts a cause it only inferred:\n{run_msg}"
+        );
+
+        // The codec message must name the codecs, which is the whole answer.
+        assert!(
+            codec_msg.contains("G729"),
+            "the undecodable-codec message must name what it found:\n{codec_msg}"
+        );
+    }
+
+    /// A wrapped ring must say so, or the duration reads as the call's length.
+    #[test]
+    fn a_wrapped_ring_is_named_in_the_summary() {
+        assert_eq!(wrap_clause(0), "", "an intact buffer adds no clause");
+
+        let wrapped = wrap_clause(4200);
+        assert!(
+            wrapped.contains("4200"),
+            "the operator's next question is how much was lost:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("PARTIAL"),
+            "a partial file must announce itself:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("END of the stream"),
+            "which END was kept decides whether the file answers the question \
+             being asked of it:\n{wrapped}"
+        );
+    }
+
     use super::*;
     use crate::rtp::parser::RtpHeader;
     use crate::rtp::stream::{RtpStream, StreamKey};

--- a/src/rtp/audio_export.rs
+++ b/src/rtp/audio_export.rs
@@ -192,6 +192,25 @@ fn nothing_to_decode(streams: &[&RtpStream]) -> String {
 /// filtered out of export. G.711 (`PCMU`/`PCMA`) is matched exactly, matching
 /// what `decode_stream_pcm` accepts.
 fn is_exportable_codec(codec: Option<&str>) -> bool {
+    is_capturable_audio_codec(codec)
+}
+
+/// The one answer to "can sipnab turn this codec into audio".
+///
+/// Both sides of the pipeline ask it: [`crate::rtp::stream_store::StreamStore`]
+/// at buffer time, deciding whether to keep a stream's payload at all, and the
+/// exporter at decode time. They used to answer it separately, and disagreed:
+/// the buffering side matched `"opus" | "OPUS" | "Opus"` exactly while this
+/// side compared case-insensitively, as SDP requires. A stream labeled `OpUs`
+/// -- legal, and what several stacks emit -- was therefore never buffered,
+/// then classified as decodable, and the export blamed retention for an empty
+/// buffer that the codec check had emptied.
+///
+/// One function rather than two that agree today, because the wrong answer
+/// here is not a failed export: it is a CORRECT-LOOKING message about the
+/// wrong subject.
+#[must_use]
+pub(crate) fn is_capturable_audio_codec(codec: Option<&str>) -> bool {
     matches!(codec, Some("PCMU") | Some("PCMA")) || codec.is_some_and(is_opus_codec)
 }
 

--- a/src/rtp/playback.rs
+++ b/src/rtp/playback.rs
@@ -153,7 +153,15 @@ impl AudioPlayer {
     /// 8 kHz and resampled to 48 kHz; Opus decodes natively at 48 kHz.
     pub fn play_stream(&self, stream: &RtpStream) -> Result<String> {
         if stream.payload_buffer.is_empty() {
-            bail!("No audio payload captured");
+            // The same explanation the exporter gives, from the same function.
+            //
+            // This line used to read "No audio payload captured" -- verbatim
+            // the wording `nothing_to_decode` was written to replace, and which
+            // its doc comment names as the defect: a reader takes it as a
+            // statement about the CALL. Only one of the two functions that
+            // decode `payload_buffer` was migrated, so pressing `P` in the TUI
+            // still produced the sentence the exporter had stopped saying.
+            bail!(crate::rtp::audio_export::nothing_to_decode(&[stream]));
         }
 
         let output_rate = 48000u32;

--- a/src/rtp/stream.rs
+++ b/src/rtp/stream.rs
@@ -397,6 +397,19 @@ pub struct RtpStream {
     /// Ring buffer of raw RTP payloads for audio export (G.711 and Opus).
     /// Each entry: (RTP timestamp, raw payload bytes).
     pub payload_buffer: std::collections::VecDeque<(u32, Vec<u8>)>,
+    /// Payload frames the ring dropped to stay inside its cap.
+    ///
+    /// The eviction was silent, and silence made the export lie by omission: a
+    /// ten-minute call whose ring holds the last 1500 frames exports as
+    /// "30.0s of mu-law audio", which is textually identical to a genuinely
+    /// thirty-second call and is read as a fact about the CALL. The duration
+    /// is a fact about the BUFFER.
+    ///
+    /// Counted rather than flagged, because "how much was lost" is the
+    /// question an operator asks next, and a bool cannot answer it.
+    /// [`LossMap::truncated`](crate::rtp::loss_map::LossMap) marks the same
+    /// class of loss for the packet-loss map; this is its equivalent for audio.
+    pub payload_frames_dropped: u64,
     /// Packetization interval the SDP declared with `a=ptime`, in
     /// milliseconds, when an offer or answer for this endpoint carried one.
     ///
@@ -747,6 +760,7 @@ impl RtpStream {
             cn_frames: 0,
             silence_periods: Vec::new(),
             payload_buffer: std::collections::VecDeque::new(),
+            payload_frames_dropped: 0,
             sdp_ptime_ms: None,
             // Same reason as `first_frame`: an RTP header carries no IP
             // header. `StreamStore::process_rtp` holds the `ParsedPacket` and

--- a/src/rtp/stream_store.rs
+++ b/src/rtp/stream_store.rs
@@ -643,6 +643,11 @@ impl StreamStore {
                     let audio = parsed.payload[payload_start..].to_vec();
                     if stream.payload_buffer.len() >= self.max_audio_frames {
                         stream.payload_buffer.pop_front();
+                        // Counted, so the export can say the ring wrapped
+                        // rather than reporting the buffer's duration as the
+                        // call's.
+                        stream.payload_frames_dropped =
+                            stream.payload_frames_dropped.saturating_add(1);
                     }
                     stream.payload_buffer.push_back((rtp.timestamp, audio));
                 }
@@ -3113,6 +3118,39 @@ a=rtpmap:96 H264/90000\r\n";
             "audio payloads must not be buffered when capture is disabled"
         );
         assert_eq!(stream.packet_count, 2, "stats still update normally");
+    }
+
+    /// A ring that wraps must COUNT what it dropped.
+    ///
+    /// The eviction was silent, so a ten-minute call exported as "30.0s of
+    /// mu-law audio" -- textually identical to a genuinely thirty-second call,
+    /// and read as a fact about the call rather than about the buffer.
+    ///
+    /// Asserted on the counter rather than on the export string, because the
+    /// string's own test can pass while nothing feeds it: removing this
+    /// increment still compiles, and `wrap_clause`'s test still passes,
+    /// because it is handed a number rather than measuring one.
+    #[test]
+    fn a_wrapping_payload_ring_counts_what_it_dropped() {
+        let mut store = StreamStore::new(100);
+        store.set_max_audio_frames(3);
+        let parsed = make_parsed(20000, 30000, 160);
+
+        for seq in 1..=10u16 {
+            store.process_rtp(&parsed, &make_rtp_header(0xA0D3, seq), ts(i64::from(seq)));
+        }
+
+        let stream = store.iter().next().expect("stream exists");
+        assert_eq!(
+            stream.payload_buffer.len(),
+            3,
+            "the ring must hold its cap and no more"
+        );
+        assert_eq!(
+            stream.payload_frames_dropped, 7,
+            "ten frames into a ring of three drops seven; a silent drop is what \
+             made the exported duration read as the call's length"
+        );
     }
 
     /// Default (TUI / library use): G.711 payloads ARE buffered so

--- a/src/rtp/stream_store.rs
+++ b/src/rtp/stream_store.rs
@@ -1679,13 +1679,13 @@ impl StreamStore {
 
 /// Check if a codec supports audio payload capture for playback/export.
 ///
-/// G.711 (PCMU/PCMA) and Opus are supported. Opus codec names are
-/// case-insensitive per SDP convention (`opus`, `OPUS`, `Opus`).
+/// Delegates rather than deciding. This used to list Opus's spellings itself
+/// -- `"opus" | "OPUS" | "Opus"` -- while the exporter compared
+/// case-insensitively, so a legal `OpUs` label was never buffered here and was
+/// still called decodable there. The export then reported that retention was
+/// off, which was a true-sounding statement about the wrong thing.
 fn is_audio_capturable(codec: Option<&str>) -> bool {
-    matches!(
-        codec,
-        Some("PCMU") | Some("PCMA") | Some("opus") | Some("OPUS") | Some("Opus")
-    )
+    crate::rtp::audio_export::is_capturable_audio_codec(codec)
 }
 
 /// Unit tests for the stream store: creation/update, SDP linking in both
@@ -1693,6 +1693,45 @@ fn is_audio_capturable(codec: Option<&str>) -> bool {
 /// merge, and the SNB-0015 performance probes.
 #[cfg(test)]
 mod tests {
+    /// The buffering gate and the export gate must answer identically.
+    ///
+    /// They diverged for real: this side matched Opus's three canonical
+    /// spellings exactly, the export side compared case-insensitively as SDP
+    /// requires, and a stream labeled `OpUs` fell in the gap -- never
+    /// buffered, still called decodable, and the export blamed retention.
+    ///
+    /// The existing test beside the exporter asserted "the two predicates must
+    /// agree" while checking two predicates in that same file, so it could not
+    /// see the pair that actually disagreed. This one spans the boundary.
+    #[test]
+    fn the_buffering_gate_agrees_with_the_export_gate() {
+        for codec in [
+            Some("PCMU"),
+            Some("PCMA"),
+            Some("opus"),
+            Some("OPUS"),
+            Some("Opus"),
+            // The spelling that fell in the gap. Legal SDP, and what several
+            // stacks emit.
+            Some("OpUs"),
+            Some("oPuS"),
+            // Must be refused by BOTH, or the buffer fills with what nothing
+            // can decode.
+            Some("G729"),
+            Some("H264"),
+            Some(""),
+            None,
+        ] {
+            assert_eq!(
+                super::is_audio_capturable(codec),
+                crate::rtp::audio_export::is_capturable_audio_codec(codec),
+                "buffering and export disagree about {codec:?}; a codec kept by \
+                 one and refused by the other produces an empty buffer that the \
+                 export explains with the wrong reason"
+            );
+        }
+    }
+
     /// RE3: an endpoint rtpengine asserted about ITSELF is not the same claim
     /// as one observed in signaling, and the difference must survive into
     /// provenance rather than being flattened at the point of use.

--- a/tests/frame_provenance_test.rs
+++ b/tests/frame_provenance_test.rs
@@ -270,6 +270,8 @@ fn the_parallel_reader_gives_each_file_of_a_set_its_own_source() {
         quiet_bad_parse: false,
         xcid_headers: Vec::new(),
         leg_correlation_window_ms: sipnab::sip::dialog_store::DEFAULT_LEG_CORRELATION_WINDOW_MS,
+        retain_audio: false,
+        max_audio_frames: 1500,
     };
     let r = sipnab::parallel::run_offline_parallel_file(&[a.clone(), b.clone()], &cc, cfg)
         .expect("the two-file set reconstructs");

--- a/website/content/docs/internals/build-ci-release.md
+++ b/website/content/docs/internals/build-ci-release.md
@@ -596,8 +596,29 @@ publishes immediately and irreversibly, whatever that commit contains: fourteen
 installable artifacts (six `.tar.gz`, four `.deb`, four `.rpm`), a `.sha256`
 beside each tarball, a combined `SHA256SUMS.txt`, two SBOMs, a provenance
 attestation, a GHCR image, and a Homebrew formula — twenty-three release assets in
-all. The order is therefore: push the release commit, wait for CI, then tag the
+all. The order is therefore: land the release commit, wait for CI, then tag the
 commit that passed.
+
+**`main` takes pull requests, and admins are not exempt.** Branch protection
+requires a PR and a green `CI success` before anything reaches `main`, with
+`enforce_admins` on, so the release commit lands the same way every other
+commit does. It asks for zero approvals — the point is that the commit exists
+and CI has run on it BEFORE it reaches `main`, not that a second person signs
+it off on a repository with one maintainer.
+
+That setting was off until 2026-08-23, and the rules it left in place were
+worse than none: every push reported `Bypassed rule violations` for a required
+check that could never run in time, because a status check gates a commit
+before it lands and a direct push creates the commit and the status together.
+A rule that every push bypasses reads as protection to anyone auditing the
+settings while providing exactly none. The `required_linear_history` rule
+went at the same time and for the same reason — `main` carries 128 merge
+commits and merging feature branches is how this repository works, so that
+rule had never described it.
+
+None of this touches tags: branch protection targets `refs/heads/main`, and a
+release is a pushed `refs/tags/v*`. The `pre-push` gate below is still what stands
+between a red commit and twenty-three published artifacts.
 
 A hook enforces this rather than merely advising it. [`pre-push`](https://github.com/NormB/sipnab/blob/main/.githooks/pre-push)
 refuses a `v*` tag whose commit has a failed run, has runs still in flight, or

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -18834,8 +18834,29 @@ publishes immediately and irreversibly, whatever that commit contains: fourteen
 installable artifacts (six `.tar.gz`, four `.deb`, four `.rpm`), a `.sha256`
 beside each tarball, a combined `SHA256SUMS.txt`, two SBOMs, a provenance
 attestation, a GHCR image, and a Homebrew formula — twenty-three release assets in
-all. The order is therefore: push the release commit, wait for CI, then tag the
+all. The order is therefore: land the release commit, wait for CI, then tag the
 commit that passed.
+
+**`main` takes pull requests, and admins are not exempt.** Branch protection
+requires a PR and a green `CI success` before anything reaches `main`, with
+`enforce_admins` on, so the release commit lands the same way every other
+commit does. It asks for zero approvals — the point is that the commit exists
+and CI has run on it BEFORE it reaches `main`, not that a second person signs
+it off on a repository with one maintainer.
+
+That setting was off until 2026-08-23, and the rules it left in place were
+worse than none: every push reported `Bypassed rule violations` for a required
+check that could never run in time, because a status check gates a commit
+before it lands and a direct push creates the commit and the status together.
+A rule that every push bypasses reads as protection to anyone auditing the
+settings while providing exactly none. The `required_linear_history` rule
+went at the same time and for the same reason — `main` carries 128 merge
+commits and merging feature branches is how this repository works, so that
+rule had never described it.
+
+None of this touches tags: branch protection targets `refs/heads/main`, and a
+release is a pushed `refs/tags/v*`. The `pre-push` gate below is still what stands
+between a red commit and twenty-three published artifacts.
 
 A hook enforces this rather than merely advising it. [`pre-push`](../../.githooks/pre-push)
 refuses a `v*` tag whose commit has a failed run, has runs still in flight, or

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5537 automated tests. Under 12 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5539 automated tests. Under 12 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5537" data-suffix="">5537</span>
+        <span class="arch-stat" data-count="5539" data-suffix="">5539</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5539 automated tests. Under 12 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5542 automated tests. Under 12 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5539" data-suffix="">5539</span>
+        <span class="arch-stat" data-count="5542" data-suffix="">5542</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>


### PR DESCRIPTION
Five bugs on the audio-retention path, found while scoping RE7's honesty requirement. They share one shape: **a message about what sipnab did, phrased as a fact about the call.**

## The bugs

**`--cores N` silently voided `--retain-audio`.** The parallel workers set `audio_capture(false)` unconditionally, commented "batch mode never reads audio buffers" — true when written, false once `--retain-audio` shipped. It only requires `--mcp`, nothing excludes `--cores`, and `cores > 1 && has_input()` takes that path. The flag was accepted, the run kept nothing, and the export explained it with a sentence that was accurate and pointed at the wrong cause.

**The two codec gates disagreed.** `is_audio_capturable` matched Opus as three exact spellings; `is_exportable_codec` compared case-insensitively, as SDP requires and as its own doc comment says. A stream labeled `OpUs` was never buffered, still classed decodable, and the export blamed retention for a buffer the codec check had emptied. One predicate now.

**The ring wrapped in silence.** A ten-minute call whose ring keeps the last 1500 frames exported as `"Exported 30.0s of mu-law audio"` — textually identical to a genuinely thirty-second call. The number was never wrong about the *file*; it was silent about what the file left out. Summaries now say `PARTIAL: … dropped N earlier frame(s), so this file holds the END of the stream, not all of it.`

**Playback kept the retired wording.** `play_stream` bailed with `"No audio payload captured"` — verbatim what `nothing_to_decode` was written to replace, and which that function's doc comment names as the defect. Only one of the two functions decoding `payload_buffer` had been migrated.

**The explanation asserted a cause it had inferred.** "Retention was off for this run" is deduced from an empty buffer alone, and `--snaplen` truncation, payload-less packets, and the codec bug above all empty it with retention **on**.

## Testing

Every fix is mutation-tested. Two mutants survived a first pass and both are worth recording:

- `cores_honor_the_audio_retention_setting` originally rebuilt the worker's two lines inline and asserted on those — it passed with the bug reinstated, because it was checking that `set_audio_capture(true)` makes `audio_capture()` true. It drives `run_offline_parallel_file` against a real capture now.
- Deleting the eviction counter compiled and `wrap_clause`'s test still passed, because that test is *handed* a number rather than measuring one. `a_wrapping_payload_ring_counts_what_it_dropped` drives ten frames into a ring of three and fails 0 against 7.

The codec test spans a boundary the existing one could not: a test beside the exporter already asserted "the two predicates must agree" while checking two predicates in that same file.

RE7's own deliverable — an artefact naming its mechanism — is not here. These had to go first: until retention is honored and the gates agree, the run does not know why a buffer is empty, so "partial" cannot be reported accurately.