### PR TITLE
Release 0.5.124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ entry that carries them.
 
 ## [Unreleased]
 
+## [0.5.124] - 2026-08-24
+
 ### Added
 
 - **sipnab can ask an rtpengine relay which calls it is carrying

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3976,7 +3976,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sipnab"
-version = "0.5.123"
+version = "0.5.124"
 dependencies = [
  "aes",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ workspace = true
 
 [package]
 name = "sipnab"
-version = "0.5.123"
+version = "0.5.124"
 edition = "2024"
 rust-version = "1.97"
 authors = ["Norm Brandinger"]

--- a/docs/install.md
+++ b/docs/install.md
@@ -597,7 +597,7 @@ sipnab -D
 `--version` lists the Cargo features compiled into the binary, e.g.
 
 ```text
-sipnab 0.5.123 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
+sipnab 0.5.124 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
 ```
 
 This is the fastest way to confirm a build carries the feature set

--- a/docs/mcp-deploy.md
+++ b/docs/mcp-deploy.md
@@ -117,7 +117,7 @@ itself):
 
    ```bash
    sipnab --version
-   # sipnab 0.5.123 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
+   # sipnab 0.5.124 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
    ```
 
    If `mcp` is missing you have a source build without features — rebuild
@@ -1196,7 +1196,7 @@ Then confirm the build can do what you are about to ask of it:
 
 ```json
 {
-  "version": "0.5.123",
+  "version": "0.5.124",
   "features": ["api", "audio", "hep", "mcp", "mcp-http", "metrics",
                "native", "plugins", "tls", "tui"],
   "can_decrypt": true,
@@ -1646,7 +1646,7 @@ stdin and the `sleep`s pace the handshake — so paste it as a unit:
 Expected first line of response:
 
 ```json
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"sipnab","version":"0.5.123"},"instructions":"sipnab MCP server — queries captured SIP dialogs ..."}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"sipnab","version":"0.5.124"},"instructions":"sipnab MCP server — queries captured SIP dialogs ..."}}
 ```
 
 ### Test the HTTP wire by hand

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -2328,7 +2328,7 @@ No parameters. Returns:
 ```jsonc
 {
   "schema_version": 1,
-  "version": "0.5.123",
+  "version": "0.5.124",
   "features": ["api", "hep", "mcp", "native", "tls", "tui"],
   "can_decrypt": true,           // tls
   "can_hep": true,               // hep

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "sipnab"
-version = "0.5.123"
+version = "0.5.124"
 dependencies = [
  "aes",
  "ahash",

--- a/man/sipnab.1
+++ b/man/sipnab.1
@@ -1,7 +1,7 @@
 .\" sipnab.1 -- man page for sipnab
 .\" Copyright 2024-2026 Norm Brandinger
 .\" License: MIT OR Apache-2.0
-.TH SIPNAB 1 "2026-08-22" "sipnab 0.5.123" "User Commands"
+.TH SIPNAB 1 "2026-08-22" "sipnab 0.5.124" "User Commands"
 .SH NAME
 sipnab \- SIP & RTP capture, analysis, and security tool
 .SH SYNOPSIS

--- a/website/config.toml
+++ b/website/config.toml
@@ -34,7 +34,7 @@ theme = "ayu-dark"
 # download links came from here. They did once — `download.html` was moved to
 # `published_version` and the claim was never revisited, which is also how the
 # same sentence ended up in site_journey_test.rs and pages.yml.
-version = "0.5.123"
+version = "0.5.124"
 # The last version that actually EXISTS as a published GitHub release, which is
 # what every download link must point at.
 #

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -602,7 +602,7 @@ sipnab -D
 `--version` lists the Cargo features compiled into the binary, e.g.
 
 ```text
-sipnab 0.5.123 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
+sipnab 0.5.124 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
 ```
 
 This is the fastest way to confirm a build carries the feature set

--- a/website/content/docs/mcp-deploy.md
+++ b/website/content/docs/mcp-deploy.md
@@ -125,7 +125,7 @@ itself):
 
    ```bash
    sipnab --version
-   # sipnab 0.5.123 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
+   # sipnab 0.5.124 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
    ```
 
    If `mcp` is missing you have a source build without features — rebuild
@@ -1204,7 +1204,7 @@ Then confirm the build can do what you are about to ask of it:
 
 ```json
 {
-  "version": "0.5.123",
+  "version": "0.5.124",
   "features": ["api", "audio", "hep", "mcp", "mcp-http", "metrics",
                "native", "plugins", "tls", "tui"],
   "can_decrypt": true,
@@ -1654,7 +1654,7 @@ stdin and the `sleep`s pace the handshake — so paste it as a unit:
 Expected first line of response:
 
 ```json
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"sipnab","version":"0.5.123"},"instructions":"sipnab MCP server — queries captured SIP dialogs ..."}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"sipnab","version":"0.5.124"},"instructions":"sipnab MCP server — queries captured SIP dialogs ..."}}
 ```
 
 ### Test the HTTP wire by hand

--- a/website/content/docs/mcp-tools.md
+++ b/website/content/docs/mcp-tools.md
@@ -2333,7 +2333,7 @@ No parameters. Returns:
 ```jsonc
 {
   "schema_version": 1,
-  "version": "0.5.123",
+  "version": "0.5.124",
   "features": ["api", "hep", "mcp", "native", "tls", "tui"],
   "can_decrypt": true,           // tls
   "can_hep": true,               // hep

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -3805,7 +3805,7 @@ sipnab -D
 `--version` lists the Cargo features compiled into the binary, e.g.
 
 ```text
-sipnab 0.5.123 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
+sipnab 0.5.124 (<hash>) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
 ```
 
 This is the fastest way to confirm a build carries the feature set
@@ -10372,7 +10372,7 @@ itself):
 
    ```bash
    sipnab --version
-   # sipnab 0.5.123 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
+   # sipnab 0.5.124 (...) features: native,tui,audio,tls,hep,api,mcp,mcp-http,metrics,plugins,bpf
    ```
 
    If `mcp` is missing you have a source build without features — rebuild
@@ -11451,7 +11451,7 @@ Then confirm the build can do what you are about to ask of it:
 
 ```json
 {
-  "version": "0.5.123",
+  "version": "0.5.124",
   "features": ["api", "audio", "hep", "mcp", "mcp-http", "metrics",
                "native", "plugins", "tls", "tui"],
   "can_decrypt": true,
@@ -11901,7 +11901,7 @@ stdin and the `sleep`s pace the handshake — so paste it as a unit:
 Expected first line of response:
 
 ```json
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"sipnab","version":"0.5.123"},"instructions":"sipnab MCP server — queries captured SIP dialogs ..."}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"sipnab","version":"0.5.124"},"instructions":"sipnab MCP server — queries captured SIP dialogs ..."}}
 ```
 
 ### Test the HTTP wire by hand
@@ -14992,7 +14992,7 @@ No parameters. Returns:
 ```jsonc
 {
   "schema_version": 1,
-  "version": "0.5.123",
+  "version": "0.5.124",
   "features": ["api", "hep", "mcp", "native", "tls", "tui"],
   "can_decrypt": true,           // tls
   "can_hep": true,               // hep


### PR DESCRIPTION
Cuts 0.5.124.

**What it contains** — RE4 (`--rtpengine-control`: sipnab asks an rtpengine relay which calls it is carrying, at two moments and no others, read-only in the type system, bounded three ways), the documentation sweep that made the reference describe the tool rather than the releases it went through, the surface-coverage matrix over every flag/route/tool, and three bug fixes.

**What deliberately does not move.** `published_version` and `docs/install.md`'s `SIPNAB_VERSION=` / `rpm -i sipnab-<v>` markers stay at 0.5.123. They advertise the last PUBLISHED release, and no artifacts exist for this one until the tag builds them — they move afterwards, in their own commit. The `sipnab <version> (<hash>)` samples are the opposite case: they show what a build of this tree prints, so they follow the crate.

Both lockfiles move with the manifest. The root one is only ever fixed by staging it, which is how 0.5.120 and 0.5.121 each shipped a tree whose manifest and lockfile disagreed about which release they were.

Tag goes on this commit only after CI is green on it.