### PR TITLE
Put the MOS grounding on every door, not just MCP

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -117,8 +117,19 @@ else
 . "$PROSE_LIB"
 
 echo -n "  Vale... "
-prose_vale_run
-case $? in
+# `set -e` is on, and a bare `prose_vale_run` is a simple command: a return of 1
+# -- the CONTRACT's "the tool ran and found something" -- killed the hook right
+# here, BEFORE the `case` that renders it. The operator saw `Vale... ` and exit
+# 1, with the findings written to $PROSE_OUTPUT and then never read. A gate that
+# blocks a commit without naming what it found is the "empty output is not
+# evidence" shape, in the gate itself.
+#
+# `&& rc=0 || rc=$?` puts the call in a compound list, where `set -e` is
+# suspended, and keeps all three contract values apart -- which a plain
+# `if prose_vale_run` would collapse, turning "vale is not installed" into a
+# FAIL. Every call of a CONTRACT runner in this repository is spelled this way.
+prose_vale_run && prose_rc=0 || prose_rc=$?
+case $prose_rc in
 0) echo -e "${GREEN}OK${NC}" ;;
 1)
     echo -e "${RED}FAIL${NC}"
@@ -131,8 +142,9 @@ esac
 rm -f "$PROSE_OUTPUT"
 
 echo -n "  Codespell... "
-prose_codespell_run
-case $? in
+# Same shape as vale above, and it failed the same way.
+prose_codespell_run && prose_rc=0 || prose_rc=$?
+case $prose_rc in
 0) echo -e "${GREEN}OK${NC}" ;;
 1)
     echo -e "${RED}FAIL${NC}"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -748,8 +748,12 @@ else
 . "$PROSE_LIB"
 
 printf '  vale (prose style) ... '
-prose_vale_run
-case $? in
+# See the note in .githooks/pre-commit: `set -eu` is on, so a bare
+# `prose_vale_run` returning the CONTRACT's 1 killed the hook before the `case`
+# that renders the findings. A blocked push with no reason printed is worse than
+# no gate at all -- the next move is a guess.
+prose_vale_run && prose_rc=0 || prose_rc=$?
+case $prose_rc in
 0)
 	printf '%bOK%b\n' "$GREEN" "$NC"
 	;;
@@ -767,8 +771,9 @@ esac
 rm -f "$PROSE_OUTPUT"
 
 printf '  codespell (spelling) ... '
-prose_codespell_run
-case $? in
+# Same shape as vale above, and it failed the same way.
+prose_codespell_run && prose_rc=0 || prose_rc=$?
+case $prose_rc in
 0)
 	printf '%bOK%b\n' "$GREEN" "$NC"
 	;;

--- a/docs/design/backlog.md
+++ b/docs/design/backlog.md
@@ -577,8 +577,8 @@ Tiers:
   entry rested on. It is also the mechanism
   behind CT2 — a stalled reader is what overflows the ring. **Latent deadlock:**
   the ordering `stores → alerts` exists only on this path and is written down
-  nowhere; `security_findings` ([`src/mcp/server.rs:4428`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4428)) currently takes
-  nowhere; `security_findings` ([`src/mcp/server.rs:4428`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4428)) currently takes
+  nowhere; `security_findings` ([`src/mcp/server.rs:4406`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4406)) currently takes
+  nowhere; `security_findings` ([`src/mcp/server.rs:4406`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4406)) currently takes
   `alerts.read()` and no store lock, so there is no cycle *today*, and nothing
   stops the next MCP tool from creating one. **Do:** queue exec requests and
   per-message output during the locked section, drain them after the guards
@@ -795,8 +795,8 @@ Tiers:
   `sipnab_capture_invalid_timestamps_total` (the field is declared at
   [`src/output/prometheus.rs:119`](https://github.com/NormB/sipnab/blob/main/src/output/prometheus.rs#L119), read from the atomic at `:149`, rendered at
   `:523`, and named in [`tests/metrics_test.rs`](https://github.com/NormB/sipnab/blob/main/tests/metrics_test.rs) so a rename cannot silently drop
-  it); the MCP `capture_status` tool carries the field ([`src/mcp/server.rs:4525`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4525),
-  it); the MCP `capture_status` tool carries the field ([`src/mcp/server.rs:4525`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4525),
+  it); the MCP `capture_status` tool carries the field ([`src/mcp/server.rs:4503`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4503),
+  it); the MCP `capture_status` tool carries the field ([`src/mcp/server.rs:4503`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4503),
   populated at `:1356`) and reports it as a delta between two calls (`:1676`);
   and the batch summary explains it in prose
   ([`src/app/batch.rs:905-925`](https://github.com/NormB/sipnab/blob/main/src/app/batch.rs#L905-L925), the doc comment on `report_capture_quality`). The
@@ -1542,7 +1542,7 @@ output path.
     2026-08-06, verified against the tree).** Shipped: `FrameRef`
     ([`src/capture/packet.rs:94`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L94)) and `capture::resolve::resolve`
     ([`src/capture/resolve.rs:191`](https://github.com/NormB/sipnab/blob/main/src/capture/resolve.rs#L191)); the `show_evidence` MCP tool
-    (`#[tool(` at [`src/mcp/server.rs:5832`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L5832), handler at `:3866`), confined to
+    (`#[tool(` at [`src/mcp/server.rs:5810`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L5810), handler at `:3866`), confined to
     the file root and honest about
     itself with three states — `verified` / `unverified` / `unresolvable` —
     rather than resolving a foreign ref against the wrong file; and

--- a/docs/design/deferred-and-declined.md
+++ b/docs/design/deferred-and-declined.md
@@ -279,9 +279,9 @@ registry has grown since, and the count is pinned by
 The argument below does not depend on the number. Four
 of them touch something other than the stores: `export_capture`
 ([`server.rs:6057`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6057)) writes a pcap, `export_audio`
-([`server.rs:6132`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6132)) writes a WAV, `list_captures`
-([`server.rs:6005`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6005)) reads a directory, and
-`shutdown_server` ([`server.rs:6602`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6602)) ends the process.
+([`server.rs:6105`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6105)) writes a WAV, `list_captures`
+([`server.rs:5983`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L5983)) reads a directory, and
+`shutdown_server` ([`server.rs:6570`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6570)) ends the process.
 
 **None of them mutates a store.** `shutdown_server` reads `dialog_store` and
 `stream_store` for its report, optionally writes a file, and then calls
@@ -361,9 +361,9 @@ and it is not incidental — it is the tool working:
 - `DialogSummary.from_user` / `to_user`
   ([`model.rs:53-57`](https://github.com/NormB/sipnab/blob/main/src/output/model.rs#L53-L57)) are copied straight off the
   From/To URIs.
-- `get_message` ([`server.rs:3885`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L3885)) returns the parsed
+- `get_message` ([`server.rs:3863`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L3863)) returns the parsed
   message through `message_to_json_value`, headers and body included.
-- `search_messages` ([`server.rs:4177`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4177)) returns
+- `search_messages` ([`server.rs:4155`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4155)) returns
   `snippet`, built as
   `truncate_string(&String::from_utf8_lossy(&msg.raw), MAX_BODY_BYTES)` — the
   raw bytes off the wire.
@@ -719,7 +719,7 @@ documents *"the tool server; cloned per HTTP session"* and
 built once at startup ([`servers.rs:224-249`](https://github.com/NormB/sipnab/blob/main/src/app/servers.rs#L224-L249)) with
 `name` taken from `cli.primary_input()` — which returns only the *first* `-I`
 argument ([`cli.rs:1363-1365`](https://github.com/NormB/sipnab/blob/main/src/cli.rs#L1363-L1365)). So after an `open_capture`,
-`capture_status` ([`server.rs:4525`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4525)) would keep naming
+`capture_status` ([`server.rs:4503`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4503)) would keep naming
 the old file, in the calling session as well as every other one, unless the
 field moves behind a shared lock. Two agents on one HTTP server would read the
 same store and disagree about which capture it is.
@@ -795,7 +795,7 @@ decision was taken, not as it stands now:
    a `SipnabMcp` cloned per HTTP session
    ([`transport.rs:192`](https://github.com/NormB/sipnab/blob/main/src/mcp/transport.rs#L192)). Until it moves behind
    a shared lock, a swap leaves `capture_status`
-   ([`server.rs:4525`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4525)) naming the old file in the
+   ([`server.rs:4503`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4503)) naming the old file in the
    calling session and in every other one.
 2. **Capture identity must be visible on the wire.** `DialogStore::generation`
    ([`dialog_store.rs:573`](https://github.com/NormB/sipnab/blob/main/src/sip/dialog_store.rs#L573)) is bumped by every
@@ -809,7 +809,7 @@ decision was taken, not as it stands now:
 The opt-in machinery and the path confinement are already solved and should be
 reused rather than redesigned: the `shutdown_server` flag, off-by-default field,
 builder and first-statement refusal
-([`server.rs:6602`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6602)), and `--mcp-file-root` with
+([`server.rs:6570`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6570)), and `--mcp-file-root` with
 `resolve_in_root` ([`server.rs:487`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L487)).
 
 **What shipped**, against those three:

--- a/docs/design/icid-correlation.md
+++ b/docs/design/icid-correlation.md
@@ -364,7 +364,7 @@ router name in disguise.
 
 **The good news is that the existing surface already does the right thing and
 needs no new discipline.** `find_correlated`'s response
-([`server.rs:6379`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6379)) returns, per leg, `call_id`,
+([`server.rs:6347`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6347)) returns, per leg, `call_id`,
 `score`, `strategy`, `identifier_match` and `observed_gap_ms` — and never the
 matched identifier. `session_id` matches today without the `Session-ID` value
 ever reaching a client. **A sixth strategy that reports only its name inherits

--- a/docs/design/implementation-plan-phases-8-10.md
+++ b/docs/design/implementation-plan-phases-8-10.md
@@ -1682,7 +1682,7 @@ For implementers picking this up, the bridge from each MCP tool to existing func
 | `tail_dialogs` | `DialogStore::iter` filtered by `updated_at > cursor` |
 | `security_findings` | `security::AlertEngine` history (extend with ring buffer) |
 | `snapshot_pcap` | `capture::PcapWriter` + filter on captured packets |
-| `stats` | Mirrors `GET /v1/stats` from `output::api::get_stats` ([`src/output/api.rs:952`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L952)) |
+| `stats` | Mirrors `GET /v1/stats` from `output::api::get_stats` ([`src/output/api.rs:981`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L981)) |
 
 | Phase 8 infra | Reuses |
 |---|---|

--- a/docs/design/live-fanout.md
+++ b/docs/design/live-fanout.md
@@ -233,7 +233,7 @@ from a headless run — `start_servers` is called with `metrics: true` and the
 real meter from [`batch.rs:1861-1879`](https://github.com/NormB/sipnab/blob/main/src/app/batch.rs#L1861-L1879).
 
 **One gap worth fixing before the experiment.** `CaptureCounters`, the
-`capture_health` MCP response ([`server.rs:6731`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6731)),
+`capture_health` MCP response ([`server.rs:6699`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6699)),
 carries `packets`, `kernel_dropped`, `interface_dropped`, `invalid_timestamps`
 and `undecodable_frames` — and **no queue depth and no backpressure count**. So
 the surface built for production field reports

--- a/docs/design/mcp-write-back.md
+++ b/docs/design/mcp-write-back.md
@@ -144,9 +144,9 @@ concrete rather than theoretical:
 
 - `DialogSummary.from_user` / `to_user` ([`model.rs:54-56`](https://github.com/NormB/sipnab/blob/main/src/output/model.rs#L54-L56),
   populated at `:91-92`) are copied off the From/To URIs.
-- `get_message` ([`server.rs:3885`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L3885)) returns headers and
+- `get_message` ([`server.rs:3863`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L3863)) returns headers and
   body.
-- `search_messages` ([`server.rs:4177`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4177)) returns a
+- `search_messages` ([`server.rs:4155`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4155)) returns a
   `snippet` built at [`:1391`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L1391) from
   `truncate_string(&String::from_utf8_lossy(&msg.raw), …)` — raw bytes off the
   wire, unmodified.

--- a/docs/design/multi-capture-comparison.md
+++ b/docs/design/multi-capture-comparison.md
@@ -218,7 +218,7 @@ calls. Under comparison it becomes the exact operation wanted, and the refusal
 must be relaxed *only* for a confirmed cross-session pair — not removed.
 
 The MCP surface has the single-capture ancestor of all three: `compare_dialogs`
-([`server.rs:4986`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4986)) takes two Call-IDs, projects state,
+([`server.rs:4964`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4964)) takes two Call-IDs, projects state,
 final status code, message count, methods and hints for each, and names the keys
 that differ. Its shape is right and its scope is one store — both Call-IDs are
 looked up in the same `dialog_store`. Extending it to cross sessions is the same

--- a/docs/design/process-isolation-and-hot-path-cost.md
+++ b/docs/design/process-isolation-and-hot-path-cost.md
@@ -276,7 +276,7 @@ the most expensive thing in the critical section, and it is there by accident.
 
 The nested `AlertEngine` lock is worse than it currently looks. The ordering
 `stores → alerts` exists only on this path; `security_findings`
-([`mcp/server.rs:4428`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4428)) takes `alerts.read()` and no
+([`mcp/server.rs:4406`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4406)) takes `alerts.read()` and no
 store lock, so there is no deadlock **today**. Nothing writes that ordering
 down, and nothing enforces it. The next MCP tool that reads an alert and then a
 dialog deadlocks the capture.

--- a/docs/design/testing-matrix.md
+++ b/docs/design/testing-matrix.md
@@ -27,12 +27,30 @@ The tiers above `parsed` need a human to distinguish "a test names this" from
 no row here should be read as a mutation-checked guarantee unless a person
 put it there.
 
+HTTP routes and MCP tools are not command-line arguments and use their own two
+tiers:
+
+| Tier | Established by | What it proves |
+|---|---|---|
+| `exercised` | the route or tool is named in a test file that also drives a running surface | a test reached it through the door users reach it through |
+| `defined only` | it is named, but nowhere that drives anything | it exists; nothing here reached it |
+
+"Drives a running surface" means the file uses one of a named set of client
+idioms -- the REST test harness, a raw socket, an MCP session, a `tools/call`.
+A route is matched allowing for its path parameters, because a test writes
+`format!("/v1/streams/{ssrc}")` or a concrete SSRC where the route says
+`{id}`. Both of those rules used to be substring tests, and both were wrong in
+the direction of a wrong answer rather than no answer: `serve(` matched
+`observe(` in a file that drives nothing, and matching a route literally
+reported every parameterized route as `defined only` while the REST test suite
+was driving all of them.
+
 ## Totals
 
 | Surface | Rows | `e2e` | `parsed` | `referenced` | `none` |
 |---|---|---|---|---|---|
 | CLI flags | 230 | 112 | 37 | 80 | 1 |
-| HTTP routes | 8 | 5 | -- | 3 | 0 |
+| HTTP routes | 8 | 8 | -- | 0 | 0 |
 | MCP tools | 37 | 37 | -- | 0 | 0 |
 
 **Flags with no occurrence at all:** `--syslog`
@@ -301,13 +319,13 @@ behind them.
 | Route | Evidence | Where |
 |---|---|---|
 | `/health` | exercised | `tests/api_test.rs` |
-| `/metrics` | exercised | `tests/api_test.rs` |
-| `/v1/dialogs` | exercised | `tests/api_test.rs` |
-| `/v1/dialogs/{call_id}` | defined only | `src/output/api.rs` |
-| `/v1/dialogs/{call_id}/report` | defined only | `src/output/api.rs` |
-| `/v1/stats` | exercised | `tests/api_test.rs`, `tests/config_wiring_test.rs` +1 |
-| `/v1/streams` | exercised | `tests/api_test.rs` |
-| `/v1/streams/{id}` | defined only | `src/output/api.rs` |
+| `/metrics` | exercised | `tests/api_test.rs`, `tests/api_token_test.rs` +2 |
+| `/v1/dialogs` | exercised | `tests/api_operator_flows_test.rs`, `tests/api_test.rs` +2 |
+| `/v1/dialogs/{call_id}` | exercised | `tests/api_operator_flows_test.rs`, `tests/api_test.rs` |
+| `/v1/dialogs/{call_id}/report` | exercised | `tests/api_test.rs` |
+| `/v1/stats` | exercised | `tests/api_test.rs`, `tests/api_token_test.rs` +3 |
+| `/v1/streams` | exercised | `tests/api_operator_flows_test.rs`, `tests/api_test.rs` +1 |
+| `/v1/streams/{id}` | exercised | `tests/api_operator_flows_test.rs`, `tests/api_test.rs` |
 
 ## MCP tools
 
@@ -315,38 +333,38 @@ behind them.
 |---|---|---|
 | `aggregate_dialogs` | exercised | `tests/mcp_stdio_test.rs` |
 | `capture_health` | exercised | `tests/mcp_stdio_test.rs` |
-| `capture_status` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_scope_test.rs` +2 |
-| `check_codec_negotiation` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_stdio_test.rs` |
+| `capture_status` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_open_capture_test.rs` +5 |
+| `check_codec_negotiation` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_operator_flows_test.rs` +1 |
 | `compare_dialogs` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_stdio_test.rs` |
 | `diagnose_registration` | exercised | `tests/mcp_stdio_test.rs` |
 | `explain_response_code` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_stdio_test.rs` |
-| `explain_rule` | exercised | `tests/mcp_lint_tools_test.rs`, `tests/mcp_stdio_test.rs` |
+| `explain_rule` | exercised | `tests/mcp_lint_tools_test.rs`, `tests/mcp_operator_flows_test.rs` +1 |
 | `export_audio` | exercised | `tests/mcp_stdio_test.rs` |
 | `export_capture` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_stdio_test.rs` |
-| `find_correlated` | exercised | `tests/mcp_stdio_test.rs` |
-| `find_problems` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_stdio_test.rs` |
+| `find_correlated` | exercised | `tests/leg_correlation_window_test.rs`, `tests/mcp_operator_flows_test.rs` +1 |
+| `find_problems` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_operator_flows_test.rs` +1 |
 | `get_capture_report` | exercised | `tests/mcp_stdio_test.rs` |
-| `get_dialog` | exercised | `tests/mcp_stdio_test.rs` |
-| `get_dialog_report` | exercised | `tests/mcp_stdio_test.rs` |
+| `get_dialog` | exercised | `tests/mcp_operator_flows_test.rs`, `tests/mcp_stdio_test.rs` |
+| `get_dialog_report` | exercised | `tests/mcp_operator_flows_test.rs`, `tests/mcp_stdio_test.rs` |
 | `get_message` | exercised | `tests/mcp_stdio_test.rs` |
-| `get_sdp_timeline` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_stdio_test.rs` |
-| `lint_dialog` | exercised | `tests/mcp_lint_tools_test.rs`, `tests/mcp_stdio_test.rs` |
+| `get_sdp_timeline` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_operator_flows_test.rs` +1 |
+| `lint_dialog` | exercised | `tests/mcp_lint_tools_test.rs`, `tests/mcp_operator_flows_test.rs` +1 |
 | `list_captures` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_stdio_test.rs` |
-| `list_dialogs` | exercised | `tests/config_wiring_test.rs`, `tests/mcp_diagnostic_tools_test.rs` +1 |
+| `list_dialogs` | exercised | `tests/config_wiring_test.rs`, `tests/mcp_diagnostic_tools_test.rs` +3 |
 | `list_tls_libraries` | exercised | `tests/mcp_stdio_test.rs` |
 | `media_diagnostics` | exercised | `tests/mcp_media_diagnostics_test.rs`, `tests/mcp_stdio_test.rs` |
-| `open_capture` | exercised | `tests/mcp_stdio_test.rs` |
-| `render_ladder` | exercised | `tests/mcp_stdio_test.rs` |
-| `rtp_stats` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_stdio_test.rs` |
-| `save_findings` | exercised | `tests/config_wiring_test.rs`, `tests/mcp_stdio_test.rs` |
+| `open_capture` | exercised | `tests/mcp_open_capture_test.rs`, `tests/mcp_stdio_test.rs` |
+| `render_ladder` | exercised | `tests/mcp_operator_flows_test.rs`, `tests/mcp_stdio_test.rs` |
+| `rtp_stats` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_operator_flows_test.rs` +1 |
+| `save_findings` | exercised | `tests/config_wiring_test.rs`, `tests/mcp_save_findings_test.rs` +1 |
 | `search_by_time` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_stdio_test.rs` |
 | `search_messages` | exercised | `tests/config_wiring_test.rs`, `tests/mcp_stdio_test.rs` |
-| `security_findings` | exercised | `tests/mcp_stdio_test.rs` |
-| `server_capabilities` | exercised | `tests/mcp_stdio_test.rs` |
-| `show_evidence` | exercised | `tests/mcp_stdio_test.rs` |
+| `security_findings` | exercised | `tests/mcp_operator_flows_test.rs`, `tests/mcp_stdio_test.rs` |
+| `server_capabilities` | exercised | `tests/mcp_open_capture_test.rs`, `tests/mcp_stdio_test.rs` |
+| `show_evidence` | exercised | `tests/mcp_operator_flows_test.rs`, `tests/mcp_stdio_test.rs` |
 | `shutdown_server` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_scope_test.rs` +1 |
 | `start_tls_capture` | exercised | `tests/mcp_stdio_test.rs` |
 | `stop_tls_capture` | exercised | `tests/mcp_stdio_test.rs` |
-| `tail_dialogs` | exercised | `tests/mcp_stdio_test.rs` |
-| `triage_call` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_stdio_test.rs` |
+| `tail_dialogs` | exercised | `tests/mcp_open_capture_test.rs`, `tests/mcp_operator_flows_test.rs` +1 |
+| `triage_call` | exercised | `tests/mcp_diagnostic_tools_test.rs`, `tests/mcp_operator_flows_test.rs` +1 |
 | `validate_message` | exercised | `tests/mcp_lint_tools_test.rs`, `tests/mcp_stdio_test.rs` |

--- a/docs/mos-and-codecs.md
+++ b/docs/mos-and-codecs.md
@@ -19,9 +19,23 @@ The short version:
 | G.722, G.726, iLBC, everything else | Not implemented | Placeholder, flagged |
 
 Anything in the last three rows scores **4.216 at 10 ms jitter — the same value
-an unidentified stream gets.** That is a placeholder, not a measurement. Tools
-that publish it say so: the `rtp_stats` MCP tool carries `mos_grounded: false`,
-`mos_grounding: "unpublished"` and a note.
+an unidentified stream gets.** That is a placeholder, not a measurement.
+
+Every door that publishes the number publishes what it is worth, in the same
+words:
+
+| Surface | How it says so |
+|---------|----------------|
+| MCP `rtp_stats` | `mos_grounded: false`, `mos_grounding: "unpublished"`, `mos_note` |
+| `GET /v1/streams` | the same three keys on every row |
+| `GET /v1/streams?mos_below=` | **never selects an ungrounded stream**, and reports `ungrounded_excluded` |
+| MCP `search_streams` with `min_mos`/`max_mos` | the same refusal, and the same count |
+| TUI stream detail | the score renders muted rather than in a quality band, annotated `no published Ie` |
+
+The filters are the part that matters most. A placeholder is a *high-looking*
+number that means nothing, so a MOS bound applied without the grounding test
+returns every stream sipnab could not score, dressed as a bad call — and an
+operator working a bad-call list goes down it top to bottom.
 
 ## Declaring an impairment factor sipnab does not have
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -4,7 +4,9 @@ sipnab includes an optional REST API and Prometheus metrics endpoint, enabled wi
 
 [CLI Reference](cli-reference.md#network-listeners) catalogs every API flag.
 
-> **Looking for AI-agent access?** sipnab also exposes the same dialog / RTP / diagnostic data as a Model Context Protocol server. See [MCP Server](mcp.md) -- the MCP path uses the same in-memory stores as this REST API, so a running sipnab instance can serve both surfaces simultaneously.
+> **Looking for AI-agent access?** sipnab also serves the dialog / RTP / diagnostic stores over the Model Context Protocol. See [MCP Server](mcp.md) -- both doors read the same in-memory stores in the same process, so one running instance can serve both at once.
+>
+> The two response *shapes* are converging deliberately and are not yet identical. Where a metric is reachable through one door and not the other, that is drift rather than design: [`tests/surface_parity_test.rs`](https://github.com/NormB/sipnab/blob/main/tests/surface_parity_test.rs) fails the build on it, and the fix is always to add the metric to the missing surface.
 
 ## Getting started
 
@@ -745,7 +747,7 @@ List all tracked RTP streams with quality metrics.
 | Parameter  | Type  | Default | Description |
 |------------|-------|---------|-------------|
 | `orphaned` | bool  | --      | `true` keeps only streams no dialog claims, `false` only those one does. The test is the stream's dialog association, applied from the stream's first packet, so `orphaned=true` catches short unclaimed streams as well as long ones |
-| `mos_below`| float | --      | Filter streams with MOS below this threshold |
+| `mos_below`| float | --      | Keep only streams whose **grounded** estimated MOS is strictly below this threshold. Streams whose codec has no impairment value score a placeholder meaning "unknown", not a low score, and are never selected by this filter -- `ungrounded_excluded` in the response counts what the filter skipped |
 | `limit`    | int   | 50      | Maximum results. Ceiling is `--api-max-rows` (1000 by default), not a fixed limit |
 | `offset`   | int   | 0       | Pagination offset |
 
@@ -815,10 +817,11 @@ streams.forEach(s =>
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "total": 14,
   "offset": 0,
   "limit": 50,
+  "ungrounded_excluded": 0,
   "streams": [
     {
       "ssrc": "0x1a2b3c4d",
@@ -830,11 +833,48 @@ streams.forEach(s =>
       "loss_pct": 0.0,
       "orphaned": false,
       "associated_dialog": "12013223@203.0.113.195",
-      "mos": 4.2
+      "mos": 4.2,
+      "mos_grounded": true,
+      "mos_grounding": "published"
     }
   ]
 }
 ```
+
+#### What the MOS is worth
+
+`mos` is always a number, on every stream. It is not always a measurement.
+
+sipnab scores MOS with the ITU-T G.107 E-model, which needs an equipment
+impairment factor (`Ie`) for the codec. G.113 publishes one for some codecs and
+not for others, and for a codec with none the score falls back to a placeholder
+that means **"unknown"** -- not "about 4.2", even though 4.2 is roughly what it
+prints. A placeholder and a genuine G.711 estimate are byte-identical in the
+`mos` field.
+
+Three keys keep them apart:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `mos_grounded` | bool | `true` when `mos` rests on a real impairment value. Always present -- every stream has a grounding, and an absent key would read as "unknown", which is a different claim |
+| `mos_grounding` | string | Which one: `published` (ITU-T G.113), `operator_declared` (this deployment's `[media.codec_ie]`), or `unpublished` (the placeholder) |
+| `mos_note` | string | The caveat, when there is one. **Absent** for a `published` score, which has nothing to disclose |
+
+sipnab keeps `published` and `operator_declared` apart because the remedies
+differ: a published score that looks wrong means suspecting sipnab's vantage
+point, a declared one means suspecting a file on your own disk.
+
+Act on `mos_grounded` before acting on `mos`. Otherwise a dashboard that sorts
+by MOS and shows the worst ten fills with streams nobody ever scored.
+
+> **`schema_version` 2.** Version 1 served `mos` with no grounding beside it,
+> and its `mos_below` filter selected placeholders. A client that reads only
+> the fields it knows sees no change; a client asserting on the exact key set
+> does.
+
+The MCP `rtp_stats` tool carries the same three keys, and the TUI's stream
+detail view draws the same distinction: an ungrounded score renders muted and
+annotated rather than in a quality band color.
 
 ---
 

--- a/scripts/coverage-matrix.py
+++ b/scripts/coverage-matrix.py
@@ -131,6 +131,40 @@ def parse_call_spans(text):
     return spans
 
 
+# What actually drives a running surface in THIS repository's tests.
+#
+# Each entry is a real client-side idiom, and each is matched on a WHOLE
+# IDENTIFIER rather than as a substring. The substring version of this list was
+# wrong in the worst available way -- quietly, and in the direction of claiming
+# coverage:
+#
+#   * `serve(` matched `observe(`, a local helper in
+#     tests/arrival_order_parity_test.rs that has nothing to do with a server.
+#     That file drives nothing, and every route or tool name it happened to
+#     mention would have been reported as EXERCISED.
+#   * `serve(` also matched `fn tls_flags_fail_fast_and_do_not_serve()`, which
+#     is a test asserting the server did NOT start. tests/api_test.rs does drive
+#     a server, thoroughly -- but the evidence this script cited for it was a
+#     function name saying the opposite, and renaming that one test would have
+#     silently downgraded every REST row in the matrix.
+#
+# `reqwest` was in the list and appears nowhere in the tree, which is the
+# harmless half of the same mistake: a marker nobody can trigger.
+SERVER_DRIVERS = (
+    # REST: the in-tree harness that spawns a real sipnab and speaks HTTP to it.
+    "ApiServer",
+    # REST/metrics: a raw socket against a listening port.
+    "TcpStream",
+    # MCP over stdio: the JSON-RPC method, and the harness that sends it.
+    "tools/call",
+    "call_tool",
+    "call_tool_with_args",
+    "McpSession",
+    # axum's own test path: a router driven in-process without a socket.
+    "oneshot",
+)
+
+
 def drives_server(text):
     """Does this file actually exercise a running surface?
 
@@ -138,19 +172,58 @@ def drives_server(text):
     CLI-shaped checks above cannot see them and every row collapsed to
     `referenced` -- a column that says the same thing about all 45 of them
     tells a reader nothing.
+
+    Whole-identifier matching, for the reason SERVER_DRIVERS records above.
     """
-    return any(
-        m in text
-        for m in ("serve(", "reqwest", "TcpStream", "tools/call", "call_tool")
-    )
+    return any(uses_identifier(text, m) for m in SERVER_DRIVERS)
 
 
-def classify_surface(name, files):
+def uses_identifier(hay, needle):
+    """Does `hay` use `needle` as a whole identifier?
+
+    The same rule tests/surface_parity_test.rs applies, and for the same reason:
+    a substring match reports a coincidence as evidence.
+    """
+    n = len(needle)
+    for i in range(len(hay)):
+        if not hay.startswith(needle, i):
+            continue
+        before = hay[i - 1] if i else ""
+        after = hay[i + n] if i + n < len(hay) else ""
+        if (before.isalnum() or before == "_") or (after.isalnum() or after == "_"):
+            continue
+        return True
+    return False
+
+
+def route_pattern(route):
+    """A regex matching every way a test can write `route`.
+
+    Axum spells a path parameter `{call_id}`; a test writes either its OWN
+    placeholder name -- `format!("/v1/streams/{ssrc}")`, which is the literal
+    text of an inline format argument -- or a concrete value,
+    `"/v1/dialogs/12013223@example"`. Neither is the route string, so matching
+    the route literally reported all three of sipnab's parameterized routes as
+    `defined only` while tests/api_test.rs was driving every one of them.
+
+    Each `{...}` becomes one path segment. The match is anchored on the right by
+    a lookahead for `"` or `?`, so `/v1/dialogs/{call_id}` is NOT credited by a
+    request to `/v1/dialogs/x/report` -- a different route, with its own row.
+    """
+    parts = re.split(r"\{[^}]*\}", route)
+    return re.compile(r'[^"/?]+'.join(re.escape(p) for p in parts) + r'(?=["?])')
+
+
+def classify_surface(name, files, is_route=False):
     """Evidence for a route or a tool: exercised by a test, or only defined."""
     exercised, defined = [], []
+    pattern = route_pattern(name) if is_route else None
     quoted = f'"{name}"'
     for path, text in files.items():
-        if quoted not in text:
+        if pattern is not None:
+            if not pattern.search(text):
+                continue
+        elif quoted not in text:
             continue
         rel = str(path.relative_to(ROOT))
         if rel.startswith("tests/") and drives_server(text):
@@ -309,7 +382,7 @@ def main():
 
     route_rows = []
     for r in routes:
-        tier, where = classify_surface(r, files)
+        tier, where = classify_surface(r, files, is_route=True)
         route_rows.append([f"`{r}`", tier, cite(where)])
 
     tool_rows = []
@@ -363,6 +436,24 @@ The tiers above `parsed` need a human to distinguish "a test names this" from
 "a test would fail if this broke". This generator does not guess at that, and
 no row here should be read as a mutation-checked guarantee unless a person
 put it there.
+
+HTTP routes and MCP tools are not command-line arguments and use their own two
+tiers:
+
+| Tier | Established by | What it proves |
+|---|---|---|
+| `exercised` | the route or tool is named in a test file that also drives a running surface | a test reached it through the door users reach it through |
+| `defined only` | it is named, but nowhere that drives anything | it exists; nothing here reached it |
+
+"Drives a running surface" means the file uses one of a named set of client
+idioms -- the REST test harness, a raw socket, an MCP session, a `tools/call`.
+A route is matched allowing for its path parameters, because a test writes
+`format!("/v1/streams/{{ssrc}}")` or a concrete SSRC where the route says
+`{{id}}`. Both of those rules used to be substring tests, and both were wrong in
+the direction of a wrong answer rather than no answer: `serve(` matched
+`observe(` in a file that drives nothing, and matching a route literally
+reported every parameterized route as `defined only` while the REST test suite
+was driving all of them.
 
 ## Totals
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -160,8 +160,13 @@ step "vale (CI-pinned version)"
 # runners. `degraded` and not `ok` for return 2: under PREFLIGHT_STRICT=1 --
 # the DEFAULT whenever stdout is not a tty, so a log file, a CI job or an agent
 # -- that sets FAILED=1, because a gate that could not run must not read green.
-prose_vale_run
-case $? in
+# `&& rc=0 || rc=$?`, matching .githooks/pre-commit and .githooks/pre-push.
+# This script runs without `set -e`, so a bare call would survive here today --
+# and would start dying silently the moment someone added it, which is exactly
+# how the hooks lost their vale output. One spelling, everywhere, so the
+# difference cannot come back.
+prose_vale_run && prose_rc=0 || prose_rc=$?
+case $prose_rc in
 0)
     ok
     ;;
@@ -205,8 +210,8 @@ _root=$(git rev-parse --show-toplevel 2>/dev/null) &&
 . "$PROSE_LIB"
 step "codespell"
 # Paths and resolution from scripts/prose-gates.sh, as above.
-prose_codespell_run
-case $? in
+prose_codespell_run && prose_rc=0 || prose_rc=$?
+case $prose_rc in
 0)
     ok
     ;;

--- a/scripts/test-pre-commit.sh
+++ b/scripts/test-pre-commit.sh
@@ -681,6 +681,81 @@ grep -q 'if ! UNWRAP_OUT=\$(python3 scripts/check-unwrap.py' "$HOOK" \
 	&& ok "hook reads the scanner's exit status" \
 	|| bad "hook must branch on the scanner's exit status, not parse its output"
 
+# ── Scenario 7: a prose gate that FINDS something says what it found ───────
+# The regression: `set -e` is on, `prose_vale_run` is a simple command, and the
+# CONTRACT in scripts/prose-gates.sh has it return 1 for "the tool ran and found
+# something". `set -e` therefore killed the hook on that return -- BEFORE the
+# `case $?` written to render it -- and before the `rm -f "$PROSE_OUTPUT"` that
+# would at least have left the findings on disk. What an operator saw was the
+# literal string `  Vale... ` and exit 1: no findings, no file names, no
+# "Commit blocked" line, and nothing to distinguish a prose failure from a hook
+# that crashed. Measured 2026-08-24 against the real hook.
+#
+# Both gates are exercised, because they are two copies of one shape and the
+# first fix touched only one of them.
+prose_sandbox() { # prose_sandbox <vale-exit> <codespell-exit>; echoes the dir
+	_p=$(sandbox 100)
+	mkdir -p "$_p/.github/workflows" "$_p/.config"
+	cp "$REPO_ROOT/scripts/prose-gates.sh" "$_p/scripts/"
+	# The pin the stub below must match. prose_vale_pin() reads it from here,
+	# and a mismatch is return 2 (NOT CHECKED), which is neither arm under test.
+	printf "env:\n  VALE_VERSION: '9.9.9'\n" > "$_p/.github/workflows/quality.yml"
+	echo 'docs' > "$_p/.config/vale-paths.txt"
+	echo 'docs' > "$_p/.config/codespell-paths.txt"
+	mkdir -p "$_p/docs"
+	echo 'Some prose.' > "$_p/docs/page.md"
+
+	cat > "$_p/bin/vale" <<-EOF
+		#!/bin/sh
+		case "\$1" in --version) echo "vale version 9.9.9"; exit 0 ;; esac
+		echo "docs/page.md:1:1  error  A findable prose problem  Some.Rule"
+		exit $1
+	EOF
+	cat > "$_p/bin/codespell" <<-EOF
+		#!/bin/sh
+		echo "docs/page.md:1: a findable spelling problem"
+		exit $2
+	EOF
+	chmod +x "$_p/bin/vale" "$_p/bin/codespell"
+	( cd "$_p" && git add -A && git commit -qm prose )
+	echo "$_p"
+}
+
+D=$(prose_sandbox 1 0)
+run_hook "$D"
+if printf '%s' "$HOOK_OUT" | grep -q 'A findable prose problem'; then
+	ok "a vale finding reaches the operator instead of dying with set -e"
+else
+	bad "vale found something and the hook printed nothing about it: $HOOK_OUT"
+fi
+if [ "$HOOK_RC" -ne 0 ] && printf '%s' "$HOOK_OUT" | grep -q 'Commit blocked'; then
+	ok "a vale finding blocks the commit, and says so"
+else
+	bad "a vale finding must block and name itself; rc=$HOOK_RC out: $HOOK_OUT"
+fi
+rm -rf "$D"
+
+D=$(prose_sandbox 0 1)
+run_hook "$D"
+if printf '%s' "$HOOK_OUT" | grep -q 'a findable spelling problem'; then
+	ok "a codespell finding reaches the operator too"
+else
+	bad "codespell found something and the hook printed nothing about it: $HOOK_OUT"
+fi
+rm -rf "$D"
+
+# The clean arm, so the two above are not passing because the hook prints
+# everything unconditionally: with both tools silent the gate must say OK and
+# carry on to the gates after it.
+D=$(prose_sandbox 0 0)
+run_hook "$D"
+if printf '%s' "$HOOK_OUT" | grep -q 'Vale... .*OK'; then
+	ok "a clean tree passes the prose gates rather than reporting a finding"
+else
+	bad "a clean prose run must render OK: $HOOK_OUT"
+fi
+rm -rf "$D"
+
 printf '\n%d passed, %d failed, %d skipped (host: %s)\n' \
 	"$PASS" "$FAIL" "$SKIP" "$(uname -s)"
 if [ "$SKIP" -ne 0 ]; then

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2648,36 +2648,13 @@ fn stream_json(
         );
         obj.insert(
             "mos_grounding".into(),
-            serde_json::Value::String(mos_grounding_label(grounding).into()),
+            serde_json::Value::String(grounding.as_str().into()),
         );
-        match grounding {
-            crate::rtp::quality::MosGrounding::Published => {}
-            // Said out loud, because the number now looks exactly like a
-            // grounded G.711 score and did not come from a standard. An agent
-            // that cites it should cite the operator, not ITU-T G.113.
-            crate::rtp::quality::MosGrounding::OperatorDeclared => {
-                obj.insert(
-                    "mos_note".into(),
-                    serde_json::Value::String(
-                        "ITU-T G.113 publishes no impairment value for this codec; \
-                         this deployment declared the one used, in \
-                         [media.codec_ie]. The MOS is an estimate on the \
-                         operator's figure, not on a published one."
-                            .into(),
-                    ),
-                );
-            }
-            crate::rtp::quality::MosGrounding::Unpublished => {
-                obj.insert(
-                    "mos_note".into(),
-                    serde_json::Value::String(
-                        "No published ITU-T G.113 impairment value for this codec, \
-                         and none declared in [media.codec_ie]. The MOS is a \
-                         placeholder meaning 'unknown', not an estimate."
-                            .into(),
-                    ),
-                );
-            }
+        // The caveat, from the same enum that named the grounding, so an agent
+        // cannot be told `operator_declared` under a sentence about G.113.
+        // `None` is the Published case and is emitted as nothing at all.
+        if let Some(note) = grounding.note() {
+            obj.insert("mos_note".into(), serde_json::Value::String(note.into()));
         }
 
         // Latency, the third of the three numbers that decide whether a call
@@ -2756,10 +2733,10 @@ fn stream_mos(s: &crate::rtp::stream::RtpStream, delay: crate::rtp::quality::Mos
 /// opposite of what happened. WHICH of the two grounded it is the separate
 /// question `mos_grounding` answers below.
 fn mos_is_grounded(s: &crate::rtp::stream::RtpStream) -> bool {
-    !matches!(
-        crate::rtp::quality::mos_grounding(s.codec.as_deref()),
-        crate::rtp::quality::MosGrounding::Unpublished
-    )
+    // One definition site: `quality::mos_is_grounded`. This wrapper only
+    // adapts a stream to it, so REST and MCP cannot drift on what "grounded"
+    // means -- which they had, and REST was the one that was wrong.
+    crate::rtp::quality::mos_is_grounded(s.codec.as_deref())
 }
 
 /// The QoS marking block of a `media_diagnostics` stream.
@@ -2933,19 +2910,6 @@ fn endpoint_reported_json(
         );
     }
     Some(v)
-}
-/// The name `rtp_stats` publishes for where this stream's `Ie` came from.
-///
-/// A separate field from `mos_grounded` because the remedies differ: a
-/// `published` score that looks wrong means suspecting sipnab's vantage point,
-/// an `operator_declared` one means suspecting a file on the operator's own
-/// disk, and an `unpublished` one means the number was never an estimate.
-fn mos_grounding_label(grounding: crate::rtp::quality::MosGrounding) -> &'static str {
-    match grounding {
-        crate::rtp::quality::MosGrounding::Published => "published",
-        crate::rtp::quality::MosGrounding::OperatorDeclared => "operator_declared",
-        crate::rtp::quality::MosGrounding::Unpublished => "unpublished",
-    }
 }
 /// The tie-break half of a stream cursor: `0xSSRC@src>dst`.
 ///

--- a/src/output/api.rs
+++ b/src/output/api.rs
@@ -796,16 +796,28 @@ async fn get_dialog_report(
 /// * `addr` — Client socket address used for rate limiting.
 /// * `headers` — Request headers (auth).
 /// * `params` — Offset/limit pagination plus `orphaned` (exact match) and
-///   `mos_below` (streams whose estimated MOS is strictly below the
+///   `mos_below` (streams whose GROUNDED estimated MOS is strictly below the
 ///   threshold) filters.
+///
+/// `mos_below` admits only streams whose MOS is a measurement. A codec with no
+/// published impairment value scores a placeholder that means "unknown", and
+/// the placeholder is low, so a bound applied without that test returns every
+/// unscoreable stream dressed as a bad one. How many were held back is
+/// reported rather than hidden — see `ungrounded_excluded` below.
 ///
 /// # Returns
 ///
-/// 200 with `{schema_version, total, offset, limit, streams}` where
-/// `total` is the FILTERED result-set size (the count the returned rows are
-/// drawn from, after `orphaned`/`mos_below` filters), so paging by `total`
-/// terminates correctly; 401/503 from the guard. `limit` is clamped to
-/// `--api-max-rows` (default 1000).
+/// 200 with `{schema_version, total, offset, limit, ungrounded_excluded,
+/// streams}` where `total` is the FILTERED result-set size (the count the
+/// returned rows are drawn from, after `orphaned`/`mos_below` filters), so
+/// paging by `total` terminates correctly, and `ungrounded_excluded` is how
+/// many streams `mos_below` skipped for want of a grounded score (always 0
+/// when `mos_below` is absent, because nothing was bounded); 401/503 from the
+/// guard. `limit` is clamped to `--api-max-rows` (default 1000).
+///
+/// `schema_version` is 2. Version 1 served a `mos` with no grounding beside it
+/// and a `mos_below` that selected placeholders; each row now carries
+/// `mos_grounded`, `mos_grounding` and, when there is a caveat, `mos_note`.
 ///
 /// # Side effects
 ///
@@ -834,6 +846,11 @@ async fn list_streams(
     // Materialize the FILTERED set first so `total` reflects what the page is
     // drawn from (see `list_dialogs`); the unfiltered store size would break a
     // client paging by `total`.
+    // Streams a `mos_below` bound would have selected on a placeholder, and
+    // did not. Counted rather than silently dropped: a caller asking "show me
+    // bad calls" who gets four rows must be able to tell that from the same
+    // four rows out of a store where sixty streams could not be scored at all.
+    let mut ungrounded_excluded = 0usize;
     let filtered: Vec<&crate::rtp::stream::RtpStream> = ss
         .iter()
         .filter(|s| {
@@ -843,6 +860,17 @@ async fn list_streams(
                 return false;
             }
             if let Some(threshold) = mos_threshold {
+                // Grounding first, and independently of the bound. An
+                // unpublished codec scores the placeholder, the placeholder is
+                // low, and a `mos_below` filter without this test returns every
+                // stream sipnab could not score AS IF it had scored them badly
+                // -- which is the one answer worse than returning nothing. MCP
+                // has tested this since `min_mos` existed; REST had not, and
+                // both now decide through `quality::mos_is_grounded`.
+                if !quality::mos_is_grounded(s.codec.as_deref()) {
+                    ungrounded_excluded += 1;
+                    return false;
+                }
                 let mos = approximate_mos(s, delay);
                 if mos >= threshold {
                     return false;
@@ -862,10 +890,11 @@ async fn list_streams(
     drop(ss);
 
     Ok(Json(json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "total": total,
         "offset": offset,
         "limit": limit,
+        "ungrounded_excluded": ungrounded_excluded,
         "streams": streams,
     })))
 }
@@ -1944,6 +1973,19 @@ mod tests {
     /// Returns after a single packet so the stream exists with `packet_count`
     /// of at least 1 and no loss/jitter (MOS near the codec ceiling).
     fn add_stream(state: &ApiState, ssrc: u32, src_port: u16, dst_port: u16) {
+        // PT 0 is PCMU, which G.113 publishes an impairment value for -- so
+        // every stream built by this helper carries a GROUNDED MOS. Tests that
+        // need the other case say so by naming a payload type.
+        add_stream_with_pt(state, ssrc, src_port, dst_port, 0);
+    }
+
+    /// `add_stream`, with the RTP payload type spelled out.
+    ///
+    /// Exists because grounding is decided by the codec and nothing else: a
+    /// dynamic payload type with no SDP to name it leaves `codec` unknown, and
+    /// an unknown codec scores the placeholder. That is the stream a
+    /// `mos_below` bound must refuse to select.
+    fn add_stream_with_pt(state: &ApiState, ssrc: u32, src_port: u16, dst_port: u16, pt: u8) {
         use crate::capture::parse::TransportProto;
         use crate::rtp::parser::RtpHeader;
 
@@ -1971,7 +2013,7 @@ mod tests {
             extension: false,
             csrc_count: 0,
             marker: false,
-            payload_type: 0, // PCMU
+            payload_type: pt,
             sequence: 1,
             timestamp: 160,
             ssrc,
@@ -2050,6 +2092,112 @@ mod tests {
             // total reflects the filtered result-set (1), not the store's 2.
             assert_eq!(parsed["total"], 1, "{query} reported the store size");
         }
+    }
+
+    /// A `mos_below` bound selects only streams whose MOS is a MEASUREMENT,
+    /// and reports how many it held back for want of one.
+    ///
+    /// The bug this pins: a codec sipnab has no impairment value for still
+    /// scores a number, because every surface showing MOS predates the
+    /// distinction and a sudden `Option` would break four of them at once.
+    /// That number is a placeholder standing in for "unknown". Applied without
+    /// a grounding test, `?mos_below=5.0` therefore returned every unscoreable
+    /// stream in the store dressed as a bad call -- and an operator triaging a
+    /// bridge would work the list top to bottom, chasing streams whose quality
+    /// nobody ever measured.
+    ///
+    /// MCP has tested this since `min_mos` existed. REST had not, which is the
+    /// whole reason both now decide through `quality::mos_is_grounded`.
+    ///
+    /// Two streams, identical but for the payload type: PT 0 is PCMU and
+    /// grounded; PT 96 is dynamic with no SDP to name it, so the codec is
+    /// unknown and the score is the placeholder. A bound generous enough to
+    /// admit both on the number alone must admit exactly one.
+    #[tokio::test]
+    async fn mos_below_refuses_to_select_on_a_placeholder_and_counts_what_it_held_back() {
+        let state = make_state();
+        add_stream_with_pt(&state, 0x5555_5555, 23000, 33000, 0);
+        add_stream_with_pt(&state, 0x6666_6666, 23002, 33002, 96);
+        let app = build_router(state);
+
+        let resp = app
+            .clone()
+            .oneshot(test_request("/v1/streams?mos_below=5.0"))
+            .await
+            .expect("oneshot");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let parsed: Value =
+            serde_json::from_str(&body_to_string(resp.into_body()).await).expect("valid JSON");
+
+        let rows = parsed["streams"].as_array().expect("array");
+        assert_eq!(
+            rows.len(),
+            1,
+            "a bound below 5.0 admitted the ungrounded stream: {}",
+            parsed["streams"]
+        );
+        assert_eq!(
+            rows[0]["ssrc"], "0x55555555",
+            "the wrong stream survived the bound"
+        );
+        assert!(
+            rows[0]["mos_grounded"].as_bool().expect("mos_grounded"),
+            "a row a MOS bound admitted must carry a grounded MOS"
+        );
+        assert_eq!(rows[0]["mos_grounding"], "published");
+        assert!(
+            rows[0].get("mos_note").is_none(),
+            "a published score has no caveat to disclose: {}",
+            rows[0]
+        );
+        assert_eq!(parsed["total"], 1, "total must count the filtered set");
+        assert_eq!(
+            parsed["ungrounded_excluded"], 1,
+            "the stream the bound could not score must be counted, not silently \
+             dropped -- four rows out of a store where sixty were unscoreable is \
+             a different answer from four out of four"
+        );
+    }
+
+    /// Without a bound there is nothing to hold back, and every row still says
+    /// what its MOS is worth.
+    ///
+    /// The counterpart to the test above, and the one that keeps its number
+    /// honest: a `ungrounded_excluded` that counted ungrounded streams
+    /// regardless of whether anything was filtered would report a store's
+    /// codec mix as an exclusion, on a request that excluded nothing.
+    #[tokio::test]
+    async fn an_unbounded_list_holds_nothing_back_and_still_grounds_every_row() {
+        let state = make_state();
+        add_stream_with_pt(&state, 0x7777_7777, 24000, 34000, 96);
+        let app = build_router(state);
+
+        let resp = app
+            .oneshot(test_request("/v1/streams"))
+            .await
+            .expect("oneshot");
+        let parsed: Value =
+            serde_json::from_str(&body_to_string(resp.into_body()).await).expect("valid JSON");
+
+        assert_eq!(parsed["schema_version"], 2);
+        assert_eq!(
+            parsed["ungrounded_excluded"], 0,
+            "nothing was bounded, so nothing was held back"
+        );
+        let row = &parsed["streams"][0];
+        assert_eq!(row["ssrc"], "0x77777777");
+        assert_eq!(
+            row["mos_grounded"], false,
+            "an unknown codec has no published impairment value"
+        );
+        assert_eq!(row["mos_grounding"], "unpublished");
+        assert!(
+            row["mos_note"]
+                .as_str()
+                .expect("an ungrounded score owes the reader a sentence")
+                .contains("placeholder"),
+            "the note must say the number is a placeholder: {row}"
+        );
     }
 
     /// `mos_below` excludes a clean high-MOS stream at 1.0 and includes it

--- a/src/output/model.rs
+++ b/src/output/model.rs
@@ -176,6 +176,37 @@ pub struct StreamSummary {
     pub associated_dialog: Option<String>,
     /// E-model MOS estimate (1.0–4.5).
     pub mos: f64,
+    /// Whether [`Self::mos`] rests on a real impairment value rather than the
+    /// placeholder.
+    ///
+    /// Carried beside the number because it is not visible in it. sipnab
+    /// returns the same score for a grounded G.711 stream and for a codec
+    /// nobody publishes an impairment value for, where the number means
+    /// "unknown" — see
+    /// [`MosGrounding::Unpublished`](crate::rtp::quality::MosGrounding::Unpublished).
+    /// A reader who cannot tell those apart will act on the second as if it
+    /// were the first.
+    ///
+    /// Not `Option`: every stream has a grounding, and an absent key would
+    /// read as "not known", which is a different and untrue claim.
+    pub mos_grounded: bool,
+    /// WHICH grounding: `published`, `operator_declared` or `unpublished`.
+    ///
+    /// A separate field from [`Self::mos_grounded`] because the remedies
+    /// differ. A `published` score that looks wrong means suspecting sipnab's
+    /// vantage point; an `operator_declared` one means suspecting a file on
+    /// the operator's own disk; an `unpublished` one means the number was
+    /// never an estimate. Collapsing the three into the boolean loses the
+    /// middle case entirely, and that is the case where the number is right
+    /// and the citation would be wrong.
+    pub mos_grounding: String,
+    /// The caveat that belongs beside [`Self::mos`], when there is one.
+    ///
+    /// Absent for a published score, where there is nothing to disclose.
+    /// Writing a reassurance there instead would train readers to skip the
+    /// field on the two occasions it carries a warning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mos_note: Option<String>,
     /// Pointer to the frame this stream's first packet arrived in, as
     /// `<source>#<ordinal>@<digest>`.
     ///
@@ -290,6 +321,7 @@ impl StreamSummary {
     #[must_use]
     pub fn of(s: &RtpStream, delay: crate::rtp::quality::MosDelay<'_>) -> Self {
         let loss_pct = s.loss_percent();
+        let grounding = crate::rtp::quality::mos_grounding(s.codec.as_deref());
         Self {
             ssrc: format!("0x{:08x}", s.key.ssrc),
             codec: s.codec.clone(),
@@ -301,6 +333,12 @@ impl StreamSummary {
             orphaned: s.orphaned(),
             associated_dialog: s.associated_dialog.clone(),
             mos: delay.score(s),
+            // Resolved once and destructured three ways, so the boolean, the
+            // label and the note cannot describe three different groundings of
+            // one stream. The vocabulary is the enum's, not this module's.
+            mos_grounded: grounding != crate::rtp::quality::MosGrounding::Unpublished,
+            mos_grounding: grounding.as_str().to_string(),
+            mos_note: grounding.note().map(ToString::to_string),
             // From the stream's own record of where it began. There is no
             // second source to derive it from: unlike a dialog, a stream
             // retains no packets at all.

--- a/src/rtp/quality.rs
+++ b/src/rtp/quality.rs
@@ -1283,6 +1283,53 @@ pub enum MosGrounding {
     Unpublished,
 }
 
+impl MosGrounding {
+    /// The wire spelling every surface serializes this as.
+    ///
+    /// One vocabulary in one place, the same rule
+    /// [`InputOrigin::as_str`](crate::capture::parse::InputOrigin::as_str) and
+    /// [`EndpointAssertion::as_str`](crate::rtp::stream_store::EndpointAssertion::as_str)
+    /// follow. It lived as a private `mos_grounding_label` inside the MCP
+    /// server, which is exactly how REST came to serve a MOS with no grounding
+    /// at all: the only spelling of the vocabulary was behind a door REST does
+    /// not open.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Published => "published",
+            Self::OperatorDeclared => "operator_declared",
+            Self::Unpublished => "unpublished",
+        }
+    }
+
+    /// The sentence a reader needs beside the number, or `None` when the score
+    /// is a plain published estimate and there is nothing to disclose.
+    ///
+    /// `None` is a real answer here and not an omission: a `Published` score
+    /// carries no caveat, and manufacturing one ("this MOS is fine") would
+    /// train readers to skip the field on the two occasions it matters.
+    #[must_use]
+    pub const fn note(self) -> Option<&'static str> {
+        match self {
+            Self::Published => None,
+            // Said out loud, because the number now looks exactly like a
+            // grounded G.711 score and did not come from a standard. Anything
+            // that cites it should cite the operator, not ITU-T G.113.
+            Self::OperatorDeclared => Some(
+                "ITU-T G.113 publishes no impairment value for this codec; \
+                 this deployment declared the one used, in [media.codec_ie]. \
+                 The MOS is an estimate on the operator's figure, not on a \
+                 published one.",
+            ),
+            Self::Unpublished => Some(
+                "No published ITU-T G.113 impairment value for this codec, \
+                 and none declared in [media.codec_ie]. The MOS is a \
+                 placeholder meaning 'unknown', not an estimate.",
+            ),
+        }
+    }
+}
+
 /// Whether [`estimate_mos`] can ground its answer for `codec`.
 ///
 /// Deliberately keyed on the same names the `match` in [`estimate_mos`] uses,
@@ -1301,6 +1348,23 @@ pub fn mos_grounding(codec: Option<&str>) -> MosGrounding {
         | Some("Opus") => MosGrounding::Published,
         _ => MosGrounding::Unpublished,
     }
+}
+
+/// Whether a MOS for this codec is a measurement rather than a placeholder.
+///
+/// The distinction is not cosmetic and it is not visible in the number.
+/// `MosGrounding::Unpublished` means "unknown", not "about 4.2", and the score
+/// sipnab returns for an unpublished codec is byte-identical to a grounded
+/// G.711 one. Anything that FILTERS on MOS has to consult this first, or it
+/// selects placeholders and presents them as findings.
+///
+/// Lifted here from a private helper in the MCP server, which was the only
+/// surface consulting it: `GET /v1/streams?mos_below=` did not, and silently
+/// returned every unpublished-codec stream whose placeholder fell below the
+/// bound. One rule, one definition site, every caller.
+#[must_use]
+pub fn mos_is_grounded(codec: Option<&str>) -> bool {
+    !matches!(mos_grounding(codec), MosGrounding::Unpublished)
 }
 
 /// Where a MOS shown beside a stream came from.

--- a/src/tui/stream_detail.rs
+++ b/src/tui/stream_detail.rs
@@ -150,10 +150,27 @@ pub fn render_stream_detail(
     // word it differently from the next one.
     let delay_note = format!("delay {one_way:.0}ms {}", delay_src.label());
 
+    // What that number MEANS, in the vocabulary the enum owns rather than one
+    // this view invents. sipnab returns the same digits for a grounded G.711
+    // score and for a codec nobody publishes an impairment value for, where the
+    // number is a placeholder standing in for "unknown" -- so the terminal has
+    // to say which it is, for the same reason RTT above renders `n/a` instead
+    // of 0. REST and MCP carry this as `mos_grounded`/`mos_grounding`; an
+    // operator at the terminal is looking at the same stream.
+    let grounding = crate::rtp::quality::mos_grounding(stream.codec.as_deref());
+    let grounded = crate::rtp::quality::mos_is_grounded(stream.codec.as_deref());
+
     let mos_band = MosBand::of(mos, quality_bands);
-    let mos_style = Style::default()
-        .fg(mos_band.color(theme))
-        .add_modifier(Modifier::BOLD);
+    // A band color on a placeholder is the lie in its most convincing form: it
+    // paints "unknown" bold green and calls it Good. Ungrounded scores render
+    // muted, so the color says what the number is worth.
+    let mos_style = if grounded {
+        Style::default()
+            .fg(mos_band.color(theme))
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.muted)
+    };
     let mos_label = mos_band.label();
 
     lines.push(section_header("Quality", theme));
@@ -161,6 +178,18 @@ pub fn render_stream_detail(
     lines.push(Line::from(vec![
         Span::raw("  MOS: "),
         Span::styled(format!("{mos:.1} ({mos_label})"), mos_style),
+        // Short enough for the triage row; the sentence behind it is on the
+        // APIs as `mos_note`. Empty for a published score, which needs no
+        // caveat -- a reassurance here would train the eye to skip the field
+        // on the two occasions it carries a warning.
+        Span::styled(
+            match grounding {
+                crate::rtp::quality::MosGrounding::Published => "",
+                crate::rtp::quality::MosGrounding::OperatorDeclared => " operator Ie",
+                crate::rtp::quality::MosGrounding::Unpublished => " no published Ie",
+            },
+            Style::default().fg(theme.muted),
+        ),
         Span::raw("    Jitter: "),
         Span::styled(
             format!("{:.1}ms", stream.jitter),

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -166,7 +166,14 @@ fn streams_endpoints_validate_against_stream_schema() {
     let resp = srv.get("/v1/streams");
     assert_eq!(resp.status, 200, "/v1/streams status");
     let body = resp.json();
-    assert_eq!(body["schema_version"], 1);
+    assert_eq!(body["schema_version"], 2);
+    // Present at zero on every response, not only on the ones that held
+    // something back: a key that shows up only when a filter bites is a key no
+    // client learns exists.
+    assert_eq!(
+        body["ungrounded_excluded"], 0,
+        "an unfiltered list bounded nothing, so it held nothing back: {body}"
+    );
     let streams = body["streams"].as_array().expect("streams array");
     assert!(!streams.is_empty(), "RTP fixture must yield streams");
     let ssrc = streams[0]["ssrc"]
@@ -182,10 +189,29 @@ fn streams_endpoints_validate_against_stream_schema() {
             "jitter_ms",
             "loss_pct",
             "mos",
+            // What that `mos` is worth, on the same row and never optional.
+            // A summary carrying the number without its grounding is the
+            // shape that let a placeholder pass for a measurement.
+            "mos_grounded",
+            "mos_grounding",
         ] {
             assert!(s.get(k).is_some(), "stream summary missing `{k}`");
         }
     }
+
+    // The fixture is G.711, which G.113 publishes an impairment value for, so
+    // this is the grounded arm end to end -- through a real server, a real
+    // pcap and a real HTTP response rather than a hand-built struct.
+    assert_eq!(
+        streams[0]["mos_grounding"], "published",
+        "sip-rtp-g711.pcap is PCMU: {}",
+        streams[0]
+    );
+    assert!(
+        streams[0]["mos_note"].is_null(),
+        "a published score has no caveat to disclose: {}",
+        streams[0]
+    );
 
     // Detail: the full StreamJson validates against the T1.3 stream schema.
     let stream_schema = load_validator("stream.schema.json");

--- a/tests/coverage_matrix_test.rs
+++ b/tests/coverage_matrix_test.rs
@@ -81,3 +81,81 @@ fn the_matrix_lists_every_flag_the_program_has() {
         stale.join(", "),
     );
 }
+
+/// Every HTTP route axum registers has a row, and none of them reads
+/// `defined only`.
+///
+/// The second half is the assertion with teeth, and it is here because the
+/// generator got it wrong in the direction that matters. Axum spells a path
+/// parameter `{call_id}`; a test writes its own placeholder --
+/// `format!("/v1/streams/{ssrc}")`, whose literal source text is what the
+/// generator reads -- or a concrete value. Matching the route string literally,
+/// all three of sipnab's parameterized routes reported `defined only` while
+/// `tests/api_test.rs` was driving every one of them, including the call-report
+/// route an operator reaches for first.
+///
+/// A document that understates coverage is as untrustworthy as one that
+/// overstates it: both stop being read. If a route genuinely has no test, the
+/// answer is to write the test, not to relax this.
+#[test]
+fn every_http_route_has_a_row_and_none_of_them_is_only_defined() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let matrix = std::fs::read_to_string(root.join("docs/design/testing-matrix.md"))
+        .expect("read testing-matrix.md");
+    let api = std::fs::read_to_string(root.join("src/output/api.rs")).expect("read api.rs");
+
+    // Every `.route("...")` axum is handed, read from the source rather than
+    // restated here -- a list written twice is a list that disagrees.
+    let mut registered = BTreeSet::new();
+    for (i, _) in api.match_indices(".route(") {
+        let rest = &api[i + ".route(".len()..];
+        let Some(open) = rest.find('"') else { continue };
+        let Some(close) = rest[open + 1..].find('"') else {
+            continue;
+        };
+        registered.insert(rest[open + 1..open + 1 + close].to_string());
+    }
+    assert!(
+        registered.len() >= 5,
+        "only {} routes were read out of api.rs, so this gate is comparing \
+         almost nothing -- the `.route(` scan stopped working",
+        registered.len()
+    );
+
+    // The matrix's route rows: `| `/v1/streams` | exercised | ... |`
+    let mut rows = BTreeSet::new();
+    let mut only_defined = Vec::new();
+    for line in matrix.lines() {
+        if !line.starts_with("| `/") {
+            continue;
+        }
+        let mut cells = line.split('|').map(str::trim);
+        cells.next();
+        let Some(route) = cells.next().and_then(|c| c.split('`').nth(1)) else {
+            continue;
+        };
+        let tier = cells.next().unwrap_or("");
+        rows.insert(route.to_string());
+        if tier == "defined only" || tier == "none" {
+            only_defined.push(format!("{route} ({tier})"));
+        }
+    }
+
+    let missing: Vec<_> = registered.difference(&rows).cloned().collect();
+    assert!(
+        missing.is_empty(),
+        "routes with no row in docs/design/testing-matrix.md: {}\n\
+         Regenerate: cargo build --features full && python3 scripts/coverage-matrix.py",
+        missing.join(", ")
+    );
+
+    assert!(
+        only_defined.is_empty(),
+        "the matrix reports these routes as unexercised: {}\n\n\
+         Either a test that drives them stopped being recognized -- check \
+         `route_pattern` and `SERVER_DRIVERS` in scripts/coverage-matrix.py, \
+         which is where this went wrong last time -- or the route really has no \
+         test, and the fix is the test.",
+        only_defined.join(", ")
+    );
+}

--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -2584,7 +2584,13 @@ fn no_documentation_table_repeats_a_row() {
     // `GET /v1/streams`. `website/content/docs/{mos-and-codecs,api}.md` are the
     // generated copies. Attributed by measurement before the number moved: those
     // four files gained exactly one each and no other page gained any.
-    const EXPECTED_TABLES: usize = 627;
+    // 627 -> 628: one table, in the generated `docs/design/testing-matrix.md`.
+    // Its "what a tier claims" section described the CLI tiers only, while the
+    // route and tool tables use two tiers of their own (`exercised`,
+    // `defined only`) that the page never defined. Attributed by measurement
+    // before the number moved: that file gained exactly one table separator and
+    // no other page gained any, and design docs have no generated mirror.
+    const EXPECTED_TABLES: usize = 628;
 
     let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let out = std::process::Command::new("git")

--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -2577,7 +2577,14 @@ fn no_documentation_table_repeats_a_row() {
     // `docs/design/testing-matrix.md`. It reports what a person found in the
     // 80 flags the generator could only call "referenced" -- 62 of them do
     // have a real behavior test, which a token search cannot see.
-    const EXPECTED_TABLES: usize = 623;
+    // 623 -> 627: two hand-written tables and their two generated mirrors, both
+    // about what a MOS is worth. `docs/mos-and-codecs.md` gained the per-surface
+    // table (which door says a score is a placeholder, and how); `docs/rest-api.md`
+    // gained the `mos_grounded`/`mos_grounding`/`mos_note` key table for
+    // `GET /v1/streams`. `website/content/docs/{mos-and-codecs,api}.md` are the
+    // generated copies. Attributed by measurement before the number moved: those
+    // four files gained exactly one each and no other page gained any.
+    const EXPECTED_TABLES: usize = 627;
 
     let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let out = std::process::Command::new("git")

--- a/tests/round_trip_surface_test.rs
+++ b/tests/round_trip_surface_test.rs
@@ -52,6 +52,13 @@ fn unmeasured() -> serde_json::Value {
         orphaned: false,
         associated_dialog: None,
         mos: 4.4,
+        // PCMU above, so the score is a published estimate. Spelled out rather
+        // than defaulted: this suite hand-builds a summary, and a fixture that
+        // silently claimed a grounding it had not thought about is how the
+        // round-trip keys would come to be tested against an impossible row.
+        mos_grounded: true,
+        mos_grounding: "published".into(),
+        mos_note: None,
         frame: None,
         round_trip_ms: None,
         round_trip_source: None,
@@ -108,6 +115,13 @@ fn a_measured_round_trip_carries_its_provenance() {
         orphaned: false,
         associated_dialog: None,
         mos: 4.4,
+        // PCMU above, so the score is a published estimate. Spelled out rather
+        // than defaulted: this suite hand-builds a summary, and a fixture that
+        // silently claimed a grounding it had not thought about is how the
+        // round-trip keys would come to be tested against an impossible row.
+        mos_grounded: true,
+        mos_grounding: "published".into(),
+        mos_note: None,
         frame: None,
         round_trip_ms: None,
         round_trip_source: None,
@@ -155,6 +169,13 @@ fn a_measured_zero_is_reported_rather_than_hidden() {
         orphaned: true,
         associated_dialog: None,
         mos: 4.4,
+        // PCMU above, so the score is a published estimate. Spelled out rather
+        // than defaulted: this suite hand-builds a summary, and a fixture that
+        // silently claimed a grounding it had not thought about is how the
+        // round-trip keys would come to be tested against an impossible row.
+        mos_grounded: true,
+        mos_grounding: "published".into(),
+        mos_note: None,
         frame: None,
         round_trip_ms: None,
         round_trip_source: None,

--- a/tests/surface_parity_test.rs
+++ b/tests/surface_parity_test.rs
@@ -218,6 +218,21 @@ const QUALITY_METRICS: &[Metric] = &[
         name: "dscp",
         aliases: &["dscp_first", "dscp_last", "dscp_remarked"],
     },
+    // What the MOS beside it MEANS. Tracked here rather than folded into
+    // `mos` because the two are not the same fact and the number cannot carry
+    // the second: sipnab returns the identical score for a grounded G.711
+    // stream and for an unpublished codec where the score is a placeholder
+    // standing in for "unknown". A surface serving `mos` without the grounding
+    // serves a guess in the shape of a measurement.
+    //
+    // The alias list is the usual reason -- MCP serializes the label as
+    // `mos_grounding` and the boolean as `mos_grounded`, and the filters on
+    // both surfaces decide through the predicate `mos_is_grounded`, which
+    // whole-identifier matching sees in neither key.
+    Metric {
+        name: "mos_grounding",
+        aliases: &["mos_grounded", "mos_is_grounded"],
+    },
 ];
 
 /// A quality metric and every identifier that carries it.

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -9,7 +9,9 @@ sipnab includes an optional REST API and Prometheus metrics endpoint, enabled wi
 
 [CLI Reference](@/docs/cli.md#network-listeners) catalogs every API flag.
 
-> **Looking for AI-agent access?** sipnab also exposes the same dialog / RTP / diagnostic data as a Model Context Protocol server. See [MCP Server](@/docs/mcp.md) -- the MCP path uses the same in-memory stores as this REST API, so a running sipnab instance can serve both surfaces simultaneously.
+> **Looking for AI-agent access?** sipnab also serves the dialog / RTP / diagnostic stores over the Model Context Protocol. See [MCP Server](@/docs/mcp.md) -- both doors read the same in-memory stores in the same process, so one running instance can serve both at once.
+>
+> The two response *shapes* are converging deliberately and are not yet identical. Where a metric is reachable through one door and not the other, that is drift rather than design: [`tests/surface_parity_test.rs`](https://github.com/NormB/sipnab/blob/main/tests/surface_parity_test.rs) fails the build on it, and the fix is always to add the metric to the missing surface.
 
 ## Getting started
 
@@ -750,7 +752,7 @@ List all tracked RTP streams with quality metrics.
 | Parameter  | Type  | Default | Description |
 |------------|-------|---------|-------------|
 | `orphaned` | bool  | --      | `true` keeps only streams no dialog claims, `false` only those one does. The test is the stream's dialog association, applied from the stream's first packet, so `orphaned=true` catches short unclaimed streams as well as long ones |
-| `mos_below`| float | --      | Filter streams with MOS below this threshold |
+| `mos_below`| float | --      | Keep only streams whose **grounded** estimated MOS is strictly below this threshold. Streams whose codec has no impairment value score a placeholder meaning "unknown", not a low score, and are never selected by this filter -- `ungrounded_excluded` in the response counts what the filter skipped |
 | `limit`    | int   | 50      | Maximum results. Ceiling is `--api-max-rows` (1000 by default), not a fixed limit |
 | `offset`   | int   | 0       | Pagination offset |
 
@@ -820,10 +822,11 @@ streams.forEach(s =>
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "total": 14,
   "offset": 0,
   "limit": 50,
+  "ungrounded_excluded": 0,
   "streams": [
     {
       "ssrc": "0x1a2b3c4d",
@@ -835,11 +838,48 @@ streams.forEach(s =>
       "loss_pct": 0.0,
       "orphaned": false,
       "associated_dialog": "12013223@203.0.113.195",
-      "mos": 4.2
+      "mos": 4.2,
+      "mos_grounded": true,
+      "mos_grounding": "published"
     }
   ]
 }
 ```
+
+#### What the MOS is worth
+
+`mos` is always a number, on every stream. It is not always a measurement.
+
+sipnab scores MOS with the ITU-T G.107 E-model, which needs an equipment
+impairment factor (`Ie`) for the codec. G.113 publishes one for some codecs and
+not for others, and for a codec with none the score falls back to a placeholder
+that means **"unknown"** -- not "about 4.2", even though 4.2 is roughly what it
+prints. A placeholder and a genuine G.711 estimate are byte-identical in the
+`mos` field.
+
+Three keys keep them apart:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `mos_grounded` | bool | `true` when `mos` rests on a real impairment value. Always present -- every stream has a grounding, and an absent key would read as "unknown", which is a different claim |
+| `mos_grounding` | string | Which one: `published` (ITU-T G.113), `operator_declared` (this deployment's `[media.codec_ie]`), or `unpublished` (the placeholder) |
+| `mos_note` | string | The caveat, when there is one. **Absent** for a `published` score, which has nothing to disclose |
+
+sipnab keeps `published` and `operator_declared` apart because the remedies
+differ: a published score that looks wrong means suspecting sipnab's vantage
+point, a declared one means suspecting a file on your own disk.
+
+Act on `mos_grounded` before acting on `mos`. Otherwise a dashboard that sorts
+by MOS and shows the worst ten fills with streams nobody ever scored.
+
+> **`schema_version` 2.** Version 1 served `mos` with no grounding beside it,
+> and its `mos_below` filter selected placeholders. A client that reads only
+> the fields it knows sees no change; a client asserting on the exact key set
+> does.
+
+The MCP `rtp_stats` tool carries the same three keys, and the TUI's stream
+detail view draws the same distinction: an ungrounded score renders muted and
+annotated rather than in a quality band color.
 
 ---
 

--- a/website/content/docs/mos-and-codecs.md
+++ b/website/content/docs/mos-and-codecs.md
@@ -24,9 +24,23 @@ The short version:
 | G.722, G.726, iLBC, everything else | Not implemented | Placeholder, flagged |
 
 Anything in the last three rows scores **4.216 at 10 ms jitter — the same value
-an unidentified stream gets.** That is a placeholder, not a measurement. Tools
-that publish it say so: the `rtp_stats` MCP tool carries `mos_grounded: false`,
-`mos_grounding: "unpublished"` and a note.
+an unidentified stream gets.** That is a placeholder, not a measurement.
+
+Every door that publishes the number publishes what it is worth, in the same
+words:
+
+| Surface | How it says so |
+|---------|----------------|
+| MCP `rtp_stats` | `mos_grounded: false`, `mos_grounding: "unpublished"`, `mos_note` |
+| `GET /v1/streams` | the same three keys on every row |
+| `GET /v1/streams?mos_below=` | **never selects an ungrounded stream**, and reports `ungrounded_excluded` |
+| MCP `search_streams` with `min_mos`/`max_mos` | the same refusal, and the same count |
+| TUI stream detail | the score renders muted rather than in a quality band, annotated `no published Ie` |
+
+The filters are the part that matters most. A placeholder is a *high-looking*
+number that means nothing, so a MOS bound applied without the grounding test
+returns every stream sipnab could not score, dressed as a bad call — and an
+operator working a bad-call list goes down it top to bottom.
 
 ## Declaring an impairment factor sipnab does not have
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1993,7 +1993,9 @@ sipnab includes an optional REST API and Prometheus metrics endpoint, enabled wi
 
 [CLI Reference](cli-reference.md#network-listeners) catalogs every API flag.
 
-> **Looking for AI-agent access?** sipnab also exposes the same dialog / RTP / diagnostic data as a Model Context Protocol server. See [MCP Server](mcp.md) -- the MCP path uses the same in-memory stores as this REST API, so a running sipnab instance can serve both surfaces simultaneously.
+> **Looking for AI-agent access?** sipnab also serves the dialog / RTP / diagnostic stores over the Model Context Protocol. See [MCP Server](mcp.md) -- both doors read the same in-memory stores in the same process, so one running instance can serve both at once.
+>
+> The two response *shapes* are converging deliberately and are not yet identical. Where a metric is reachable through one door and not the other, that is drift rather than design: [`tests/surface_parity_test.rs`](https://github.com/NormB/sipnab/blob/main/tests/surface_parity_test.rs) fails the build on it, and the fix is always to add the metric to the missing surface.
 
 ## Getting started
 
@@ -2734,7 +2736,7 @@ List all tracked RTP streams with quality metrics.
 | Parameter  | Type  | Default | Description |
 |------------|-------|---------|-------------|
 | `orphaned` | bool  | --      | `true` keeps only streams no dialog claims, `false` only those one does. The test is the stream's dialog association, applied from the stream's first packet, so `orphaned=true` catches short unclaimed streams as well as long ones |
-| `mos_below`| float | --      | Filter streams with MOS below this threshold |
+| `mos_below`| float | --      | Keep only streams whose **grounded** estimated MOS is strictly below this threshold. Streams whose codec has no impairment value score a placeholder meaning "unknown", not a low score, and are never selected by this filter -- `ungrounded_excluded` in the response counts what the filter skipped |
 | `limit`    | int   | 50      | Maximum results. Ceiling is `--api-max-rows` (1000 by default), not a fixed limit |
 | `offset`   | int   | 0       | Pagination offset |
 
@@ -2804,10 +2806,11 @@ streams.forEach(s =>
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "total": 14,
   "offset": 0,
   "limit": 50,
+  "ungrounded_excluded": 0,
   "streams": [
     {
       "ssrc": "0x1a2b3c4d",
@@ -2819,11 +2822,48 @@ streams.forEach(s =>
       "loss_pct": 0.0,
       "orphaned": false,
       "associated_dialog": "12013223@203.0.113.195",
-      "mos": 4.2
+      "mos": 4.2,
+      "mos_grounded": true,
+      "mos_grounding": "published"
     }
   ]
 }
 ```
+
+#### What the MOS is worth
+
+`mos` is always a number, on every stream. It is not always a measurement.
+
+sipnab scores MOS with the ITU-T G.107 E-model, which needs an equipment
+impairment factor (`Ie`) for the codec. G.113 publishes one for some codecs and
+not for others, and for a codec with none the score falls back to a placeholder
+that means **"unknown"** -- not "about 4.2", even though 4.2 is roughly what it
+prints. A placeholder and a genuine G.711 estimate are byte-identical in the
+`mos` field.
+
+Three keys keep them apart:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `mos_grounded` | bool | `true` when `mos` rests on a real impairment value. Always present -- every stream has a grounding, and an absent key would read as "unknown", which is a different claim |
+| `mos_grounding` | string | Which one: `published` (ITU-T G.113), `operator_declared` (this deployment's `[media.codec_ie]`), or `unpublished` (the placeholder) |
+| `mos_note` | string | The caveat, when there is one. **Absent** for a `published` score, which has nothing to disclose |
+
+sipnab keeps `published` and `operator_declared` apart because the remedies
+differ: a published score that looks wrong means suspecting sipnab's vantage
+point, a declared one means suspecting a file on your own disk.
+
+Act on `mos_grounded` before acting on `mos`. Otherwise a dashboard that sorts
+by MOS and shows the worst ten fills with streams nobody ever scored.
+
+> **`schema_version` 2.** Version 1 served `mos` with no grounding beside it,
+> and its `mos_below` filter selected placeholders. A client that reads only
+> the fields it knows sees no change; a client asserting on the exact key set
+> does.
+
+The MCP `rtp_stats` tool carries the same three keys, and the TUI's stream
+detail view draws the same distinction: an ungrounded score renders muted and
+annotated rather than in a quality band color.
 
 ---
 
@@ -8455,9 +8495,23 @@ The short version:
 | G.722, G.726, iLBC, everything else | Not implemented | Placeholder, flagged |
 
 Anything in the last three rows scores **4.216 at 10 ms jitter — the same value
-an unidentified stream gets.** That is a placeholder, not a measurement. Tools
-that publish it say so: the `rtp_stats` MCP tool carries `mos_grounded: false`,
-`mos_grounding: "unpublished"` and a note.
+an unidentified stream gets.** That is a placeholder, not a measurement.
+
+Every door that publishes the number publishes what it is worth, in the same
+words:
+
+| Surface | How it says so |
+|---------|----------------|
+| MCP `rtp_stats` | `mos_grounded: false`, `mos_grounding: "unpublished"`, `mos_note` |
+| `GET /v1/streams` | the same three keys on every row |
+| `GET /v1/streams?mos_below=` | **never selects an ungrounded stream**, and reports `ungrounded_excluded` |
+| MCP `search_streams` with `min_mos`/`max_mos` | the same refusal, and the same count |
+| TUI stream detail | the score renders muted rather than in a quality band, annotated `no published Ie` |
+
+The filters are the part that matters most. A placeholder is a *high-looking*
+number that means nothing, so a MOS bound applied without the grounding test
+returns every stream sipnab could not score, dressed as a bad call — and an
+operator working a bad-call list goes down it top to bottom.
 
 ## Declaring an impairment factor sipnab does not have
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5622 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5624 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5622" data-suffix="">5622</span>
+        <span class="arch-stat" data-count="5624" data-suffix="">5624</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5624 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5625 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5624" data-suffix="">5624</span>
+        <span class="arch-stat" data-count="5625" data-suffix="">5625</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>


### PR DESCRIPTION
## Why

`MCP / CLI / REST must be as close to being in sync as possible.` This is the
first increment against that, and it starts with the gap that misleads rather
than merely omits.

sipnab returns a MOS for every stream. For a codec ITU-T G.113 publishes no
impairment value for, that number is a placeholder meaning **unknown** — and it
is byte-identical to a grounded G.711 score. Measured on the fixture added
here: **4.223** for an unidentified codec against **4.358** for PCMU.

Only MCP said so. `GET /v1/streams` served the number bare, and its `mos_below`
filter applied the bound without asking whether there was anything to bound, so
`?mos_below=5.0` returned every stream sipnab could not score, dressed as a bad
call.

## What changed

| | Before | After |
|---|---|---|
| MCP `rtp_stats` | `mos_grounded`, `mos_grounding`, `mos_note` | unchanged, byte for byte |
| `GET /v1/streams` | `mos` alone | the same three keys, `schema_version` 2 |
| `GET /v1/streams?mos_below=` | selected placeholders | grounded only, plus `ungrounded_excluded` |
| TUI stream detail | placeholder painted bold green as "Good" | muted, annotated `no published Ie` |

One definition site for the vocabulary: `MosGrounding::as_str` and
`MosGrounding::note` replace a private `mos_grounding_label` and two inline
string literals in `src/mcp/server.rs`; `quality::mos_is_grounded` replaces the
private predicate that was the only copy, behind a door REST does not open.

## How it was found, and how it stays found

`tests/surface_parity_test.rs` now tracks `mos_grounding` as a quality metric.
Adding it failed the gate immediately (`on MCP but NOT the REST API`), and
closing that half made the gate name the TUI in the same run — which is how the
third surface got fixed in the same change rather than in a later one.

The `mos_below` test is mutation-proven: replacing the grounding check with
`if false` fails it, and the failure output is the bug verbatim.

## Also here

A second commit fixes a bug in the hooks themselves. `set -e` is on and
`prose_vale_run` is a simple command, so the CONTRACT's return of 1 — "the tool
ran and found something" — killed the hook before the `case` written to render
it. An operator saw `  Vale... ` and exit 1, with no file names and no reason.
Three scenarios in `scripts/test-pre-commit.sh` pin it against the real hook.
The fix proved itself on its first run by catching a misspelling in the very
fixture added to test it.

## Docs

`docs/rest-api.md` gains a "What the MOS is worth" section, and drops its claim
that MCP "exposes the same data as" REST — untrue in both directions. What
replaces it says the shapes are converging, names the gate that fails on drift,
and does not pretend the work is finished.
