### PR TITLE
Advertise 0.5.124, now that it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,24 @@ entry that carries them.
   binding made from one withholds the cross-source claim instead of inventing
   one.
 
+### Changed
+
+- **The published binary-size claim is 13 MB, and it is measured.** The claim
+  said "Under 12 MB" and the x86_64 musl release binary had grown past it, which
+  failed the release build's own size gate. Rather than relax the claim, the
+  duplication that caused the growth was removed: `slice::sort_by` is generic
+  over the COMPARATOR, so each of seventeen call sites emitted its own complete
+  copy of the stable sort. Routing them through one `&mut dyn FnMut` collapses
+  that to one copy per element type and returned 75,648 bytes of `.text`. No
+  feature or capability was dropped.
+
+  The ceiling that replaced it was then derived from the artifact rather than
+  chosen: the binary this release publishes is 12,527,432 bytes (11.94 MB),
+  rounded up to the next megabyte. One value in `website/config.toml` feeds the
+  home page tile, the feature table, `docs/install.md` and `docs/build.md`, and
+  a test fails if any of them disagrees with the number the release gate
+  enforces.
+
 ### Fixed
 
 - **`--kill-ua` detected nothing on its own, and said nothing about it.** The

--- a/docs/install.md
+++ b/docs/install.md
@@ -41,7 +41,7 @@ Two environment variables tune it. To pin a specific version instead of taking
 whatever the latest release is:
 
 ```bash
-curl -fsSL https://sipnab.com/install.sh | SIPNAB_VERSION=0.5.123 sh
+curl -fsSL https://sipnab.com/install.sh | SIPNAB_VERSION=0.5.124 sh
 ```
 
 To install somewhere other than `/usr/local/bin` — a directory you already own,
@@ -139,7 +139,7 @@ canonical triples deliberately: they match `rustc -vV`, they are what
 script constructs them.
 
 On Linux x86_64, the static musl tarball runs on any distro and any glibc,
-Alpine included. Replace `<version>` with the latest, e.g. 0.5.123:
+Alpine included. Replace `<version>` with the latest, e.g. 0.5.124:
 
 ```bash
 # Run all of these, in order.
@@ -158,7 +158,7 @@ sudo install -m 755 sipnab-<version>-aarch64-unknown-linux-musl/sipnab /usr/loca
 ```
 
 Manual download with checksum verification (replace `<version>` with the
-latest, e.g. 0.5.123):
+latest, e.g. 0.5.124):
 
 ```bash
 # Run all of these, in order.
@@ -200,7 +200,7 @@ cargo install sipnab --features full
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install with `apt` (it resolves the `libpcap0.8` runtime dependency). The `.deb` needs glibc >= 2.36, i.e. Debian 12+ / Ubuntu 23.04+ -- on older releases use the static musl tarball above.
 
 Download and install the amd64 (x86_64) package — replace `<version>` with the
-latest, e.g. 0.5.123:
+latest, e.g. 0.5.124:
 
 ```bash
 # Run all of these, in order.
@@ -259,26 +259,26 @@ dependency — for headless servers, mirroring the `.deb` variants).
 The standard package on an x86_64 host:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.x86_64.rpm
+sudo rpm -i sipnab-0.5.124-1.x86_64.rpm
 ```
 
 The headless / no-ALSA variant on the same architecture:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.x86_64-noaudio.rpm
+sudo rpm -i sipnab-0.5.124-1.x86_64-noaudio.rpm
 ```
 
 The standard package on an aarch64 (arm64) host — pick the variant matching
 `uname -m`:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.aarch64.rpm
+sudo rpm -i sipnab-0.5.124-1.aarch64.rpm
 ```
 
 The headless / no-ALSA variant on aarch64:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.aarch64-noaudio.rpm
+sudo rpm -i sipnab-0.5.124-1.aarch64-noaudio.rpm
 ```
 
 ### Homebrew (macOS)

--- a/website/config.toml
+++ b/website/config.toml
@@ -48,7 +48,7 @@ version = "0.5.124"
 # Bumped after a release finishes publishing, not while cutting it.
 # `site_advertises_only_a_released_version` requires a matching `v<x.y.z>` tag,
 # so advertising something unreleased fails the suite rather than the visitor.
-published_version = "0.5.123"
+published_version = "0.5.124"
 # Release date of `published_version` above -- NOT of `version`, further up.
 # `download.html` renders this beside `published_version` in a single sentence,
 # so the date belongs to the release a reader can actually download.
@@ -57,7 +57,7 @@ published_version = "0.5.123"
 # untagged version is the conflation the published_version split exists to
 # prevent. `site_release_date_matches_changelog` reads `published_version` and
 # enforces this.
-release_date = "2026-08-22"
+release_date = "2026-08-24"
 # Minimum glibc of the released -gnu binaries and .debs. This is NOT a free
 # choice: it is whatever the "Enforce glibc floor" step in release.yml admits,
 # and it must equal SIPNAB_GLIBC_FLOOR in static/install.sh, which decides

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -46,7 +46,7 @@ Two environment variables tune it. To pin a specific version instead of taking
 whatever the latest release is:
 
 ```bash
-curl -fsSL https://sipnab.com/install.sh | SIPNAB_VERSION=0.5.123 sh
+curl -fsSL https://sipnab.com/install.sh | SIPNAB_VERSION=0.5.124 sh
 ```
 
 To install somewhere other than `/usr/local/bin` — a directory you already own,
@@ -144,7 +144,7 @@ canonical triples deliberately: they match `rustc -vV`, they are what
 script constructs them.
 
 On Linux x86_64, the static musl tarball runs on any distro and any glibc,
-Alpine included. Replace `<version>` with the latest, e.g. 0.5.123:
+Alpine included. Replace `<version>` with the latest, e.g. 0.5.124:
 
 ```bash
 # Run all of these, in order.
@@ -163,7 +163,7 @@ sudo install -m 755 sipnab-<version>-aarch64-unknown-linux-musl/sipnab /usr/loca
 ```
 
 Manual download with checksum verification (replace `<version>` with the
-latest, e.g. 0.5.123):
+latest, e.g. 0.5.124):
 
 ```bash
 # Run all of these, in order.
@@ -205,7 +205,7 @@ cargo install sipnab --features full
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install with `apt` (it resolves the `libpcap0.8` runtime dependency). The `.deb` needs glibc >= 2.36, i.e. Debian 12+ / Ubuntu 23.04+ -- on older releases use the static musl tarball above.
 
 Download and install the amd64 (x86_64) package — replace `<version>` with the
-latest, e.g. 0.5.123:
+latest, e.g. 0.5.124:
 
 ```bash
 # Run all of these, in order.
@@ -264,26 +264,26 @@ dependency — for headless servers, mirroring the `.deb` variants).
 The standard package on an x86_64 host:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.x86_64.rpm
+sudo rpm -i sipnab-0.5.124-1.x86_64.rpm
 ```
 
 The headless / no-ALSA variant on the same architecture:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.x86_64-noaudio.rpm
+sudo rpm -i sipnab-0.5.124-1.x86_64-noaudio.rpm
 ```
 
 The standard package on an aarch64 (arm64) host — pick the variant matching
 `uname -m`:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.aarch64.rpm
+sudo rpm -i sipnab-0.5.124-1.aarch64.rpm
 ```
 
 The headless / no-ALSA variant on aarch64:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.aarch64-noaudio.rpm
+sudo rpm -i sipnab-0.5.124-1.aarch64-noaudio.rpm
 ```
 
 ### Homebrew (macOS)

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -3249,7 +3249,7 @@ Two environment variables tune it. To pin a specific version instead of taking
 whatever the latest release is:
 
 ```bash
-curl -fsSL https://sipnab.com/install.sh | SIPNAB_VERSION=0.5.123 sh
+curl -fsSL https://sipnab.com/install.sh | SIPNAB_VERSION=0.5.124 sh
 ```
 
 To install somewhere other than `/usr/local/bin` — a directory you already own,
@@ -3347,7 +3347,7 @@ canonical triples deliberately: they match `rustc -vV`, they are what
 script constructs them.
 
 On Linux x86_64, the static musl tarball runs on any distro and any glibc,
-Alpine included. Replace `<version>` with the latest, e.g. 0.5.123:
+Alpine included. Replace `<version>` with the latest, e.g. 0.5.124:
 
 ```bash
 # Run all of these, in order.
@@ -3366,7 +3366,7 @@ sudo install -m 755 sipnab-<version>-aarch64-unknown-linux-musl/sipnab /usr/loca
 ```
 
 Manual download with checksum verification (replace `<version>` with the
-latest, e.g. 0.5.123):
+latest, e.g. 0.5.124):
 
 ```bash
 # Run all of these, in order.
@@ -3408,7 +3408,7 @@ cargo install sipnab --features full
 Download the `.deb` for your architecture from the [latest release](https://github.com/NormB/sipnab/releases/latest) and install with `apt` (it resolves the `libpcap0.8` runtime dependency). The `.deb` needs glibc >= 2.36, i.e. Debian 12+ / Ubuntu 23.04+ -- on older releases use the static musl tarball above.
 
 Download and install the amd64 (x86_64) package — replace `<version>` with the
-latest, e.g. 0.5.123:
+latest, e.g. 0.5.124:
 
 ```bash
 # Run all of these, in order.
@@ -3467,26 +3467,26 @@ dependency — for headless servers, mirroring the `.deb` variants).
 The standard package on an x86_64 host:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.x86_64.rpm
+sudo rpm -i sipnab-0.5.124-1.x86_64.rpm
 ```
 
 The headless / no-ALSA variant on the same architecture:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.x86_64-noaudio.rpm
+sudo rpm -i sipnab-0.5.124-1.x86_64-noaudio.rpm
 ```
 
 The standard package on an aarch64 (arm64) host — pick the variant matching
 `uname -m`:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.aarch64.rpm
+sudo rpm -i sipnab-0.5.124-1.aarch64.rpm
 ```
 
 The headless / no-ALSA variant on aarch64:
 
 ```bash
-sudo rpm -i sipnab-0.5.123-1.aarch64-noaudio.rpm
+sudo rpm -i sipnab-0.5.124-1.aarch64-noaudio.rpm
 ```
 
 ### Homebrew (macOS)


### PR DESCRIPTION
## Why

v0.5.124 published at 14:07 UTC with 23 assets across eight targets, so the
site may now point at it.

`published_version` and `release_date` move **after** the artifacts exist and
never while cutting a release. Between the tag and the last artifact there is a
window in which the version is real and undownloadable, and 0.5.61 spent that
window red: it tagged nothing and would have left the site advertising a
release that never happened.

## What moved

| | From | To |
|---|---|---|
| `website/config.toml` `published_version` | 0.5.123 | 0.5.124 |
| `website/config.toml` `release_date` | 2026-08-22 | 2026-08-24 |
| `docs/install.md` | 0.5.123 ×9 | 0.5.124 |

The `docs/install.md` half matters more than a version string usually does.
Four of those nine were `rpm -i sipnab-0.5.123-…` — a command that works, and
installs the *previous* release.

## Changelog

0.5.124 gains the `### Changed` entry the binary-size work never got. It
shipped in this release and it changed a **published claim** — "Under 12 MB"
became "Under 13 MB" on the home page, the feature table and two docs pages —
so a reader diffing 0.5.123 against 0.5.124 was left to notice on their own.

The entry says what grew, what was removed instead of relaxing the claim
(seventeen `sort_by` call sites each emitting their own copy of the stable sort;
one `&mut dyn FnMut` returned 75,648 bytes of `.text`), and that the replacement
ceiling was measured off the artifact this release actually publishes:
**12,527,432 bytes, 11.94 MB**, rounded up to the next megabyte.

No feature or capability was dropped to get there.
