### PR TITLE
Say what the capture declined, on every door and not just the CLI

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -2269,6 +2269,9 @@ No parameters. Returns:
     "undecodable_frames": 0,
     "degraded": false
   },
+  "caveats": {
+    "media_creating_commands": 0  // relay commands seen and NOT attributed
+  },
   "source_exhausted": false,     // true once a file is read to the end
   "writing_to": null,            // path packets are being saved to, if any
   "unsaved": true,               // stopping now would lose packets
@@ -2338,6 +2341,27 @@ remedies, so a non-zero figure names its own flag:
 
 Both are zero on a live capture, where BPF filtered before the pipeline saw
 anything and there is nothing to under-report.
+
+#### What the capture DECLINED — `caveats`
+
+`capture_quality` above counts what the capture **lost**. `caveats` counts what
+sipnab **chose not to do**, which is a different thing and is not a defect.
+
+| Key | What it counts |
+|-----|----------------|
+| `media_creating_commands` | rtpengine `subscribe`, `publish` and `start recording` commands seen and deliberately not attributed |
+
+Those commands create media belonging to a call without being one of its two
+legs. Decoding one as an ordinary leg would make a two-party call report three
+streams, after which the analysis that judges one-way audio and asymmetry
+answers a question nobody asked — so sipnab counts them instead.
+
+**Read this before reasoning about a stream count.** A call with a recording
+fork has media on the wire that no `rtp_stats` row explains, and this number is
+how you know that is a decision rather than a gap. Zero is a real
+answer and the key is always present.
+
+`GET /v1/stats` carries the same block under the same name.
 
 ### `server_capabilities`
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1025,6 +1025,9 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
     "total": 46,
     "orphaned": 3
   },
+  "caveats": {
+    "media_creating_commands": 0
+  },
   "timing": {
     "pdd_p50_ms": 120,
     "pdd_p95_ms": 850,
@@ -1039,6 +1042,27 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
   }
 }
 ```
+
+`caveats` is the other half of that question, and it reads the opposite way.
+`capture_quality` counts what the capture **lost**. `caveats` counts what
+sipnab **declined**.
+
+| Key | What it counts |
+|-----|----------------|
+| `media_creating_commands` | rtpengine `subscribe`, `publish` and `start recording` commands seen and deliberately not attributed |
+
+Declining is the right call. Those commands create media belonging to a call
+without being one of its two legs, and decoding one as an ordinary leg makes a
+two-party call report three streams — after which the analysis that judges
+one-way audio and asymmetry answers a question nobody asked.
+
+Which makes the count the disclosure. A run that saw `start recording` and said
+nothing would be a tool that cannot say what it did not attribute. **The key is
+always present and zero is a real answer** — a field that appears only once
+something has happened is a field no client learns exists.
+
+The MCP `capture_status` tool carries the same block under the same name, so
+this endpoint and an agent never disagree about it.
 
 `capture_quality` says how much of the wire the rest of the response draws
 from. Read it before the counts, not after: with `degraded` true, every number

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1615,6 +1615,19 @@ pub struct CaptureStatusResponse {
     pub active_call_count: usize,
     /// Drops, invalid timestamps and undecodable frames on the capture path.
     pub capture_quality: CaptureQualityJson,
+    /// What the capture DECLINED, beside what it lost.
+    ///
+    /// `capture_quality` above counts packets that went missing.
+    /// This counts work sipnab chose not to do and owes an answer for --
+    /// today, media-creating relay commands seen and deliberately not
+    /// attributed. An agent reasoning about a call's stream count has to know
+    /// whether any went past, because sipnab declining to decode them is why
+    /// the count is what it is.
+    ///
+    /// The same projection `GET /v1/stats` embeds
+    /// ([`CaptureCaveats`](crate::output::json::CaptureCaveats)), so an agent
+    /// and an HTTP client cannot be told different things.
+    pub caveats: serde_json::Value,
     /// True once a file source has been read to the end.
     pub source_exhausted: bool,
     /// Where packets are being written, if anywhere.
@@ -4568,6 +4581,10 @@ impl SipnabMcp {
                 active_dialog_count: ds.active_dialog_count(),
                 active_call_count: ds.active_call_count(),
                 capture_quality,
+                // Read from the process-global tally, with no lock held: it has
+                // no relationship to either store's revision, so folding it
+                // inside the guards would buy nothing and cost contention.
+                caveats: crate::output::json::CaptureCaveats::current().to_json(),
                 source_exhausted: exhausted,
                 writing_to: writing_to.clone(),
                 // Only a live capture can hold packets that exist nowhere else.
@@ -7550,6 +7567,52 @@ mod tests {
 
     /// `capture_status` reports SIP the portrange skipped (#95).
     ///
+    /// `capture_status` carries what the capture DECLINED, under the same key
+    /// and the same name `GET /v1/stats` uses.
+    ///
+    /// The number counts media-creating relay commands -- `subscribe`,
+    /// `publish`, `start recording` -- that sipnab saw and deliberately did not
+    /// attribute. Declining is the right call: decoded as an ordinary leg, a
+    /// two-party call reports three streams and the media analysis then answers
+    /// a question nobody asked. But an agent reasoning about a stream count
+    /// needs to know some went past, because sipnab's decision is why the count
+    /// is what it is -- and until this key existed the response was
+    /// byte-identical whether one had gone past or a thousand.
+    ///
+    /// Asserted at ZERO as well as present, for the reason the unanalysed-SIP
+    /// test below gives about key presence: a field that appears only once
+    /// something has happened is a field no client learns exists.
+    #[tokio::test]
+    async fn capture_status_carries_what_the_capture_declined() {
+        let result = empty_server()
+            .capture_status()
+            .await
+            .expect("capture_status");
+        let v: serde_json::Value = serde_json::from_str(&text_of(&result)).unwrap();
+
+        let seen = v["caveats"]["media_creating_commands"]
+            .as_u64()
+            .unwrap_or_else(|| panic!("declined work must be a number on every response: {v}"));
+
+        // The tally is process-global and shared with every other test in this
+        // binary, so this is a DELTA. An exact figure would be true only until
+        // the next test ran.
+        crate::rtpengine::note_media_creating_command();
+        let after_result = empty_server()
+            .capture_status()
+            .await
+            .expect("capture_status");
+        let after: serde_json::Value = serde_json::from_str(&text_of(&after_result)).unwrap();
+        assert!(
+            after["caveats"]["media_creating_commands"]
+                .as_u64()
+                .expect("still a number")
+                > seen,
+            "a media-creating command went past and the count did not move; the \
+             key is wired to nothing: {after}"
+        );
+    }
+
     /// `dialog_count` alone reads as "how much was there". On the corpus it was
     /// 2,311 against 3,712 real — 37.7% lost — because a third of the SIP never
     /// touches 5060/5061. That reached the operator as stderr warnings and

--- a/src/output/api.rs
+++ b/src/output/api.rs
@@ -1021,6 +1021,11 @@ async fn get_stats(
     // atomics with no relationship to either store's revision, so holding a
     // lock across the read would buy nothing and cost contention.
     let quality = output::prometheus::CaptureQuality::current();
+    // What the capture DECLINED, beside what it lost. `capture_quality` below
+    // counts packets that went missing; this counts work sipnab chose not to
+    // do and owes the reader a number for. Same projection MCP's
+    // `capture_status` embeds, so the two doors cannot disagree about it.
+    let caveats = output::json::CaptureCaveats::current();
 
     Ok(Json(json!({
         // 2: `dialogs.in_call` added. `dialogs.active` is unchanged — it
@@ -1046,6 +1051,9 @@ async fn get_stats(
             "total": total_streams,
             "orphaned": orphaned_count,
         },
+        // Always present, always complete, and zero is a real answer. A key
+        // that shows up only on a bad run is a key no client learns exists.
+        "caveats": caveats.to_json(),
         "timing": {
             "pdd_p50_ms": pdd_p50,
             "pdd_p95_ms": pdd_p95,
@@ -1427,6 +1435,61 @@ mod tests {
 
         let resp = app.oneshot(req).await.expect("oneshot");
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// The declined-work count is on `/v1/stats`, present at zero, and moves
+    /// when a media-creating command goes past.
+    ///
+    /// Zero is the assertion that matters most here. A key that appears only
+    /// once something has gone wrong is a key no client learns exists, and a
+    /// dashboard cannot ask about a field it has never seen. The second half
+    /// then proves the key is wired to the tally rather than to the literal 0
+    /// that would satisfy the first half on its own.
+    #[tokio::test]
+    async fn stats_reports_declined_work_at_zero_and_when_it_happens() {
+        let before = crate::rtpengine::media_creating_commands_seen();
+
+        let app = build_router(make_state());
+        let parsed: Value = serde_json::from_str(
+            &body_to_string(
+                app.clone()
+                    .oneshot(test_request("/v1/stats"))
+                    .await
+                    .expect("oneshot")
+                    .into_body(),
+            )
+            .await,
+        )
+        .expect("valid JSON");
+        assert_eq!(
+            parsed["caveats"]["media_creating_commands"], before,
+            "the count must be present and complete on an ordinary response: {}",
+            parsed["caveats"]
+        );
+
+        // The tally is process-global and shared with every other test in this
+        // binary, so this asserts a DELTA rather than an absolute -- an exact
+        // figure here would be true only until the next test ran.
+        crate::rtpengine::note_media_creating_command();
+
+        let parsed: Value = serde_json::from_str(
+            &body_to_string(
+                app.oneshot(test_request("/v1/stats"))
+                    .await
+                    .expect("oneshot")
+                    .into_body(),
+            )
+            .await,
+        )
+        .expect("valid JSON");
+        let after = parsed["caveats"]["media_creating_commands"]
+            .as_u64()
+            .expect("the count is a number");
+        assert!(
+            after > before,
+            "a media-creating command went past and the count did not move \
+             ({before} -> {after}); the key is wired to nothing"
+        );
     }
 
     /// `GET /v1/stats` returns 200 with dialogs/streams/timing objects and

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -933,6 +933,64 @@ fn build_stream_json(stream: &RtpStream) -> StreamJson {
     }
 }
 
+/// What this capture could NOT do, in one shape for every door.
+///
+/// Lives here rather than beside either server for the reason
+/// `tests/surface_parity_test.rs` records about this exact file: both surfaces
+/// delegate to it, so both surface scans include it, and a projection put
+/// anywhere else would be invisible to the gate that keeps the two in step.
+///
+/// The contents are counts of things sipnab declined, could not read, or was
+/// never given what it needed for. They are load-bearing in a way an ordinary
+/// metric is not, because **their absence is not neutral**: a response that
+/// omits them does not read as incomplete, it reads as clean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct CaptureCaveats {
+    /// Media-creating relay commands seen and deliberately not attributed.
+    ///
+    /// `subscribe`, `publish` and `start recording` create media that belongs
+    /// to a call without being one of its two legs. sipnab counts them rather
+    /// than decoding them, and that is a decision rather than a gap: counted as
+    /// an ordinary leg, a two-party call reports three streams, and the media
+    /// analysis that judges one-way audio and asymmetry then answers a question
+    /// nobody asked.
+    ///
+    /// Which makes the COUNT the disclosure. A run that saw `start recording`
+    /// and said nothing is the failure `src/rtpengine/mod.rs` names in its own
+    /// comment above the tally -- "a forensics tool that cannot say what it did
+    /// not attribute" -- and until this projection existed, only the CLI's
+    /// `--report` said it.
+    pub media_creating_commands: u64,
+}
+
+impl CaptureCaveats {
+    /// Read the process-global tallies.
+    ///
+    /// Cheap and lock-free, the same shape as
+    /// [`CaptureQuality::current`](crate::output::prometheus::CaptureQuality::current),
+    /// so a server can call it while holding nothing.
+    #[must_use]
+    pub fn current() -> Self {
+        Self {
+            media_creating_commands: crate::rtpengine::media_creating_commands_seen(),
+        }
+    }
+
+    /// The block both servers embed, always present and always complete.
+    ///
+    /// Emitted at ZERO rather than omitted, unlike the optional keys on a
+    /// stream. A key that appears only when something went wrong is a key no
+    /// client learns exists, and this is the one class of number where a
+    /// consumer has to be able to tell "nothing to report" from "this build
+    /// does not report it".
+    #[must_use]
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "media_creating_commands": self.media_creating_commands,
+        })
+    }
+}
+
 // ── Tests ────────────────────────────────────────────────────────────
 
 /// Tests for the NDJSON message projection (CSeq/SDP/malformed handling),

--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -2599,7 +2599,13 @@ fn no_documentation_table_repeats_a_row() {
     // other two pages. Attributed by measurement before the number moved: those
     // six files gained exactly one table separator each and no other page
     // gained any.
-    const EXPECTED_TABLES: usize = 634;
+    // 634 -> 638: two hand-written tables and their two generated mirrors, one
+    // each in `docs/rest-api.md` and `docs/mcp-tools.md`, listing what the new
+    // `caveats` block counts -- work sipnab DECLINED, as against the
+    // `capture_quality` block beside it, which counts what the capture LOST.
+    // Attributed by measurement before the number moved: those four files
+    // gained exactly one table separator each and no other page gained any.
+    const EXPECTED_TABLES: usize = 638;
 
     let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let out = std::process::Command::new("git")

--- a/tests/surface_parity_test.rs
+++ b/tests/surface_parity_test.rs
@@ -235,6 +235,99 @@ const QUALITY_METRICS: &[Metric] = &[
     },
 ];
 
+/// Counters that say what the capture COULD NOT do, which must reach every door.
+///
+/// The strictest list in this file, and the bar is "both APIs" rather than
+/// "somebody". A quality metric missing from one surface makes that surface
+/// less useful. One of these missing makes it **wrong**: every one of them
+/// counts something sipnab did not attribute, did not decode, or was never
+/// given the keys for, and a response that omits it does not read as
+/// incomplete. It reads as clean.
+///
+/// That is the failure this project has already named once, in its own words --
+/// "a forensics tool that cannot say what it did not attribute", written in the
+/// comment above the media-creating tally, whose value the CLI report printed
+/// and neither API did.
+///
+/// Each entry must ALSO be shown to exist in the code that keeps it, so the
+/// list cannot outlive the counter it names.
+const CAPTURE_CAVEAT_COUNTERS: &[Caveat] = &[
+    // `subscribe`, `publish` and `start recording` make media that belongs to a
+    // call without being one of its two legs. sipnab counts them rather than
+    // attributing them -- decoding one as an ordinary leg would make a
+    // two-party call report three streams -- so the count IS the disclosure.
+    Caveat {
+        kept_in: "src/rtpengine/mod.rs",
+        metric: Metric {
+            name: "media_creating",
+            aliases: &["media_creating_commands_seen", "MEDIA_CREATING_SEEN"],
+        },
+    },
+    // NEXT: `TlsDecryptReport` -- records offered to the decryptor against
+    // records actually opened. Not listed yet, and deliberately not listed
+    // before it can pass: the report is built from a decryptor `batch.rs` owns
+    // locally, so neither server can reach it without either process-global
+    // counters or a shared handle. Adding the entry is the first half of that
+    // change, not a note to be carried here indefinitely.
+];
+
+/// A counter, and the file that keeps it.
+struct Caveat {
+    kept_in: &'static str,
+    metric: Metric,
+}
+
+/// Every "what this capture could not do" counter is on BOTH APIs.
+///
+/// Not "at least one surface", which is the bar the provenance gate below
+/// uses. These change what a whole response MEANS, and a client that never
+/// learns the number was available cannot know to ask for it.
+#[test]
+fn caveat_counters_reach_both_api_doors() {
+    let mcp = mcp_surface();
+    let api = rest_surface();
+
+    let mut unkept = Vec::new();
+    let mut missing = Vec::new();
+
+    for c in CAPTURE_CAVEAT_COUNTERS {
+        // The list must describe this program, not a past one.
+        if !c.metric.carried_by(&code(c.kept_in)) {
+            unkept.push(format!("`{}` (not in {})", c.metric.name, c.kept_in));
+            continue;
+        }
+        let in_mcp = c.metric.carried_by(&mcp);
+        let in_api = c.metric.carried_by(&api);
+        if !in_mcp || !in_api {
+            missing.push(format!(
+                "`{}` -- MCP: {}, REST: {}",
+                c.metric.name,
+                if in_mcp { "yes" } else { "NO" },
+                if in_api { "yes" } else { "NO" }
+            ));
+        }
+    }
+
+    assert!(
+        unkept.is_empty(),
+        "these counters are named here but the code no longer keeps them: {}\n\
+         Remove the entry or restore the counter -- a list naming something \
+         deleted asserts nothing while looking like it asserts something.",
+        unkept.join(", ")
+    );
+
+    assert!(
+        missing.is_empty(),
+        "counters saying what the capture could not do, missing from an API \
+         door:\n  {}\n\n\
+         Every one of these counts something sipnab did not attribute, did not \
+         decode, or was never given the keys for. A response that omits one \
+         does not read as incomplete -- it reads as clean, which is the exact \
+         answer this project exists not to give.",
+        missing.join("\n  ")
+    );
+}
+
 /// Provenance sipnab RECORDS on a stream, which must reach somebody.
 ///
 /// A different question from [`QUALITY_METRICS`], and a weaker bar on purpose.

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -1030,6 +1030,9 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
     "total": 46,
     "orphaned": 3
   },
+  "caveats": {
+    "media_creating_commands": 0
+  },
   "timing": {
     "pdd_p50_ms": 120,
     "pdd_p95_ms": 850,
@@ -1044,6 +1047,27 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
   }
 }
 ```
+
+`caveats` is the other half of that question, and it reads the opposite way.
+`capture_quality` counts what the capture **lost**. `caveats` counts what
+sipnab **declined**.
+
+| Key | What it counts |
+|-----|----------------|
+| `media_creating_commands` | rtpengine `subscribe`, `publish` and `start recording` commands seen and deliberately not attributed |
+
+Declining is the right call. Those commands create media belonging to a call
+without being one of its two legs, and decoding one as an ordinary leg makes a
+two-party call report three streams — after which the analysis that judges
+one-way audio and asymmetry answers a question nobody asked.
+
+Which makes the count the disclosure. A run that saw `start recording` and said
+nothing would be a tool that cannot say what it did not attribute. **The key is
+always present and zero is a real answer** — a field that appears only once
+something has happened is a field no client learns exists.
+
+The MCP `capture_status` tool carries the same block under the same name, so
+this endpoint and an agent never disagree about it.
 
 `capture_quality` says how much of the wire the rest of the response draws
 from. Read it before the counts, not after: with `degraded` true, every number

--- a/website/content/docs/mcp-tools.md
+++ b/website/content/docs/mcp-tools.md
@@ -2274,6 +2274,9 @@ No parameters. Returns:
     "undecodable_frames": 0,
     "degraded": false
   },
+  "caveats": {
+    "media_creating_commands": 0  // relay commands seen and NOT attributed
+  },
   "source_exhausted": false,     // true once a file is read to the end
   "writing_to": null,            // path packets are being saved to, if any
   "unsaved": true,               // stopping now would lose packets
@@ -2343,6 +2346,27 @@ remedies, so a non-zero figure names its own flag:
 
 Both are zero on a live capture, where BPF filtered before the pipeline saw
 anything and there is nothing to under-report.
+
+#### What the capture DECLINED — `caveats`
+
+`capture_quality` above counts what the capture **lost**. `caveats` counts what
+sipnab **chose not to do**, which is a different thing and is not a defect.
+
+| Key | What it counts |
+|-----|----------------|
+| `media_creating_commands` | rtpengine `subscribe`, `publish` and `start recording` commands seen and deliberately not attributed |
+
+Those commands create media belonging to a call without being one of its two
+legs. Decoding one as an ordinary leg would make a two-party call report three
+streams, after which the analysis that judges one-way audio and asymmetry
+answers a question nobody asked — so sipnab counts them instead.
+
+**Read this before reasoning about a stream count.** A call with a recording
+fork has media on the wire that no `rtp_stats` row explains, and this number is
+how you know that is a decision rather than a gap. Zero is a real
+answer and the key is always present.
+
+`GET /v1/stats` carries the same block under the same name.
 
 ### `server_capabilities`
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -3014,6 +3014,9 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
     "total": 46,
     "orphaned": 3
   },
+  "caveats": {
+    "media_creating_commands": 0
+  },
   "timing": {
     "pdd_p50_ms": 120,
     "pdd_p95_ms": 850,
@@ -3028,6 +3031,27 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
   }
 }
 ```
+
+`caveats` is the other half of that question, and it reads the opposite way.
+`capture_quality` counts what the capture **lost**. `caveats` counts what
+sipnab **declined**.
+
+| Key | What it counts |
+|-----|----------------|
+| `media_creating_commands` | rtpengine `subscribe`, `publish` and `start recording` commands seen and deliberately not attributed |
+
+Declining is the right call. Those commands create media belonging to a call
+without being one of its two legs, and decoding one as an ordinary leg makes a
+two-party call report three streams — after which the analysis that judges
+one-way audio and asymmetry answers a question nobody asked.
+
+Which makes the count the disclosure. A run that saw `start recording` and said
+nothing would be a tool that cannot say what it did not attribute. **The key is
+always present and zero is a real answer** — a field that appears only once
+something has happened is a field no client learns exists.
+
+The MCP `capture_status` tool carries the same block under the same name, so
+this endpoint and an agent never disagree about it.
 
 `capture_quality` says how much of the wire the rest of the response draws
 from. Read it before the counts, not after: with `degraded` true, every number
@@ -15042,6 +15066,9 @@ No parameters. Returns:
     "undecodable_frames": 0,
     "degraded": false
   },
+  "caveats": {
+    "media_creating_commands": 0  // relay commands seen and NOT attributed
+  },
   "source_exhausted": false,     // true once a file is read to the end
   "writing_to": null,            // path packets are being saved to, if any
   "unsaved": true,               // stopping now would lose packets
@@ -15111,6 +15138,27 @@ remedies, so a non-zero figure names its own flag:
 
 Both are zero on a live capture, where BPF filtered before the pipeline saw
 anything and there is nothing to under-report.
+
+#### What the capture DECLINED — `caveats`
+
+`capture_quality` above counts what the capture **lost**. `caveats` counts what
+sipnab **chose not to do**, which is a different thing and is not a defect.
+
+| Key | What it counts |
+|-----|----------------|
+| `media_creating_commands` | rtpengine `subscribe`, `publish` and `start recording` commands seen and deliberately not attributed |
+
+Those commands create media belonging to a call without being one of its two
+legs. Decoding one as an ordinary leg would make a two-party call report three
+streams, after which the analysis that judges one-way audio and asymmetry
+answers a question nobody asked — so sipnab counts them instead.
+
+**Read this before reasoning about a stream count.** A call with a recording
+fork has media on the wire that no `rtp_stats` row explains, and this number is
+how you know that is a decision rather than a gap. Zero is a real
+answer and the key is always present.
+
+`GET /v1/stats` carries the same block under the same name.
 
 ### `server_capabilities`
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5627 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5630 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5627" data-suffix="">5627</span>
+        <span class="arch-stat" data-count="5630" data-suffix="">5630</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>


### PR DESCRIPTION
## The finding

`subscribe`, `publish` and `start recording` create media that belongs to a
call **without being one of its two legs**. sipnab counts them rather than
attributing them — and that is the right call, not a gap: decoded as an
ordinary leg, a two-party call reports three streams, after which the media
analysis that judges one-way audio and asymmetry answers a question nobody
asked.

Which makes the **count** the disclosure. `src/rtpengine/mod.rs` says so in the
comment above the tally — *"a forensics tool that cannot say what it did not
attribute"* — and then only the CLI's `--report` said it.

`GET /v1/stats` and MCP `capture_status` were byte-identical whether one such
command had gone past or a thousand. An agent reasoning about a call's stream
count could not tell sipnab's decision from an absence of media.

## What changed

| Surface | Before | After |
|---|---|---|
| `--report` | prints the count | unchanged |
| `GET /v1/stats` | silent | `"caveats": { "media_creating_commands": N }` |
| MCP `capture_status` | silent | same block, same name |

`CaptureCaveats` in `src/output/json.rs` is the projection both servers embed.
It lives *there* for the reason that file already carries in
`tests/surface_parity_test.rs`: both surfaces delegate to it, both surface
scans include it, and a projection put anywhere else would be invisible to the
gate meant to keep the two in step.

## It reads the opposite way from the block beside it

`capture_quality` counts what the capture **lost**. `caveats` counts what
sipnab **declined**. Both belong on the page and neither substitutes for the
other.

**Always present, and zero is a real answer.** A key that appears only once
something has happened is a key no client learns exists, and a dashboard cannot
ask about a field it has never seen.

## The gate

`caveat_counters_reach_both_api_doors` is the strictest list in that file, and
the bar is **both APIs**, not "somebody".

A quality metric missing from one surface makes that surface less useful. One
of *these* missing makes it **wrong** — because a response that omits it does
not read as incomplete, it reads as clean, which is the exact answer this
project exists not to give.

It also verifies the counter still exists in the file that keeps it, so the
list cannot outlive what it names.

## The tests

Both assert a **delta**, not a figure: the tally is process-global and shared
with every other test in the binary, so an exact number would be true only
until the next test ran.

Both are mutation-proven — rendering a constant `0` fails them with *"the key
is wired to nothing"*, which is precisely what the present-at-zero half cannot
catch on its own.

## Deliberately not included

`TlsDecryptReport` is the other counter of this class. It is built from a
decryptor `batch.rs` owns locally, so neither server can reach it without
process-global counters or a shared handle. I left it **out of the gate list**
rather than listing something that could not pass — adding the entry is the
first half of that change, not a note to carry indefinitely.
