### PR TITLE
Report the SIP the port gate never analyzed, on REST as well as MCP

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1028,6 +1028,10 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
   "caveats": {
     "media_creating_commands": 0
   },
+  "unanalysed_sip_messages": 0,
+  "unanalysed_busiest_ports": [],
+  "unanalysed_websocket_messages": 0,
+  "unanalysed_websocket_ports": [],
   "timing": {
     "pdd_p50_ms": 120,
     "pdd_p95_ms": 850,
@@ -1102,6 +1106,40 @@ the end-of-run summary the command line prints.
 
 The MCP `capture_status` tool carries the same block under the same name, so
 this endpoint and an agent never disagree about it.
+
+### SIP the port gate never analyzed
+
+`unanalysed_sip_messages` is the largest loss this project has measured, and it
+is the one `capture_quality` cannot see. No packet went missing and no decoder gave up — sipnab read the
+bytes, recognized them as SIP, and set them aside because both ports fell
+outside `--portrange`.
+
+On the corpus that was **2,311 dialogs against 3,712 real: 37.7% gone**, because
+a third of the SIP never touches 5060/5061. `dialogs.total` alone reads as "how
+much was there", and a capture missing a third of its calls renders identically
+to one that only had two-thirds.
+
+| Key | Meaning |
+|-----|---------|
+| `unanalysed_sip_messages` | plain SIP with both ports outside `--portrange` |
+| `unanalysed_busiest_ports` | the top five ports carrying it, busiest first |
+| `unanalysed_websocket_messages` | SIP-over-WebSocket ([RFC 7118](https://www.rfc-editor.org/rfc/rfc7118)) outside the WebSocket port set |
+| `unanalysed_websocket_ports` | the top five ports carrying that |
+
+The ports travel with the counts because the answer has to name its own remedy —
+they are what you write into `--portrange`. A bare number says something is
+wrong without saying where to look.
+
+**The two counts stay apart because the remedies differ.** Widening
+`--portrange` recovers none of the WebSocket half. That needs `--ws-portrange`.
+This is the common case behind a WSS listener on a reverse proxy, and on
+Kamailio, OpenSIPS and Janus, which all default outside sipnab's shipped
+80/443/8080/8443.
+
+Both are zero on a live capture, where BPF filtered before the pipeline saw
+anything and there is nothing to under-report.
+
+MCP `capture_status` carries all four under the same names.
 
 `capture_quality` says how much of the wire the rest of the response draws
 from. Read it before the counts, not after: with `degraded` true, every number

--- a/src/output/api.rs
+++ b/src/output/api.rs
@@ -1026,6 +1026,33 @@ async fn get_stats(
     // do and owes the reader a number for. Same projection MCP's
     // `capture_status` embeds, so the two doors cannot disagree about it.
     let caveats = output::json::CaptureCaveats::current();
+    // SIP the PORT GATE excluded, before anything analyzed it. A different loss
+    // from `capture_quality` above -- nothing was dropped and nothing failed to
+    // decode; the bytes were read and then set aside because both ports fell
+    // outside the configured range.
+    //
+    // Measured on the corpus: 2,311 dialogs against 3,712 real, 37.7% lost,
+    // because a third of the SIP never touches 5060/5061. `dialogs.total` alone
+    // reads as "how much was there", and a capture missing a third of its calls
+    // renders identically to one that only had two-thirds.
+    //
+    // Same keys and same names as MCP `capture_status`, deliberately: a client
+    // that learned this from one door must not have to learn it again at the
+    // other.
+    let skipped = crate::pipeline::portrange_skip_report();
+    let ws_skipped = crate::pipeline::ws_port_skip_report();
+    // Top five, because the answer names its own remedy and an operator writes
+    // a `--portrange` from it. A full table would bury that.
+    // Takes the port slice rather than either report type: the two reports are
+    // separate structs that happen to carry the same `Vec<SkippedPort>`, and a
+    // closure over the slice serves both without a trait or a second copy.
+    let port_rows = |ports: &[crate::pipeline::SkippedPort]| -> Vec<Value> {
+        ports
+            .iter()
+            .take(5)
+            .map(|p| json!({ "port": p.port, "messages": p.messages }))
+            .collect()
+    };
 
     Ok(Json(json!({
         // 2: `dialogs.in_call` added. `dialogs.active` is unchanged — it
@@ -1054,6 +1081,16 @@ async fn get_stats(
         // Always present, always complete, and zero is a real answer. A key
         // that shows up only on a bad run is a key no client learns exists.
         "caveats": caveats.to_json(),
+        // Kept at the top level rather than folded into `caveats`, because MCP
+        // publishes them at the top level and the whole point is that the two
+        // doors name one fact the same way.
+        "unanalysed_sip_messages": skipped.messages,
+        "unanalysed_busiest_ports": port_rows(&skipped.ports),
+        // Counted apart, because the remedies differ and only one of them is
+        // `--portrange`. SIP-over-WebSocket outside the WS port set needs
+        // `--ws-portrange`; widening `--portrange` recovers none of it.
+        "unanalysed_websocket_messages": ws_skipped.messages,
+        "unanalysed_websocket_ports": port_rows(&ws_skipped.ports),
         "timing": {
             "pdd_p50_ms": pdd_p50,
             "pdd_p95_ms": pdd_p95,
@@ -1435,6 +1472,111 @@ mod tests {
 
         let resp = app.oneshot(req).await.expect("oneshot");
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// SIP the port gate excluded is on `/v1/stats`, under the SAME names MCP
+    /// `capture_status` uses, and the busiest ports come with it.
+    ///
+    /// The loss this catches is the largest one this project has measured: on
+    /// the corpus, 2,311 dialogs against 3,712 real -- 37.7% gone, because a
+    /// third of the SIP never touches 5060/5061. Nothing was dropped and
+    /// nothing failed to decode, so `capture_quality` is clean and
+    /// `dialogs.total` reads as "how much was there". A capture missing a third
+    /// of its calls renders identically to one that only had two-thirds.
+    ///
+    /// The ports travel with the count because the answer has to name its own
+    /// remedy: they are literally what an operator writes into `--portrange`.
+    /// A bare number tells a reader something is wrong and not where to look.
+    ///
+    /// Driven through the REAL gate rather than by poking the tally, so this
+    /// also proves the endpoint reads the counter the pipeline actually writes.
+    /// `serial`, because that counter is process-global and shared with every
+    /// other test in this binary.
+    #[tokio::test]
+    #[serial_test::serial(portrange_skips)]
+    async fn stats_reports_sip_the_port_gate_excluded_and_where_it_was() {
+        use crate::capture::parse::TransportProto;
+
+        crate::pipeline::reset_portrange_skips();
+
+        let app = build_router(make_state());
+        let stats = |app: axum::Router| async move {
+            let body = body_to_string(
+                app.oneshot(test_request("/v1/stats"))
+                    .await
+                    .expect("oneshot")
+                    .into_body(),
+            )
+            .await;
+            serde_json::from_str::<Value>(&body).expect("valid JSON")
+        };
+
+        let v = stats(app.clone()).await;
+        // Present at ZERO. A key that shows up only on a bad capture is a key
+        // no client learns exists, and a dashboard cannot ask for a field it
+        // has never seen.
+        for key in [
+            "unanalysed_sip_messages",
+            "unanalysed_busiest_ports",
+            "unanalysed_websocket_messages",
+            "unanalysed_websocket_ports",
+        ] {
+            assert!(v.get(key).is_some(), "`{key}` missing from /v1/stats: {v}");
+        }
+        assert_eq!(v["unanalysed_sip_messages"], 0);
+        assert!(
+            v["unanalysed_busiest_ports"]
+                .as_array()
+                .expect("array")
+                .is_empty()
+        );
+
+        // One OPTIONS to a SIP service on 8090, with the gate set to 5060-5061.
+        // The pipeline recognizes it as SIP, declines it, and counts it.
+        let sip = b"OPTIONS sip:probe@test SIP/2.0\r\nCall-ID: oor@test\r\nCSeq: 1 OPTIONS\r\n\r\n";
+        let pp = crate::capture::ParsedPacket {
+            frame: None,
+            timestamp: chrono::DateTime::from_timestamp(1_700_000_000, 0).expect("ts"),
+            src_addr: IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
+            dst_addr: IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 2)),
+            src_port: 41000,
+            dst_port: 8090,
+            transport: TransportProto::Udp,
+            payload: sip.to_vec().into(),
+            ip_id: None,
+            tcp_seq: None,
+            tcp_flags: None,
+            fragment_offset: None,
+            more_fragments: false,
+            ip_protocol: 17,
+            dscp: None,
+            input_origin: crate::capture::parse::InputOrigin::Wire,
+        };
+        let gated = crate::pipeline::PipelineOptions {
+            sip_portrange: Some((5060, 5061)),
+            ..Default::default()
+        };
+        let mut decrypt = crate::pipeline::MediaDecrypt::default();
+        let mut heuristic = crate::rtp::heuristic::RtpHeuristic::default();
+        let action = crate::pipeline::classify_packet(&pp, &mut heuristic, &gated, &mut decrypt);
+        assert!(
+            matches!(action, crate::pipeline::PacketAction::None),
+            "the gate must still skip -- --portrange means what it says"
+        );
+
+        let v = stats(app).await;
+        assert_eq!(
+            v["unanalysed_sip_messages"], 1,
+            "the skipped SIP did not reach the response: {v}"
+        );
+        assert_eq!(
+            v["unanalysed_busiest_ports"][0]["port"], 8090,
+            "the count arrived without the port an operator needs. The service \
+             port is a request's DESTINATION, not the ephemeral client port: {v}"
+        );
+        assert_eq!(v["unanalysed_busiest_ports"][0]["messages"], 1);
+
+        crate::pipeline::reset_portrange_skips();
     }
 
     /// The declined-work count is on `/v1/stats`, present at zero, and moves

--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -2605,7 +2605,13 @@ fn no_documentation_table_repeats_a_row() {
     // `capture_quality` block beside it, which counts what the capture LOST.
     // Attributed by measurement before the number moved: those four files
     // gained exactly one table separator each and no other page gained any.
-    const EXPECTED_TABLES: usize = 638;
+    // 638 -> 640: one hand-written table and its generated mirror, in
+    // `docs/rest-api.md`, listing the four port-gate keys `/v1/stats` gained --
+    // SIP and SIP-over-WebSocket the gate read, recognized and set aside, each
+    // with the ports carrying it. Attributed by measurement before the number
+    // moved: those two files gained exactly one table separator each and no
+    // other page gained any.
+    const EXPECTED_TABLES: usize = 640;
 
     let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let out = std::process::Command::new("git")

--- a/tests/surface_parity_test.rs
+++ b/tests/surface_parity_test.rs
@@ -277,6 +277,31 @@ const CAPTURE_CAVEAT_COUNTERS: &[Caveat] = &[
             aliases: &["app_data_records", "TlsDecryptReport", "read_nothing"],
         },
     },
+    // SIP the port gate excluded before anything analyzed it.
+    //
+    // On the corpus this was 2,311 dialogs against 3,712 real -- 37.7% lost,
+    // because a third of the SIP never touches 5060/5061. `dialog_count` alone
+    // reads as "how much was there", and a capture missing a third of its calls
+    // renders identically to one that only had two-thirds. The ports are
+    // reported with it so the answer names its own remedy: they are what an
+    // operator passes to `--portrange`.
+    Caveat {
+        kept_in: "src/pipeline.rs",
+        metric: Metric {
+            name: "unanalysed_sip_messages",
+            aliases: &["portrange_skip_report", "unanalysed_busiest_ports"],
+        },
+    },
+    // The same loss on a different transport, and NOT recovered by the same
+    // remedy: SIP-over-WebSocket outside the WS port set needs
+    // `--ws-portrange`, and widening `--portrange` recovers none of it.
+    Caveat {
+        kept_in: "src/pipeline.rs",
+        metric: Metric {
+            name: "unanalysed_websocket_messages",
+            aliases: &["ws_port_skip_report", "unanalysed_websocket_ports"],
+        },
+    },
 ];
 
 /// A counter, and the file that keeps it.

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -1033,6 +1033,10 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
   "caveats": {
     "media_creating_commands": 0
   },
+  "unanalysed_sip_messages": 0,
+  "unanalysed_busiest_ports": [],
+  "unanalysed_websocket_messages": 0,
+  "unanalysed_websocket_ports": [],
   "timing": {
     "pdd_p50_ms": 120,
     "pdd_p95_ms": 850,
@@ -1107,6 +1111,40 @@ the end-of-run summary the command line prints.
 
 The MCP `capture_status` tool carries the same block under the same name, so
 this endpoint and an agent never disagree about it.
+
+### SIP the port gate never analyzed
+
+`unanalysed_sip_messages` is the largest loss this project has measured, and it
+is the one `capture_quality` cannot see. No packet went missing and no decoder gave up — sipnab read the
+bytes, recognized them as SIP, and set them aside because both ports fell
+outside `--portrange`.
+
+On the corpus that was **2,311 dialogs against 3,712 real: 37.7% gone**, because
+a third of the SIP never touches 5060/5061. `dialogs.total` alone reads as "how
+much was there", and a capture missing a third of its calls renders identically
+to one that only had two-thirds.
+
+| Key | Meaning |
+|-----|---------|
+| `unanalysed_sip_messages` | plain SIP with both ports outside `--portrange` |
+| `unanalysed_busiest_ports` | the top five ports carrying it, busiest first |
+| `unanalysed_websocket_messages` | SIP-over-WebSocket ([RFC 7118](https://www.rfc-editor.org/rfc/rfc7118)) outside the WebSocket port set |
+| `unanalysed_websocket_ports` | the top five ports carrying that |
+
+The ports travel with the counts because the answer has to name its own remedy —
+they are what you write into `--portrange`. A bare number says something is
+wrong without saying where to look.
+
+**The two counts stay apart because the remedies differ.** Widening
+`--portrange` recovers none of the WebSocket half. That needs `--ws-portrange`.
+This is the common case behind a WSS listener on a reverse proxy, and on
+Kamailio, OpenSIPS and Janus, which all default outside sipnab's shipped
+80/443/8080/8443.
+
+Both are zero on a live capture, where BPF filtered before the pipeline saw
+anything and there is nothing to under-report.
+
+MCP `capture_status` carries all four under the same names.
 
 `capture_quality` says how much of the wire the rest of the response draws
 from. Read it before the counts, not after: with `degraded` true, every number

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -3017,6 +3017,10 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
   "caveats": {
     "media_creating_commands": 0
   },
+  "unanalysed_sip_messages": 0,
+  "unanalysed_busiest_ports": [],
+  "unanalysed_websocket_messages": 0,
+  "unanalysed_websocket_ports": [],
   "timing": {
     "pdd_p50_ms": 120,
     "pdd_p95_ms": 850,
@@ -3091,6 +3095,40 @@ the end-of-run summary the command line prints.
 
 The MCP `capture_status` tool carries the same block under the same name, so
 this endpoint and an agent never disagree about it.
+
+### SIP the port gate never analyzed
+
+`unanalysed_sip_messages` is the largest loss this project has measured, and it
+is the one `capture_quality` cannot see. No packet went missing and no decoder gave up — sipnab read the
+bytes, recognized them as SIP, and set them aside because both ports fell
+outside `--portrange`.
+
+On the corpus that was **2,311 dialogs against 3,712 real: 37.7% gone**, because
+a third of the SIP never touches 5060/5061. `dialogs.total` alone reads as "how
+much was there", and a capture missing a third of its calls renders identically
+to one that only had two-thirds.
+
+| Key | Meaning |
+|-----|---------|
+| `unanalysed_sip_messages` | plain SIP with both ports outside `--portrange` |
+| `unanalysed_busiest_ports` | the top five ports carrying it, busiest first |
+| `unanalysed_websocket_messages` | SIP-over-WebSocket ([RFC 7118](https://www.rfc-editor.org/rfc/rfc7118)) outside the WebSocket port set |
+| `unanalysed_websocket_ports` | the top five ports carrying that |
+
+The ports travel with the counts because the answer has to name its own remedy —
+they are what you write into `--portrange`. A bare number says something is
+wrong without saying where to look.
+
+**The two counts stay apart because the remedies differ.** Widening
+`--portrange` recovers none of the WebSocket half. That needs `--ws-portrange`.
+This is the common case behind a WSS listener on a reverse proxy, and on
+Kamailio, OpenSIPS and Janus, which all default outside sipnab's shipped
+80/443/8080/8443.
+
+Both are zero on a live capture, where BPF filtered before the pipeline saw
+anything and there is nothing to under-report.
+
+MCP `capture_status` carries all four under the same names.
 
 `capture_quality` says how much of the wire the rest of the response draws
 from. Read it before the counts, not after: with `degraded` true, every number

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5634 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5635 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5634" data-suffix="">5634</span>
+        <span class="arch-stat" data-count="5635" data-suffix="">5635</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5633 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5634 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5633" data-suffix="">5633</span>
+        <span class="arch-stat" data-count="5634" data-suffix="">5634</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>


### PR DESCRIPTION
## The finding

This is the **largest loss this project has measured**, and the one
`capture_quality` cannot see.

No packet went missing and no decoder gave up. sipnab read the bytes,
recognized them as SIP, and set them aside because both ports fell outside
`--portrange`.

On the corpus that was **2,311 dialogs against 3,712 real — 37.7% gone**,
because a third of the SIP never touches 5060/5061. `dialogs.total` alone reads
as "how much was there", so a capture missing a third of its calls renders
identically to one that only had two-thirds — and every other number in the
response is clean while it happens.

MCP `capture_status` has carried this since it absorbed the `stats` tool.
`GET /v1/stats` never did. The answer depended on which door the client came
through, and the door without it is the one a **dashboard polls**.

## What changed

Four keys on `/v1/stats`:

| Key | Meaning |
|---|---|
| `unanalysed_sip_messages` | plain SIP with both ports outside `--portrange` |
| `unanalysed_busiest_ports` | the top five ports carrying it, busiest first |
| `unanalysed_websocket_messages` | SIP-over-WebSocket outside the WS port set |
| `unanalysed_websocket_ports` | the top five ports carrying that |

## Three decisions worth reviewing

**Top level, not inside `caveats`.** Nesting would have been tidier and wrong.
The point is that one fact is named identically at both doors; a client that
learned it from MCP must not have to learn it again here.

**The ports travel with the counts.** The answer has to name its own remedy —
they are literally what an operator writes into `--portrange`. A bare number
says something is wrong without saying where to look. Top five, because a full
table buries the one worth widening to.

**WebSocket is counted apart, not summed in.** Widening `--portrange` recovers
none of it; that needs `--ws-portrange`. A single combined figure would name the
wrong remedy for whichever half dominates. This is the common case behind a WSS
listener on a reverse proxy, and on Kamailio, OpenSIPS and Janus, which all
default outside sipnab's shipped 80/443/8080/8443.

## The test

Drives the **real gate**: a SIP `OPTIONS` to port 8090 through
`classify_packet` with `sip_portrange: Some((5060, 5061))`, asserting the
pipeline still declines it *and* that the endpoint then reports 1 message on
port 8090.

Poking the tally directly would have proven the endpoint reads *a* counter.
This proves it reads the one the pipeline writes. Mutation-proven — a constant
`0` fails it. `serial`, because that tally is process-global.

Both counts are asserted **present at zero** first: a key that appears only on a
bad capture is a key no client learns exists, and a dashboard cannot ask for a
field it has never seen.
