### PR TITLE
Show who named a stream's dialog, instead of only recording it

### DIFF
--- a/docs/design/implementation-plan-phases-8-10.md
+++ b/docs/design/implementation-plan-phases-8-10.md
@@ -1674,7 +1674,7 @@ For implementers picking this up, the bridge from each MCP tool to existing func
 | `list_dialogs` | `DialogStore::iter` ([`src/sip/dialog_store.rs:939`](https://github.com/NormB/sipnab/blob/main/src/sip/dialog_store.rs#L939)) + `FilterExpr::matches_dialog` ([`src/sip/dsl.rs:530`](https://github.com/NormB/sipnab/blob/main/src/sip/dsl.rs#L530)) + `expand_alias` ([`src/sip/dsl.rs:358`](https://github.com/NormB/sipnab/blob/main/src/sip/dsl.rs#L358)) |
 | `get_dialog` | `DialogStore::get` ([`src/sip/dialog_store.rs:184`](https://github.com/NormB/sipnab/blob/main/src/sip/dialog_store.rs#L184)) + iterate `dialog.messages` + `output::json::message_to_json` |
 | `get_dialog_report` | `output::generate_call_report` ([`src/output/call_report.rs:53`](https://github.com/NormB/sipnab/blob/main/src/output/call_report.rs#L53)) with `ReportFormat::Json/Markdown/Text` |
-| `get_message` | `output::json::message_to_json` ([`src/output/json.rs:553`](https://github.com/NormB/sipnab/blob/main/src/output/json.rs#L553)) |
+| `get_message` | `output::json::message_to_json` ([`src/output/json.rs:576`](https://github.com/NormB/sipnab/blob/main/src/output/json.rs#L576)) |
 | `render_ladder` | `output::generate_call_report` with `ReportFormat::Markdown` (v0.4); rich SVG ladder deferred |
 | `rtp_stats` | `StreamStore::iter` ([`src/rtp/stream_store.rs:1546`](https://github.com/NormB/sipnab/blob/main/src/rtp/stream_store.rs#L1546)) + `rtp::diagnosis::diagnose_media` + `output::json::stream_to_json` |
 | `search_messages` | Same iteration the `--filter` CLI path uses; `FilterExpr` covers most of it |

--- a/docs/design/maintainability-perf-spec.md
+++ b/docs/design/maintainability-perf-spec.md
@@ -349,7 +349,7 @@ Five implementations of "dialog summary", already divergent on the wire:
 
 | Surface | Site | Drift |
 |---|---|---|
-| CLI/NDJSON | [`src/output/json.rs:397`](https://github.com/NormB/sipnab/blob/main/src/output/json.rs#L397) `DialogJson` | `msg_count`, `schema_version: 1` |
+| CLI/NDJSON | [`src/output/json.rs:420`](https://github.com/NormB/sipnab/blob/main/src/output/json.rs#L420) `DialogJson` | `msg_count`, `schema_version: 1` |
 | REST API | [`src/output/api.rs:715`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L715) ad-hoc `json!` | `msg_count`, `method.as_str()` |
 | MCP | [`src/mcp/server.rs:247`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L247) `DialogSummary` | **`message_count`**, **`format!("{:?}", method)`** |
 | TUI save | [`src/tui/save.rs:212`](https://github.com/NormB/sipnab/blob/main/src/tui/save.rs#L212) hand-built `json!` | third field set, no `schema_version` |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -763,6 +763,28 @@ either direction: its nine modes genuinely span about 4.49 down to 3.51. Do not
 report a MOS to a human without checking this field. See
 [MOS and codecs](mos-and-codecs.md) for the full picture.
 
+#### Who named the dialog — `dialog_assertion`
+
+Each stream also says who asserted the SDP media endpoint that tied it to its
+Call-ID:
+
+| `dialog_assertion` | Who said it | What the address is |
+|---|---|---|
+| `signaled` | a negotiating party, in its own SDP | that party's endpoint |
+| `media-relay` | an rtpengine relay, about a port it allocated | the leg's **midpoint** |
+
+A relay cannot be wrong about which socket it opened, so the address is
+authoritative — and it is still not an endpoint. An agent reasoning about where
+media went must not report a `media-relay` address as the far party's, because
+it names the box in the middle and the two lead to opposite conclusions.
+
+sipnab emits the key whenever it knows the answer, `signaled` included. **Absent
+means nobody recorded who asserted it**, never "a party did". Do not default it.
+
+Distinct from `dialog_origin`, which names the capture **source** that delivered
+the assertion rather than its author. See
+[rtpengine relay attribution](rtpengine.md).
+
 #### Capture-wide sweep — omit `call_id`
 
 "Every stream with a MOS below 3.5" is one call rather than a listing plus one

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -876,6 +876,31 @@ The MCP `rtp_stats` tool carries the same three keys, and the TUI's stream
 detail view draws the same distinction: an ungrounded score renders muted and
 annotated rather than in a quality band color.
 
+#### Who named the dialog
+
+`dialog_assertion` says who asserted the SDP media endpoint that tied this
+stream to its Call-ID:
+
+| Value | Who said it | What the address is |
+|-------|-------------|---------------------|
+| `signaled` | a negotiating party, in its own SDP | that party's endpoint |
+| `media-relay` | an rtpengine relay, about a port it allocated | the leg's **midpoint** |
+
+A relay's answer is authoritative about the port — rtpengine cannot be wrong
+about which socket it opened — and at the same time it is not an endpoint. An
+operator tracing one-way audio to `10.0.0.40:38664` needs to know whether that
+address is the far end or the box in the middle, and the two lead to opposite
+next steps.
+
+sipnab emits the key whenever it knows the answer, `signaled` included. **Absent means
+nobody recorded who asserted it**, never "a party did" — that is a claim, and
+keeping the two apart is why the field exists.
+
+It answers a different question from `dialog_origin`, which names the capture
+**source** that delivered the assertion rather than its author. See
+[rtpengine relay attribution](rtpengine.md) for how a relay comes to name a
+call whose signaling sipnab never saw.
+
 ---
 
 ### GET /v1/streams/:id

--- a/docs/rtpengine.md
+++ b/docs/rtpengine.md
@@ -215,6 +215,36 @@ never appears in the capture — the whole reason for asking — lands under
 **Calls named by a media relay**, the same heading the mirrored control
 plane fills.
 
+#### Telling a relay's answer from a party's
+
+Every stream says who named its dialog, on every door:
+
+| Value | Who said it | What the address is |
+|-------|-------------|---------------------|
+| `signaled` | a negotiating party, in its own SDP | that party's endpoint |
+| `media-relay` | rtpengine, about a port it allocated | the leg's **midpoint** |
+
+`GET /v1/streams` and `GET /v1/streams/{id}` carry it as `dialog_assertion`,
+the MCP `rtp_stats` tool carries the same key with the same two spellings, and
+the TUI's stream detail prints `(via media-relay)` beside the Call-ID.
+
+The distinction changes what the address means, which is why it is not folded
+away. A relay's answer is **authoritative about the port** — rtpengine cannot
+be wrong about which socket it opened — and at the same time it is **not an
+endpoint**: it names the box the media passed through, not where either party
+sits. An operator tracing a one-way-audio fault to `10.0.0.40:38664` needs to
+know whether that is the far end or the box in the middle, and those lead to
+opposite next steps.
+
+An absent key means nobody recorded who asserted the binding. It does not mean
+`signaled` — that is a claim, and keeping the two apart is the entire reason
+the field exists.
+
+`dialog_assertion` is a different question from `dialog_origin`, which says
+which **capture source** delivered the assertion. A relay can name a stream over a
+HEP mirror or answer sipnab directly, and a party's SDP can arrive off the NIC.
+The two keys answer one half of that each.
+
 The second summary arrives when the capture ends:
 
 ```text

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -264,6 +264,29 @@ struct StreamJson {
     /// which is a claim.
     #[serde(skip_serializing_if = "Option::is_none")]
     dialog_origin: Option<&'static str>,
+    /// WHO asserted the SDP media endpoint that named this stream's dialog:
+    /// `signaled` (a negotiating party describing its own address) or
+    /// `media-relay` (an rtpengine relay describing a port it allocated).
+    ///
+    /// A different question from [`dialog_origin`](Self::dialog_origin), which
+    /// says which capture SOURCE delivered the assertion. Both can be
+    /// surprising on their own and they are surprising in different ways: a
+    /// cross-source binding means two halves of the evidence came from places
+    /// that can disagree, while a relay assertion means the address is
+    /// authoritative -- the relay cannot be wrong about which port it opened --
+    /// but names the leg's MIDPOINT rather than either party's endpoint.
+    ///
+    /// An operator reading `signaled` and an operator reading `media-relay` are
+    /// looking at different pictures of where the media went, and until this
+    /// key existed neither could tell which they had.
+    ///
+    /// Emitted whenever it is known, INCLUDING `signaled`, which is the common
+    /// case. Omitting the common case would make absence mean two things --
+    /// "a party said so" and "nobody recorded who said so" -- and the whole
+    /// reason to record this is to keep a relay's claim apart from a party's.
+    /// Absent therefore means only "nobody said".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dialog_assertion: Option<&'static str>,
     /// DSCP of this stream's MOST RECENT packet, when it differs from
     /// [`dscp`](Self::dscp).
     ///
@@ -900,6 +923,13 @@ fn build_stream_json(stream: &RtpStream) -> StreamJson {
             .dialog_bound_across_sources()
             .then(|| stream.dialog_origin.map(|o| o.as_str()))
             .flatten(),
+        // NOT gated on anything, unlike `dialog_origin` above. That one is
+        // emitted only when the binding crossed sources because agreement is
+        // the uninteresting case and its absence is well defined. Here the
+        // common case is `signaled`, and suppressing it would leave absence
+        // meaning both "a party said so" and "nobody said" -- which is exactly
+        // the distinction this field exists to preserve.
+        dialog_assertion: stream.dialog_assertion.map(|a| a.as_str()),
     }
 }
 

--- a/src/output/model.rs
+++ b/src/output/model.rs
@@ -272,6 +272,21 @@ pub struct StreamSummary {
     /// agree", which is a claim.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dialog_origin: Option<String>,
+    /// WHO asserted the SDP media endpoint that named this stream's dialog:
+    /// `signaled` (a negotiating party describing its own address) or
+    /// `media-relay` (an rtpengine relay describing a port it allocated).
+    ///
+    /// Separate from [`Self::dialog_origin`], which says which capture SOURCE
+    /// delivered the assertion. A relay's address is authoritative -- it cannot
+    /// be wrong about which port it opened -- but it names the leg's MIDPOINT,
+    /// not either party's endpoint, so an operator tracing where media actually
+    /// went needs to know which kind of claim they are reading.
+    ///
+    /// Emitted whenever it is known, `signaled` included. Suppressing the
+    /// common case would make absence mean both "a party said so" and "nobody
+    /// recorded who said so", collapsing the one distinction this field is for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dialog_assertion: Option<String>,
 }
 
 impl StreamSummary {
@@ -358,6 +373,10 @@ impl StreamSummary {
                 .dialog_bound_across_sources()
                 .then(|| s.dialog_origin.map(|o| o.as_str().to_string()))
                 .flatten(),
+            // Ungated, unlike `dialog_origin`: see the field's own note. The
+            // spelling is the enum's, so REST, MCP and the call report cannot
+            // name a relay assertion three ways.
+            dialog_assertion: s.dialog_assertion.map(|a| a.as_str().to_string()),
         }
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2815,6 +2815,122 @@ mod relay_control_tests {
         );
     }
 
+    /// The relay assertion survives all the way to a reader.
+    ///
+    /// The test below proves the pipeline writes the right provenance onto the
+    /// stream. That is not the same as anyone being able to SEE it, and for as
+    /// long as this feature existed nobody could: `dialog_assertion` was
+    /// written on every binding, and `EndpointAssertion::as_str` carried a doc
+    /// comment describing itself as "the name this assertion is written under
+    /// on every output surface" while no output surface wrote it and nothing
+    /// outside tests ever called it. The whole point of asking an rtpengine
+    /// relay what it is carrying is to be able to tell its claim about a port
+    /// apart from a party's claim about its own address -- and the answer
+    /// reached no operator, no agent and no HTTP client.
+    ///
+    /// Asserted through the SHARED renderer both APIs and the call report
+    /// serialize through, so this covers `GET /v1/streams/{id}`, MCP
+    /// `rtp_stats` and the `streams` array of a call report at once.
+    ///
+    /// Gated on the ITEM rather than the module, per the pre-push hook's own
+    /// advice: `crate::output` is `native`-only, and gating the whole
+    /// `relay_control_tests` module would take the three tests either side of
+    /// this one out of every feature combination that does not build a
+    /// renderer -- which is exactly where a store-level regression would be
+    /// cheapest to catch.
+    #[cfg(feature = "native")]
+    #[test]
+    fn a_relay_assertion_reaches_the_serialized_stream() {
+        use crate::capture::ParsedPacket;
+        use crate::capture::parse::{InputOrigin, TransportProto};
+        use crate::rtp::parser::RtpHeader;
+        use crate::rtp::stream_store::StreamStore;
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let relay = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 40));
+        let ts = chrono::Utc::now();
+
+        // One RTP packet at the endpoint under test, built the way production
+        // builds one. Registration alone creates no stream -- a stream is a
+        // thing packets made -- so without this there is nothing to serialize.
+        let media = |port: u16| ParsedPacket {
+            frame: None,
+            timestamp: ts,
+            src_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            dst_addr: relay,
+            src_port: 20000,
+            dst_port: port,
+            transport: TransportProto::Udp,
+            payload: vec![0u8; 12 + 160].into(),
+            ip_id: None,
+            tcp_seq: None,
+            tcp_flags: None,
+            fragment_offset: None,
+            more_fragments: false,
+            ip_protocol: 17,
+            dscp: None,
+            input_origin: InputOrigin::Wire,
+        };
+        let rtp = RtpHeader {
+            version: 2,
+            padding: false,
+            extension: false,
+            csrc_count: 0,
+            marker: false,
+            payload_type: 0,
+            sequence: 1,
+            timestamp: 160,
+            ssrc: 0xDEAD_BEEF,
+            payload_offset: 12,
+        };
+
+        let rendered = |store: &StreamStore| -> serde_json::Value {
+            let stream = store.iter().next().expect("the packet created a stream");
+            serde_json::from_str(&crate::output::json::stream_to_json(stream))
+                .expect("the renderer emits valid JSON")
+        };
+
+        // The relay's own `ng` control plane naming a port it allocated.
+        let sdp = "v=0\r\nc=IN IP4 10.0.0.40\r\nm=audio 38664 RTP/AVP 0";
+        let raw = format!("ck d3:sdp{}:{sdp}6:result2:oke", sdp.len());
+        let links = crate::rtpengine::sdp_links_from_ng(raw.as_bytes(), Some("cid1"));
+        assert_eq!(links.len(), 1, "fixture must yield exactly one endpoint");
+
+        let mut relay_store = StreamStore::new(1000);
+        super::apply_relay_control_links(&mut relay_store, &links, InputOrigin::Hep, ts);
+        relay_store.process_rtp(&media(links[0].1), &rtp, ts);
+        let relay_json = rendered(&relay_store);
+
+        assert_eq!(
+            relay_json["dialog_assertion"], "media-relay",
+            "a reader must be able to tell the relay named this port: {relay_json}"
+        );
+
+        // The other arm, and the reason the first one means anything. If a
+        // relay assertion and an ordinary signaled one rendered the same, the
+        // key would be decoration -- present, stable, and carrying nothing.
+        let mut signaled_store = StreamStore::new(1000);
+        signaled_store.link_to_dialog_with_sdp_from(
+            links[0].0,
+            links[0].1,
+            &links[0].2,
+            &links[0].3,
+            crate::rtp::stream_store::SdpProvenance::observed(InputOrigin::Wire, ts),
+        );
+        signaled_store.process_rtp(&media(links[0].1), &rtp, ts);
+        let signaled_json = rendered(&signaled_store);
+
+        assert_eq!(
+            signaled_json["dialog_assertion"], "signaled",
+            "a party's own SDP must not read as a relay's claim: {signaled_json}"
+        );
+        assert_ne!(
+            relay_json["dialog_assertion"], signaled_json["dialog_assertion"],
+            "the two assertions must be distinguishable on the wire, or the key \
+             tells a reader nothing"
+        );
+    }
+
     /// RE3, at the point it actually matters: the endpoint WRITTEN to the
     /// store must record that a media relay asserted it.
     ///

--- a/src/tui/stream_detail.rs
+++ b/src/tui/stream_detail.rs
@@ -113,6 +113,20 @@ pub fn render_stream_detail(
         ),
         Span::raw("  Dialog: "),
         Span::raw(stream.associated_dialog.as_deref().unwrap_or("(orphaned)")),
+        // WHO said this stream belongs to that dialog. A relay's assertion is
+        // authoritative about the port -- it opened it -- but names the leg's
+        // MIDPOINT, so an operator tracing where media actually went is looking
+        // at a different picture from the one a signaled endpoint gives them.
+        // Beside the Call-ID because it qualifies the Call-ID and nothing else,
+        // and absent (rather than a word meaning "probably a party") when
+        // nobody recorded who asserted it.
+        Span::styled(
+            stream
+                .dialog_assertion
+                .map(|a| format!(" (via {})", a.as_str()))
+                .unwrap_or_default(),
+            Style::default().fg(theme.muted),
+        ),
     ]));
 
     lines.push(Line::raw(""));

--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -2590,7 +2590,16 @@ fn no_documentation_table_repeats_a_row() {
     // `defined only`) that the page never defined. Attributed by measurement
     // before the number moved: that file gained exactly one table separator and
     // no other page gained any, and design docs have no generated mirror.
-    const EXPECTED_TABLES: usize = 628;
+    // 628 -> 634: three hand-written tables and their three generated mirrors,
+    // all the same two-row table saying who asserted a stream's dialog --
+    // `signaled` (a party's own SDP) against `media-relay` (an rtpengine relay
+    // naming a port it allocated). One each in `docs/rtpengine.md`,
+    // `docs/rest-api.md` and `docs/mcp-tools.md`, because the three readers
+    // arrive at the fact from three different doors and none of them reads the
+    // other two pages. Attributed by measurement before the number moved: those
+    // six files gained exactly one table separator each and no other page
+    // gained any.
+    const EXPECTED_TABLES: usize = 634;
 
     let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let out = std::process::Command::new("git")

--- a/tests/link_integrity_test.rs
+++ b/tests/link_integrity_test.rs
@@ -605,7 +605,12 @@ fn wiki_intra_docs_links_resolve() {
     // The changelog lives in CHANGELOG.md; a tool reference describes what the
     // tools do now. No other page moved, and the extractor still matches --
     // the drop is a deletion, not a narrowing.
-    const EXPECTED_WIKI_LINKS: usize = 478;
+    // 478 -> 480: two links to rtpengine.md, one from docs/rest-api.md and one
+    // from docs/mcp-tools.md, where each `dialog_assertion` section says what a
+    // `media-relay` assertion IS rather than re-explaining relay attribution
+    // twice. Two pages, one link each; the site mirrors are generated and this
+    // gate reads docs/.
+    const EXPECTED_WIKI_LINKS: usize = 480;
     // Raised 459 -> 460 when SRC1 stage 1 shipped: docs/cli-reference.md's
     // `--hep-listen` row now points at cookbook recipe 6d in docs/examples.md
     // rather than restating how to pair `-L` with `-d`. Attributed per file

--- a/tests/round_trip_surface_test.rs
+++ b/tests/round_trip_surface_test.rs
@@ -66,6 +66,11 @@ fn unmeasured() -> serde_json::Value {
         // capture source, and `None` is the honest answer rather than `wire`.
         input_origin: None,
         dialog_origin: None,
+        // Nobody said who asserted the endpoint, which is what a hand-built
+        // summary honestly knows. `None` here is "nobody said" and must not be
+        // filled in with `signaled` -- that is a claim, and it is the exact
+        // claim this field exists to keep apart from a relay's.
+        dialog_assertion: None,
     };
     serde_json::to_value(s).expect("serialize")
 }
@@ -129,6 +134,11 @@ fn a_measured_round_trip_carries_its_provenance() {
         // capture source, and `None` is the honest answer rather than `wire`.
         input_origin: None,
         dialog_origin: None,
+        // Nobody said who asserted the endpoint, which is what a hand-built
+        // summary honestly knows. `None` here is "nobody said" and must not be
+        // filled in with `signaled` -- that is a claim, and it is the exact
+        // claim this field exists to keep apart from a relay's.
+        dialog_assertion: None,
     };
 
     let xr = serde_json::to_value(
@@ -181,6 +191,11 @@ fn a_measured_zero_is_reported_rather_than_hidden() {
         round_trip_source: None,
         input_origin: None,
         dialog_origin: None,
+        // Nobody said who asserted the endpoint, which is what a hand-built
+        // summary honestly knows. `None` here is "nobody said" and must not be
+        // filled in with `signaled` -- that is a claim, and it is the exact
+        // claim this field exists to keep apart from a relay's.
+        dialog_assertion: None,
     }
     .with_round_trip(Some((0.0, RttSource::XrVoipMetrics)));
 

--- a/tests/schemas/call_report.schema.json
+++ b/tests/schemas/call_report.schema.json
@@ -490,7 +490,15 @@
           ],
           "description": "Which capture source this stream's MEDIA arrived over. Absent rather than null when the stream came from no captured packet."
         },
-        "dialog_origin": {
+        "dialog_assertion": {
+      "type": "string",
+      "enum": [
+        "signaled",
+        "media-relay"
+      ],
+      "description": "WHO asserted the SDP media endpoint that named this stream's dialog: `signaled` (a negotiating party describing its own address) or `media-relay` (an rtpengine relay describing a port it allocated, learned from its `ng` control plane). A different question from `dialog_origin`, which says which capture SOURCE delivered the assertion. A relay's address is authoritative -- it cannot be wrong about which port it opened -- but it names the leg's MIDPOINT rather than either party's endpoint, so the two answers describe different pictures of where the media went. Emitted whenever it is known, `signaled` included: suppressing the common case would make absence mean both 'a party said so' and 'nobody recorded who said so'. Absent therefore means only the latter."
+    },
+    "dialog_origin": {
           "type": "string",
           "enum": [
             "wire",

--- a/tests/schemas/stream.schema.json
+++ b/tests/schemas/stream.schema.json
@@ -65,6 +65,14 @@
       ],
       "description": "Which capture source this stream's MEDIA arrived over. Absent rather than null when the stream came from no captured packet."
     },
+    "dialog_assertion": {
+      "type": "string",
+      "enum": [
+        "signaled",
+        "media-relay"
+      ],
+      "description": "WHO asserted the SDP media endpoint that named this stream's dialog: `signaled` (a negotiating party describing its own address) or `media-relay` (an rtpengine relay describing a port it allocated, learned from its `ng` control plane). A different question from `dialog_origin`, which says which capture SOURCE delivered the assertion. A relay's address is authoritative -- it cannot be wrong about which port it opened -- but it names the leg's MIDPOINT rather than either party's endpoint, so the two answers describe different pictures of where the media went. Emitted whenever it is known, `signaled` included: suppressing the common case would make absence mean both 'a party said so' and 'nobody recorded who said so'. Absent therefore means only the latter."
+    },
     "dialog_origin": {
       "type": "string",
       "enum": [

--- a/tests/surface_parity_test.rs
+++ b/tests/surface_parity_test.rs
@@ -235,6 +235,103 @@ const QUALITY_METRICS: &[Metric] = &[
     },
 ];
 
+/// Provenance sipnab RECORDS on a stream, which must reach somebody.
+///
+/// A different question from [`QUALITY_METRICS`], and a weaker bar on purpose.
+/// Those are numbers that decide whether a call was acceptable, and one surface
+/// having them alone is drift. These are facts about WHERE an answer came from,
+/// and the failure mode is not asymmetry -- it is a field the program takes the
+/// trouble to record and then shows to nobody at all.
+///
+/// That is not hypothetical. `dialog_assertion` says whether the SDP endpoint
+/// that named a stream's dialog was a negotiating party describing its own
+/// address or a media relay describing a port it allocated -- the entire point
+/// of asking an rtpengine relay what it is carrying. It was written on every
+/// binding, and `EndpointAssertion::as_str` carried a doc comment calling itself
+/// "the name this assertion is written under on every output surface" while no
+/// output surface wrote it and nothing outside tests ever called it.
+///
+/// Each entry must ALSO be verified to still exist on the stream, so this list
+/// cannot outlive the field it names and start asserting about nothing.
+const RECORDED_PROVENANCE: &[Metric] = &[
+    // Which capture source the MEDIA arrived over.
+    Metric::named("input_origin"),
+    // Which source delivered the SDP that named the dialog, when it differs.
+    Metric::named("dialog_origin"),
+    // WHO asserted that SDP endpoint: a party, or a relay describing its own
+    // socket. `asserted_by` is the field on the provenance record it is copied
+    // from, and `media-relay` is the wire spelling, neither of which
+    // whole-identifier matching sees in the other.
+    Metric {
+        name: "dialog_assertion",
+        aliases: &["asserted_by", "media-relay"],
+    },
+];
+
+/// Every provenance field the program records reaches at least one surface, and
+/// anything one API carries the other carries too.
+///
+/// The first half is the one that failed: a field can be computed, stored and
+/// unit-tested without a single reader ever being able to see it, and nothing
+/// else in this suite notices. The second half holds the ones that DO get out
+/// to the same standard the quality metrics are held to.
+#[test]
+fn provenance_the_program_records_reaches_a_reader() {
+    let stream = code("src/rtp/stream.rs");
+    let mcp = mcp_surface();
+    let api = rest_surface();
+    let tui = code("src/tui");
+
+    let mut unrecorded = Vec::new();
+    let mut invisible = Vec::new();
+    let mut asymmetric = Vec::new();
+
+    for m in RECORDED_PROVENANCE {
+        // The list must describe this program, not a past one.
+        if !uses(&stream, m.name) {
+            unrecorded.push(m.name);
+            continue;
+        }
+        let in_mcp = m.carried_by(&mcp);
+        let in_api = m.carried_by(&api);
+        if !in_mcp && !in_api && !m.carried_by(&tui) {
+            invisible.push(m.name);
+            continue;
+        }
+        if in_mcp != in_api {
+            asymmetric.push(format!(
+                "`{}` is on {} but not the other",
+                m.name,
+                if in_mcp { "MCP" } else { "the REST API" }
+            ));
+        }
+    }
+
+    assert!(
+        unrecorded.is_empty(),
+        "these fields are named here but no longer exist on RtpStream: {}\n\
+         Remove the entry, or restore the field -- a list naming a deleted \
+         field asserts nothing while looking like it asserts something.",
+        unrecorded.join(", ")
+    );
+
+    assert!(
+        invisible.is_empty(),
+        "sipnab records these and shows them to nobody: {}\n\n\
+         Not one of REST, MCP or the TUI emits them. Work went into deciding \
+         each of these and the answer reaches no reader, which is the same as \
+         not having decided it -- except that it costs memory and reads as a \
+         feature to anyone who greps for it.",
+        invisible.join(", ")
+    );
+
+    assert!(
+        asymmetric.is_empty(),
+        "provenance on one API door and not the other:\n  {}",
+        asymmetric.join("\n  ")
+    );
+}
+
 /// A quality metric and every identifier that carries it.
 ///
 /// Most metrics are spelled the same everywhere, so `aliases` is usually just

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -881,6 +881,31 @@ The MCP `rtp_stats` tool carries the same three keys, and the TUI's stream
 detail view draws the same distinction: an ungrounded score renders muted and
 annotated rather than in a quality band color.
 
+#### Who named the dialog
+
+`dialog_assertion` says who asserted the SDP media endpoint that tied this
+stream to its Call-ID:
+
+| Value | Who said it | What the address is |
+|-------|-------------|---------------------|
+| `signaled` | a negotiating party, in its own SDP | that party's endpoint |
+| `media-relay` | an rtpengine relay, about a port it allocated | the leg's **midpoint** |
+
+A relay's answer is authoritative about the port — rtpengine cannot be wrong
+about which socket it opened — and at the same time it is not an endpoint. An
+operator tracing one-way audio to `10.0.0.40:38664` needs to know whether that
+address is the far end or the box in the middle, and the two lead to opposite
+next steps.
+
+sipnab emits the key whenever it knows the answer, `signaled` included. **Absent means
+nobody recorded who asserted it**, never "a party did" — that is a claim, and
+keeping the two apart is why the field exists.
+
+It answers a different question from `dialog_origin`, which names the capture
+**source** that delivered the assertion rather than its author. See
+[rtpengine relay attribution](@/docs/rtpengine.md) for how a relay comes to name a
+call whose signaling sipnab never saw.
+
 ---
 
 ### GET /v1/streams/:id

--- a/website/content/docs/mcp-tools.md
+++ b/website/content/docs/mcp-tools.md
@@ -768,6 +768,28 @@ either direction: its nine modes genuinely span about 4.49 down to 3.51. Do not
 report a MOS to a human without checking this field. See
 [MOS and codecs](@/docs/mos-and-codecs.md) for the full picture.
 
+#### Who named the dialog — `dialog_assertion`
+
+Each stream also says who asserted the SDP media endpoint that tied it to its
+Call-ID:
+
+| `dialog_assertion` | Who said it | What the address is |
+|---|---|---|
+| `signaled` | a negotiating party, in its own SDP | that party's endpoint |
+| `media-relay` | an rtpengine relay, about a port it allocated | the leg's **midpoint** |
+
+A relay cannot be wrong about which socket it opened, so the address is
+authoritative — and it is still not an endpoint. An agent reasoning about where
+media went must not report a `media-relay` address as the far party's, because
+it names the box in the middle and the two lead to opposite conclusions.
+
+sipnab emits the key whenever it knows the answer, `signaled` included. **Absent
+means nobody recorded who asserted it**, never "a party did". Do not default it.
+
+Distinct from `dialog_origin`, which names the capture **source** that delivered
+the assertion rather than its author. See
+[rtpengine relay attribution](@/docs/rtpengine.md).
+
 #### Capture-wide sweep — omit `call_id`
 
 "Every stream with a MOS below 3.5" is one call rather than a listing plus one

--- a/website/content/docs/rtpengine.md
+++ b/website/content/docs/rtpengine.md
@@ -220,6 +220,36 @@ never appears in the capture — the whole reason for asking — lands under
 **Calls named by a media relay**, the same heading the mirrored control
 plane fills.
 
+#### Telling a relay's answer from a party's
+
+Every stream says who named its dialog, on every door:
+
+| Value | Who said it | What the address is |
+|-------|-------------|---------------------|
+| `signaled` | a negotiating party, in its own SDP | that party's endpoint |
+| `media-relay` | rtpengine, about a port it allocated | the leg's **midpoint** |
+
+`GET /v1/streams` and `GET /v1/streams/{id}` carry it as `dialog_assertion`,
+the MCP `rtp_stats` tool carries the same key with the same two spellings, and
+the TUI's stream detail prints `(via media-relay)` beside the Call-ID.
+
+The distinction changes what the address means, which is why it is not folded
+away. A relay's answer is **authoritative about the port** — rtpengine cannot
+be wrong about which socket it opened — and at the same time it is **not an
+endpoint**: it names the box the media passed through, not where either party
+sits. An operator tracing a one-way-audio fault to `10.0.0.40:38664` needs to
+know whether that is the far end or the box in the middle, and those lead to
+opposite next steps.
+
+An absent key means nobody recorded who asserted the binding. It does not mean
+`signaled` — that is a claim, and keeping the two apart is the entire reason
+the field exists.
+
+`dialog_assertion` is a different question from `dialog_origin`, which says
+which **capture source** delivered the assertion. A relay can name a stream over a
+HEP mirror or answer sipnab directly, and a party's SDP can arrive off the NIC.
+The two keys answer one half of that each.
+
 The second summary arrives when the capture ends:
 
 ```text

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2865,6 +2865,31 @@ The MCP `rtp_stats` tool carries the same three keys, and the TUI's stream
 detail view draws the same distinction: an ungrounded score renders muted and
 annotated rather than in a quality band color.
 
+#### Who named the dialog
+
+`dialog_assertion` says who asserted the SDP media endpoint that tied this
+stream to its Call-ID:
+
+| Value | Who said it | What the address is |
+|-------|-------------|---------------------|
+| `signaled` | a negotiating party, in its own SDP | that party's endpoint |
+| `media-relay` | an rtpengine relay, about a port it allocated | the leg's **midpoint** |
+
+A relay's answer is authoritative about the port — rtpengine cannot be wrong
+about which socket it opened — and at the same time it is not an endpoint. An
+operator tracing one-way audio to `10.0.0.40:38664` needs to know whether that
+address is the far end or the box in the middle, and the two lead to opposite
+next steps.
+
+sipnab emits the key whenever it knows the answer, `signaled` included. **Absent means
+nobody recorded who asserted it**, never "a party did" — that is a claim, and
+keeping the two apart is why the field exists.
+
+It answers a different question from `dialog_origin`, which names the capture
+**source** that delivered the assertion rather than its author. See
+[rtpengine relay attribution](rtpengine.md) for how a relay comes to name a
+call whose signaling sipnab never saw.
+
 ---
 
 ### GET /v1/streams/:id
@@ -4173,6 +4198,36 @@ Streams the relay accounts for stop orphaning. A call whose own signaling
 never appears in the capture — the whole reason for asking — lands under
 **Calls named by a media relay**, the same heading the mirrored control
 plane fills.
+
+#### Telling a relay's answer from a party's
+
+Every stream says who named its dialog, on every door:
+
+| Value | Who said it | What the address is |
+|-------|-------------|---------------------|
+| `signaled` | a negotiating party, in its own SDP | that party's endpoint |
+| `media-relay` | rtpengine, about a port it allocated | the leg's **midpoint** |
+
+`GET /v1/streams` and `GET /v1/streams/{id}` carry it as `dialog_assertion`,
+the MCP `rtp_stats` tool carries the same key with the same two spellings, and
+the TUI's stream detail prints `(via media-relay)` beside the Call-ID.
+
+The distinction changes what the address means, which is why it is not folded
+away. A relay's answer is **authoritative about the port** — rtpengine cannot
+be wrong about which socket it opened — and at the same time it is **not an
+endpoint**: it names the box the media passed through, not where either party
+sits. An operator tracing a one-way-audio fault to `10.0.0.40:38664` needs to
+know whether that is the far end or the box in the middle, and those lead to
+opposite next steps.
+
+An absent key means nobody recorded who asserted the binding. It does not mean
+`signaled` — that is a claim, and keeping the two apart is the entire reason
+the field exists.
+
+`dialog_assertion` is a different question from `dialog_origin`, which says
+which **capture source** delivered the assertion. A relay can name a stream over a
+HEP mirror or answer sipnab directly, and a party's SDP can arrive off the NIC.
+The two keys answer one half of that each.
 
 The second summary arrives when the capture ends:
 
@@ -13480,6 +13535,28 @@ For AMR-WB specifically the placeholder is wrong by roughly a full MOS point in
 either direction: its nine modes genuinely span about 4.49 down to 3.51. Do not
 report a MOS to a human without checking this field. See
 [MOS and codecs](mos-and-codecs.md) for the full picture.
+
+#### Who named the dialog — `dialog_assertion`
+
+Each stream also says who asserted the SDP media endpoint that tied it to its
+Call-ID:
+
+| `dialog_assertion` | Who said it | What the address is |
+|---|---|---|
+| `signaled` | a negotiating party, in its own SDP | that party's endpoint |
+| `media-relay` | an rtpengine relay, about a port it allocated | the leg's **midpoint** |
+
+A relay cannot be wrong about which socket it opened, so the address is
+authoritative — and it is still not an endpoint. An agent reasoning about where
+media went must not report a `media-relay` address as the far party's, because
+it names the box in the middle and the two lead to opposite conclusions.
+
+sipnab emits the key whenever it knows the answer, `signaled` included. **Absent
+means nobody recorded who asserted it**, never "a party did". Do not default it.
+
+Distinct from `dialog_origin`, which names the capture **source** that delivered
+the assertion rather than its author. See
+[rtpengine relay attribution](rtpengine.md).
 
 #### Capture-wide sweep — omit `call_id`
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5625 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5627 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5625" data-suffix="">5625</span>
+        <span class="arch-stat" data-count="5627" data-suffix="">5627</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>


### PR DESCRIPTION
## The finding

sipnab can ask an rtpengine relay which calls it is carrying. The answer
carries a fact a party's SDP cannot: whether an endpoint is a **negotiating
party describing its own address** or a **relay describing a port it
allocated**. sipnab wrote that on every binding as `dialog_assertion` — and
showed it to nobody.

`EndpointAssertion::as_str` carried a doc comment calling itself *"the name this
assertion is written under on every output surface."* No output surface wrote
it. Nothing outside tests ever called it. The one thing RE4 exists to establish
reached no operator, no agent and no HTTP client.

## Why it matters at 3am

A relay's answer is **authoritative about the port** — rtpengine cannot be wrong
about which socket it opened. It is also **not an endpoint**: it names the leg's
*midpoint*.

An operator tracing one-way audio to `10.0.0.40:38664` needs to know whether
that address is the far end or the box in the middle. Those lead to opposite
next steps, and until now the answer was in memory and nowhere else.

## What changed

| Surface | How it reads |
|---|---|
| `GET /v1/streams`, `GET /v1/streams/{id}` | `"dialog_assertion": "media-relay"` |
| MCP `rtp_stats` | same key, same two spellings |
| Call report `streams[]` | same |
| TUI stream detail | `Dialog: cid1 (via media-relay)` |

One edit to the shared renderer reached the first three; `StreamSummary` covers
the list endpoint and the TUI's JSON save.

## One deliberate asymmetry

`dialog_assertion` is emitted **whenever it is known, `signaled` included**,
while `dialog_origin` right beside it is emitted **only when it differs**.

That is not an inconsistency. `dialog_origin`'s interesting case is
disagreement, and its absence is well defined. Here the common case *is*
`signaled` — so suppressing it would leave absence meaning both "a party said
so" and "nobody recorded who said so", collapsing the exact distinction the
field exists for. Absent therefore means only "nobody said".

## How it was found, and how it stays found

A new gate, not a reading: `provenance_the_program_records_reaches_a_reader`
asserts every provenance field sipnab records on a stream reaches at least one
of REST, MCP or the TUI, and that anything one API carries the other carries
too. `dialog_assertion` failed it on the first run.

The gate also verifies each field still exists on `RtpStream`, so the list
cannot outlive what it names and quietly start asserting about nothing.

The wire test asserts **both** arms and is mutation-proven: rendering a constant
`"signaled"` fails it. That is the point — if a relay's claim and a party's
rendered identically, the key would be decoration: present, stable, and
carrying no information at all.

## Docs

Each reader gets it where they arrive — `docs/rtpengine.md` for the operator who
turned the feature on, `docs/rest-api.md` for the HTTP client, `docs/mcp-tools.md`
for the agent — each saying what the address **is**, and each linking rather
than re-arguing relay attribution.
