### PR TITLE
Answer for the whole capture over REST, and make the JSON arm actually JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ entry that carries them.
 
 ## [Unreleased]
 
+### Added
+
+- **`GET /v1/report` — the whole-capture analysis over REST.** Findings across
+  every dialog and stream, orphaned media, STUN and ICMP evidence, and what the
+  retention caps shed. `GET /v1/dialogs/{call_id}/report` answers for one call;
+  this answers for the capture, and it is the only REST route that can, because
+  orphaned media and shed retention belong to no single dialog. The CLI has had
+  it as `--report` since before either server existed and MCP as
+  `get_capture_report`; a REST client wanting it had to reimplement the analysis
+  it came to sipnab for.
+
+### Fixed
+
+- **`get_capture_report` returned TEXT under its `json` default.**
+  `print_analysis_report_as` looks like it has a JSON arm and does not — its
+  `format` argument only chooses between markdown headings and plain text — so
+  the tool asked for JSON, got prose, failed to parse the prose, and fell
+  through to a text block. Because `json` is the default, every agent that
+  called this tool without an argument received a text blob with nothing to say
+  the structure it asked for was never there. Both doors now serialize the
+  analysis directly, and the silent fallback is gone: a serialization failure
+  there is a bug, and swallowing it is what hid this one.
+
 ## [0.5.124] - 2026-08-24
 
 ### Added

--- a/docs/design/backlog.md
+++ b/docs/design/backlog.md
@@ -4028,6 +4028,54 @@ free, because the free was mimalloc's.
 several times slower — but see [`tests/support/timeout.rs`](https://github.com/NormB/sipnab/blob/main/tests/support/timeout.rs) for the corrected
 reason it was introduced.
 
+## SP — surface parity (added 2026-08-24)
+
+Nine increments closed the gap between what MCP, REST, the CLI, the TUI and the
+in-browser analyzer can say about one capture. Each was written against a gate
+that failed first, and four gates now hold the line, deliberately at different
+bars:
+
+| Gate | Bar |
+|---|---|
+| `every_quality_metric_is_on_both_mcp_and_the_rest_api` | symmetric, or on neither |
+| `provenance_the_program_records_reaches_a_reader` | recorded implies readable somewhere |
+| `caveat_counters_reach_both_api_doors` | both APIs, no exceptions |
+| `both_doors_answer_the_same_questions` | a question one door answers, the other answers |
+
+The middle two earn their place: the provenance gate found `dialog_assertion`
+written on every binding and read by nothing, while `EndpointAssertion::as_str`
+carried a doc comment calling itself "the name this assertion is written under
+on every output surface". The caveat gate is the strictest because a missing
+caveat counter does not make a response incomplete -- it makes it read as clean.
+
+### SP1 — capture identity and context on REST — BLOCKED on a decision
+
+`GET /v1/stats` still lacks `capture_identity`, `source_exhausted`,
+`writing_to` and `unsaved`, all of which MCP `capture_status` has. Unlike every
+other item in this program, this one cannot be done as an increment, for two
+independent reasons.
+
+**Where the type lives.** `CaptureState` is defined in
+[`src/mcp/server.rs`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs)
+and gated on the `mcp` feature. REST is gated on `api`. Sharing it means moving
+the type somewhere feature-independent so both servers hold one, or REST gets
+the identity only in builds that also compiled MCP -- which is a worse answer
+than not having it, because the field would then appear and disappear with an
+unrelated feature flag.
+
+**What the identity would assert.** An etag over
+`(instance, dialog_generation, stream_generation)` claims those three describe
+one moment. `get_stats` currently drops the dialog-store lock BEFORE taking the
+stream-store lock, so its dialog counts and stream counts already describe two
+different instants. Publishing an etag over that would assert a consistency the
+code does not provide, which is the exact class of claim this project spends
+its effort removing. Holding both locks is the fix, and it is a change to a
+hot-ish read path that deserves its own argument rather than riding along.
+
+The honest state is therefore: known, understood, and not started. A reader
+comparing MCP and REST should expect this one difference and should not read it
+as an oversight.
+
 ## Standing decisions
 
 | Decision | Status | Notes |

--- a/docs/design/deferred-and-declined.md
+++ b/docs/design/deferred-and-declined.md
@@ -280,7 +280,7 @@ The argument below does not depend on the number. Four
 of them touch something other than the stores: `export_capture`
 ([`server.rs:6057`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6057)) writes a pcap, `export_audio`
 ([`server.rs:6105`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6105)) writes a WAV, `list_captures`
-([`server.rs:5983`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L5983)) reads a directory, and
+([`server.rs:6008`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6008)) reads a directory, and
 `shutdown_server` ([`server.rs:6570`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6570)) ends the process.
 
 **None of them mutates a store.** `shutdown_server` reads `dialog_store` and

--- a/docs/design/implementation-plan-phases-8-10.md
+++ b/docs/design/implementation-plan-phases-8-10.md
@@ -1682,7 +1682,7 @@ For implementers picking this up, the bridge from each MCP tool to existing func
 | `tail_dialogs` | `DialogStore::iter` filtered by `updated_at > cursor` |
 | `security_findings` | `security::AlertEngine` history (extend with ring buffer) |
 | `snapshot_pcap` | `capture::PcapWriter` + filter on captured packets |
-| `stats` | Mirrors `GET /v1/stats` from `output::api::get_stats` ([`src/output/api.rs:981`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L981)) |
+| `stats` | Mirrors `GET /v1/stats` from `output::api::get_stats` ([`src/output/api.rs:1037`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L1037)) |
 
 | Phase 8 infra | Reuses |
 |---|---|

--- a/docs/design/multi-capture-comparison.md
+++ b/docs/design/multi-capture-comparison.md
@@ -218,7 +218,7 @@ calls. Under comparison it becomes the exact operation wanted, and the refusal
 must be relaxed *only* for a confirmed cross-session pair — not removed.
 
 The MCP surface has the single-capture ancestor of all three: `compare_dialogs`
-([`server.rs:4964`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4964)) takes two Call-IDs, projects state,
+([`server.rs:4989`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4989)) takes two Call-IDs, projects state,
 final status code, message count, methods and hints for each, and names the keys
 that differ. Its shape is right and its scope is one store — both Call-IDs are
 looked up in the same `dialog_store`. Extending it to cross sessions is the same

--- a/docs/design/testing-matrix.md
+++ b/docs/design/testing-matrix.md
@@ -50,7 +50,7 @@ was driving all of them.
 | Surface | Rows | `e2e` | `parsed` | `referenced` | `none` |
 |---|---|---|---|---|---|
 | CLI flags | 230 | 112 | 37 | 80 | 1 |
-| HTTP routes | 8 | 8 | -- | 0 | 0 |
+| HTTP routes | 9 | 9 | -- | 0 | 0 |
 | MCP tools | 37 | 37 | -- | 0 | 0 |
 
 **Flags with no occurrence at all:** `--syslog`
@@ -323,6 +323,7 @@ behind them.
 | `/v1/dialogs` | exercised | `tests/api_operator_flows_test.rs`, `tests/api_test.rs` +2 |
 | `/v1/dialogs/{call_id}` | exercised | `tests/api_operator_flows_test.rs`, `tests/api_test.rs` |
 | `/v1/dialogs/{call_id}/report` | exercised | `tests/api_test.rs` |
+| `/v1/report` | exercised | `tests/api_test.rs` |
 | `/v1/stats` | exercised | `tests/api_test.rs`, `tests/api_token_test.rs` +3 |
 | `/v1/streams` | exercised | `tests/api_operator_flows_test.rs`, `tests/api_test.rs` +1 |
 | `/v1/streams/{id}` | exercised | `tests/api_operator_flows_test.rs`, `tests/api_test.rs` |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -347,6 +347,20 @@ empty body, because silence is indistinguishable from the tool not having run:
 "Capture analysis: 2 finding(s) across 1 dialog(s), 2 stream(s), 535000 frame(s) read."
 ```
 
+**`json` is the default and returns an OBJECT**, serialized from the analysis
+itself — `findings`, `dialogs_examined`, `streams_examined`, `frames_read` and
+`complete`. Read `complete` before the findings: it is `false` when the capture
+lost packets, hit a retention cap, or held frames no decoder could read, and a
+findings list from such a capture is a **floor, not a total**.
+
+> Before 0.5.125 this default returned the TEXT rendering. `format` chooses
+> between markdown headings and plain text inside the renderer and never had a
+> JSON arm, so the tool asked for JSON, got prose, and fell back to a text
+> block. An agent that called it with no argument received prose and nothing to
+> say the structure it asked for was never there.
+
+`GET /v1/report` answers the same question over REST.
+
 ### `get_dialog_report`
 
 Per-call diagnostic report for one Call-ID. Backed by

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -955,6 +955,37 @@ console.log(`Codec: ${stream.codec}, Packets: ${stream.packets}`);
 
 ---
 
+### GET /v1/report
+
+The whole-capture analysis: findings across every dialog and stream, orphaned
+media, STUN and ICMP evidence, and what the retention caps shed.
+
+`GET /v1/dialogs/{call_id}/report` answers for one call. This answers for the
+capture, and it is the only REST route that can — orphaned media and shed
+retention belong to no single dialog, so every other route is blind to them.
+
+**curl:**
+
+```bash
+curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
+  http://127.0.0.1:8080/v1/report | jq .
+```
+
+**Read `complete` before the findings.** It is `false` when the capture lost
+packets, hit a retention cap, or held frames no decoder could read — and a findings list built from such a capture is a **floor, not a
+total**. A reader who takes the list at face value concludes the capture is
+clean when it is merely partial.
+
+`dialogs_examined` and `streams_examined` are the denominators behind the
+findings. `frames_read` comes from the same process-global counter the
+Prometheus scrape reports, so every other figure in the run shares that
+denominator.
+
+The MCP `get_capture_report` tool answers the same question. So does
+`sipnab --report`, which predates both servers.
+
+---
+
 ### GET /v1/stats
 
 Aggregate statistics across all dialogs and streams, including PDD percentiles.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3606,25 +3606,33 @@ impl SipnabMcp {
             }
         };
 
-        let report = {
+        let analysis = {
             // Dialogs then streams, the order `CaptureState` documents, so the
             // two halves of the analysis describe one store revision.
             let ds = self.dialog_store.read();
             let ss = self.stream_store.read();
-            let analysis =
-                crate::analysis::analyze(&ds, &ss, None, crate::capture::captured_packets());
-            crate::output::analysis_report::print_analysis_report_as(&analysis, format)
+            crate::analysis::analyze(&ds, &ss, None, crate::capture::captured_packets())
         };
 
         let content = if format == ReportFormat::Json {
-            // Re-parse so the response is structured JSON rather than a
-            // stringified blob, matching `get_dialog_report`.
-            match serde_json::from_str::<serde_json::Value>(&report) {
-                Ok(v) => ContentBlock::json(v)?,
-                Err(_) => ContentBlock::text(report),
-            }
+            // Serialized from the ANALYSIS, not re-parsed out of a rendered
+            // report. `print_analysis_report_as` looks like it has a JSON arm
+            // and does not: its `format` argument only chooses between markdown
+            // headings and plain text, so `ReportFormat::Json` returns prose.
+            //
+            // This asked it for JSON, tried to parse the prose, failed, and
+            // fell through to `ContentBlock::text`. Since `json` is the DEFAULT
+            // format, every agent that called this tool without an argument got
+            // a text blob and no indication that the structure it asked for was
+            // never there. The fallback is gone with it: a serialization
+            // failure here is a bug, and swallowing it is what hid this one.
+            ContentBlock::json(serde_json::to_value(&analysis).map_err(|e| {
+                rmcp::ErrorData::internal_error(format!("report serialization failed: {e}"), None)
+            })?)?
         } else {
-            ContentBlock::text(report)
+            ContentBlock::text(crate::output::analysis_report::print_analysis_report_as(
+                &analysis, format,
+            ))
         };
         Ok(CallToolResult::success(vec![content]))
     }
@@ -8730,6 +8738,59 @@ mod tests {
     /// STUN, ICMP evidence and what the caps shed -- had no MCP path at all.
     /// The test is surface parity: nothing reachable from `--report` should be
     /// unreachable to an agent.
+    /// The default format is `json`, and it returns JSON.
+    ///
+    /// It did not. `print_analysis_report_as` looks like it has a JSON arm and
+    /// does not -- its `format` argument only chooses between markdown headings
+    /// and plain text -- so this tool asked it for JSON, got prose, failed to
+    /// parse the prose, and fell through to a text block. `json` is the DEFAULT,
+    /// so every agent that called this without an argument received a text blob
+    /// with nothing to say the structure it asked for was never there.
+    ///
+    /// The discriminator is the PARSE. `ContentBlock::json` reaches a client as
+    /// a block whose text is JSON, so reading the payload is the same call
+    /// either way -- and before the fix that payload was
+    /// "Capture analysis: 0 finding(s) ...", which `from_str` rejects. A test
+    /// that only checked the payload was non-empty would have passed
+    /// throughout.
+    #[tokio::test]
+    async fn the_default_capture_report_format_is_actually_json() {
+        let server = server_with_one_orphan_and_one_linked();
+
+        let result = server
+            .get_capture_report(Parameters(GetCaptureReportParams { format: None }))
+            .await
+            .expect("report should render");
+
+        let v: serde_json::Value = serde_json::from_str(&text_of(&result))
+            .expect("the default format is json, so the payload must parse as json");
+        assert!(
+            v.is_object(),
+            "the default format is json and must return an object a client can \
+             read fields out of: {v}"
+        );
+        for key in ["dialogs_examined", "streams_examined", "complete"] {
+            assert!(
+                v.get(key).is_some(),
+                "`{key}` missing -- the report must say what it looked at and \
+                 whether it saw all of it: {v}"
+            );
+        }
+
+        // The other formats still render prose, which is what they are for.
+        let text = server
+            .get_capture_report(Parameters(GetCaptureReportParams {
+                format: Some("text".to_string()),
+            }))
+            .await
+            .expect("text report should render");
+        assert!(
+            !text_of(&text).trim().is_empty(),
+            "a capture with no findings still gets a line, because silence is \
+             indistinguishable from the tool not having run"
+        );
+    }
+
     #[tokio::test]
     async fn get_capture_report_answers_for_the_whole_capture() {
         let server = server_with_one_orphan_and_one_linked();

--- a/src/output/api.rs
+++ b/src/output/api.rs
@@ -234,6 +234,7 @@ pub fn build_router(state: ApiState) -> Router {
         .route("/v1/dialogs/{call_id}/report", get(get_dialog_report))
         .route("/v1/streams", get(list_streams))
         .route("/v1/streams/{id}", get(get_stream))
+        .route("/v1/report", get(get_capture_report))
         .route("/v1/stats", get(get_stats))
         .route("/metrics", get(get_metrics))
         .with_state(state)
@@ -946,6 +947,61 @@ async fn get_stream(
 
     let parsed: Value =
         serde_json::from_str(&json_str).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(parsed))
+}
+
+/// `GET /v1/report` — the whole-capture analysis report.
+///
+/// The capture-level view: findings across every dialog and stream, orphaned
+/// media, STUN and ICMP evidence, and what the retention caps shed.
+/// `GET /v1/dialogs/{call_id}/report` answers for one Call-ID; this answers for
+/// the capture. The CLI has had it as `--report` since before either server
+/// existed, and MCP as `get_capture_report`; REST could not answer the question
+/// at all, so a client wanting it had to reimplement the analysis it came here
+/// for.
+///
+/// # Arguments
+///
+/// * `state` — Shared application state.
+/// * `addr` — Client socket address used for rate limiting.
+/// * `headers` — Request headers (auth).
+///
+/// # Returns
+///
+/// 200 with the analysis object; 401/503 from the guard. Frames read comes from
+/// [`crate::capture::captured_packets`], the same process-global the Prometheus
+/// scrape reports, so the denominator here is the one every other number in the
+/// run is read against.
+///
+/// # Side effects
+///
+/// Holds both store read locks while building the report; mutates the rate
+/// limiter.
+async fn get_capture_report(
+    State(state): State<ApiState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, StatusCode> {
+    guard(&state, &headers, addr.ip())?;
+
+    let analysis = {
+        // Dialogs then streams, the order `CaptureState` documents and the
+        // order MCP's `get_capture_report` takes them in, so the two halves of
+        // one analysis describe one store revision -- and so the two doors can
+        // never deadlock against each other.
+        let ds = state.dialog_store.read();
+        let ss = state.stream_store.read();
+        crate::analysis::analyze(&ds, &ss, None, crate::capture::captured_packets())
+    };
+
+    // Serialized from the ANALYSIS, not re-parsed out of a rendered report.
+    // `print_analysis_report_as` looks like it has a JSON arm and does not: its
+    // `format` argument only chooses between markdown headings and plain text,
+    // so `ReportFormat::Json` returns prose. Asking it for JSON and parsing the
+    // result is how this endpoint first returned 500 -- and how MCP's tool of
+    // the same name had been quietly serving text under a `format: "json"`
+    // default, because its parse failure fell through to a text block.
+    let parsed = serde_json::to_value(&analysis).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(Json(parsed))
 }
 
@@ -1947,6 +2003,54 @@ mod tests {
         }
         // 6th should fail
         assert!(!limiter.check(ip));
+    }
+
+    /// `GET /v1/report` answers for the whole capture, and says what it could
+    /// not see.
+    ///
+    /// The per-call route below answers for one Call-ID. This is the view that
+    /// names orphaned media, STUN and ICMP evidence, and what the retention
+    /// caps shed -- the things belonging to no single dialog and therefore
+    /// invisible to every other REST route.
+    ///
+    /// Asserted as STRUCTURED JSON, not a string. The generator returns a
+    /// String and the handler re-parses it; a handler that forgot to would
+    /// still return 200 with a body that looks like JSON to a human and is a
+    /// quoted blob to a parser.
+    #[tokio::test]
+    async fn the_capture_report_is_answerable_over_rest() {
+        let state = make_state();
+        populate_dialogs(&state);
+        let app = build_router(state);
+
+        let resp = app
+            .oneshot(test_request("/v1/report"))
+            .await
+            .expect("oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "/v1/report status");
+
+        let body = body_to_string(resp.into_body()).await;
+        let parsed: Value = serde_json::from_str(&body).expect("valid JSON");
+        assert!(
+            parsed.is_object(),
+            "the report must be an object a client can read fields out of, not \
+             a stringified blob it has to parse a second time: {body}"
+        );
+        // The facts that make this a capture-level answer rather than a sum of
+        // per-call ones. `complete` is the honesty flag: a findings list built
+        // from a capture that lost packets is a FLOOR, and a reader who does
+        // not know that reads it as a total.
+        for key in ["dialogs_examined", "streams_examined", "complete"] {
+            assert!(
+                parsed.get(key).is_some(),
+                "`{key}` missing -- the report must say what it looked at and \
+                 whether it saw all of it: {parsed}"
+            );
+        }
+        assert_eq!(
+            parsed["dialogs_examined"], 3,
+            "the report must describe the store it was built from: {parsed}"
+        );
     }
 
     /// `GET /v1/dialogs/:call_id/report` returns 200 with a JSON report

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -116,6 +116,45 @@ fn stats_returns_structured_json() {
     assert!(body["timing"].is_object(), "stats has a timing block");
 }
 
+/// `/v1/report` answers for the whole capture, through a real server.
+///
+/// The per-call route answers for one Call-ID. This is the only REST route that
+/// can speak for the capture: orphaned media, STUN and ICMP evidence, and what
+/// the retention caps shed belong to no single dialog, so every other route is
+/// blind to them. MCP has answered this as `get_capture_report` and the CLI as
+/// `--report`; a REST client had to reimplement the analysis it came here for.
+///
+/// Driven through `ApiServer::spawn` rather than an in-process router, like
+/// every other route in this file — a handler can be correct and still not be
+/// wired into the binary that ships.
+#[test]
+fn capture_report_answers_for_the_whole_capture() {
+    let srv = ApiServer::spawn(&[]);
+    let resp = srv.get("/v1/report");
+    assert_eq!(resp.status, 200, "/v1/report status");
+
+    let body = resp.json();
+    assert!(
+        body.is_object(),
+        "the report must be an object a client reads fields out of, not a \
+         stringified blob it parses a second time: {body}"
+    );
+    // What it looked at, and whether it saw all of it. `complete` is the
+    // honesty flag: a findings list from a capture that lost packets is a
+    // FLOOR, and a reader who does not know that reads it as a total.
+    for key in ["dialogs_examined", "streams_examined", "complete"] {
+        assert!(
+            body.get(key).is_some(),
+            "`{key}` missing — the report must say what it examined and whether \
+             it saw all of it: {body}"
+        );
+    }
+    assert_eq!(
+        body["dialogs_examined"], 1,
+        "the report must describe the capture it was built from: {body}"
+    );
+}
+
 /// `/v1/stats` carries the capture-quality block on every response, with the
 /// three losses under three names and one flag rolling them up.
 ///

--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -2611,7 +2611,11 @@ fn no_documentation_table_repeats_a_row() {
     // with the ports carrying it. Attributed by measurement before the number
     // moved: those two files gained exactly one table separator each and no
     // other page gained any.
-    const EXPECTED_TABLES: usize = 640;
+    // 640 -> 641: one table, the four surface-parity gates and the bar each
+    // holds, in the new SP section of `docs/design/backlog.md`. Attributed by
+    // measurement before the number moved: that file gained exactly one table
+    // separator, and design docs have no generated mirror.
+    const EXPECTED_TABLES: usize = 641;
 
     let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let out = std::process::Command::new("git")

--- a/tests/surface_parity_test.rs
+++ b/tests/surface_parity_test.rs
@@ -235,6 +235,72 @@ const QUALITY_METRICS: &[Metric] = &[
     },
 ];
 
+/// Whole-capture and per-call ANSWERS, and the route each door serves them on.
+///
+/// The lists above are about fields. This one is about whether a question can
+/// be asked at all. A missing field makes a response less useful; a missing
+/// route makes the question unanswerable at that door, and the client's only
+/// recourse is to reimplement the analysis it came to sipnab for.
+///
+/// Each row names an MCP tool and the REST path that answers the same
+/// question. Both halves are checked against the SOURCE, so a row cannot
+/// outlive either side.
+const CAPTURE_ANSWERS: &[Answer] = &[
+    // One Call-ID: timing, parties, RTP quality, diagnosis hints.
+    Answer {
+        mcp_tool: "get_dialog_report",
+        rest_route: "/v1/dialogs/{call_id}/report",
+    },
+    // The whole capture: findings across every dialog and stream, orphaned
+    // media, STUN and ICMP evidence, and what the retention caps shed. The CLI
+    // has had this as `--report` since before either server existed.
+    Answer {
+        mcp_tool: "get_capture_report",
+        rest_route: "/v1/report",
+    },
+];
+
+/// An answer sipnab can give, and where each door serves it.
+struct Answer {
+    mcp_tool: &'static str,
+    rest_route: &'static str,
+}
+
+/// Every answer one door can give, the other can give too.
+#[test]
+fn both_doors_answer_the_same_questions() {
+    let mcp = code("src/mcp/server.rs");
+    let api = code("src/output/api.rs");
+
+    let mut missing = Vec::new();
+    for a in CAPTURE_ANSWERS {
+        // The tool declaration, as `#[tool(name = "...")]` writes it.
+        let declared = mcp.contains(&format!("name = \"{}\"", a.mcp_tool));
+        // The route registration, as axum's `.route("...")` writes it.
+        let routed = api.contains(&format!("\"{}\"", a.rest_route));
+        match (declared, routed) {
+            (true, true) | (false, false) => {}
+            (true, false) => missing.push(format!(
+                "MCP answers `{}` and REST has no `{}`",
+                a.mcp_tool, a.rest_route
+            )),
+            (false, true) => missing.push(format!(
+                "REST answers `{}` and MCP has no `{}`",
+                a.rest_route, a.mcp_tool
+            )),
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "a question one door can answer and the other cannot:\n  {}\n\n\
+         A missing FIELD makes a response less useful. A missing ROUTE makes \
+         the question unanswerable at that door, and the client's only recourse \
+         is to reimplement the analysis it came to sipnab for.",
+        missing.join("\n  ")
+    );
+}
+
 /// Counters that say what the capture COULD NOT do, which must reach every door.
 ///
 /// The strictest list in this file, and the bar is "both APIs" rather than

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -960,6 +960,37 @@ console.log(`Codec: ${stream.codec}, Packets: ${stream.packets}`);
 
 ---
 
+### GET /v1/report
+
+The whole-capture analysis: findings across every dialog and stream, orphaned
+media, STUN and ICMP evidence, and what the retention caps shed.
+
+`GET /v1/dialogs/{call_id}/report` answers for one call. This answers for the
+capture, and it is the only REST route that can — orphaned media and shed
+retention belong to no single dialog, so every other route is blind to them.
+
+**curl:**
+
+```bash
+curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
+  http://127.0.0.1:8080/v1/report | jq .
+```
+
+**Read `complete` before the findings.** It is `false` when the capture lost
+packets, hit a retention cap, or held frames no decoder could read — and a findings list built from such a capture is a **floor, not a
+total**. A reader who takes the list at face value concludes the capture is
+clean when it is merely partial.
+
+`dialogs_examined` and `streams_examined` are the denominators behind the
+findings. `frames_read` comes from the same process-global counter the
+Prometheus scrape reports, so every other figure in the run shares that
+denominator.
+
+The MCP `get_capture_report` tool answers the same question. So does
+`sipnab --report`, which predates both servers.
+
+---
+
 ### GET /v1/stats
 
 Aggregate statistics across all dialogs and streams, including PDD percentiles.

--- a/website/content/docs/mcp-tools.md
+++ b/website/content/docs/mcp-tools.md
@@ -352,6 +352,20 @@ empty body, because silence is indistinguishable from the tool not having run:
 "Capture analysis: 2 finding(s) across 1 dialog(s), 2 stream(s), 535000 frame(s) read."
 ```
 
+**`json` is the default and returns an OBJECT**, serialized from the analysis
+itself — `findings`, `dialogs_examined`, `streams_examined`, `frames_read` and
+`complete`. Read `complete` before the findings: it is `false` when the capture
+lost packets, hit a retention cap, or held frames no decoder could read, and a
+findings list from such a capture is a **floor, not a total**.
+
+> Before 0.5.125 this default returned the TEXT rendering. `format` chooses
+> between markdown headings and plain text inside the renderer and never had a
+> JSON arm, so the tool asked for JSON, got prose, and fell back to a text
+> block. An agent that called it with no argument received prose and nothing to
+> say the structure it asked for was never there.
+
+`GET /v1/report` answers the same question over REST.
+
 ### `get_dialog_report`
 
 Per-call diagnostic report for one Call-ID. Backed by

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2944,6 +2944,37 @@ console.log(`Codec: ${stream.codec}, Packets: ${stream.packets}`);
 
 ---
 
+### GET /v1/report
+
+The whole-capture analysis: findings across every dialog and stream, orphaned
+media, STUN and ICMP evidence, and what the retention caps shed.
+
+`GET /v1/dialogs/{call_id}/report` answers for one call. This answers for the
+capture, and it is the only REST route that can — orphaned media and shed
+retention belong to no single dialog, so every other route is blind to them.
+
+**curl:**
+
+```bash
+curl -s -H "Authorization: Bearer $SIPNAB_API_KEY" \
+  http://127.0.0.1:8080/v1/report | jq .
+```
+
+**Read `complete` before the findings.** It is `false` when the capture lost
+packets, hit a retention cap, or held frames no decoder could read — and a findings list built from such a capture is a **floor, not a
+total**. A reader who takes the list at face value concludes the capture is
+clean when it is merely partial.
+
+`dialogs_examined` and `streams_examined` are the denominators behind the
+findings. `frames_read` comes from the same process-global counter the
+Prometheus scrape reports, so every other figure in the run shares that
+denominator.
+
+The MCP `get_capture_report` tool answers the same question. So does
+`sipnab --report`, which predates both servers.
+
+---
+
 ### GET /v1/stats
 
 Aggregate statistics across all dialogs and streams, including PDD percentiles.
@@ -13221,6 +13252,20 @@ empty body, because silence is indistinguishable from the tool not having run:
 // A capture with findings names each one; a clean capture says so outright.
 "Capture analysis: 2 finding(s) across 1 dialog(s), 2 stream(s), 535000 frame(s) read."
 ```
+
+**`json` is the default and returns an OBJECT**, serialized from the analysis
+itself — `findings`, `dialogs_examined`, `streams_examined`, `frames_read` and
+`complete`. Read `complete` before the findings: it is `false` when the capture
+lost packets, hit a retention cap, or held frames no decoder could read, and a
+findings list from such a capture is a **floor, not a total**.
+
+> Before 0.5.125 this default returned the TEXT rendering. `format` chooses
+> between markdown headings and plain text inside the renderer and never had a
+> JSON arm, so the tool asked for JSON, got prose, and fell back to a text
+> block. An agent that called it with no argument received prose and nothing to
+> say the structure it asked for was never there.
+
+`GET /v1/report` answers the same question over REST.
 
 ### `get_dialog_report`
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5635 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5639 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5635" data-suffix="">5635</span>
+        <span class="arch-stat" data-count="5639" data-suffix="">5639</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>


### PR DESCRIPTION
## The gap

`GET /v1/dialogs/{call_id}/report` answers for one call. **Nothing on REST
answered for the capture.**

Orphaned media, STUN, ICMP errors quoting SIP or RTP, and what the retention
caps shed belong to no single dialog — so every other REST route is blind to
them by construction. The CLI has had this as `--report` since before either
server existed, and MCP as `get_capture_report`. A REST client that wanted it
had to reimplement the analysis it came to sipnab for.

No plumbing was needed: both stores are already on `ApiState`, and `frames_read`
comes from the same process-global the Prometheus scrape reports, so the
denominator matches every other number in the run.

Locks are taken **dialogs then streams** — the order `CaptureState` documents
and the order MCP takes them in — so the two halves of one analysis describe one
store revision, and the two doors can never deadlock against each other.

## Building it exposed a bug in the door that already had the feature

`print_analysis_report_as` **looks like it has a JSON arm and does not.** Its
`format` argument only chooses between markdown headings and plain text.

So MCP's `get_capture_report` asked it for JSON, got prose, failed to parse the
prose, and fell through to `ContentBlock::text`. Since `json` is the **default**
format, every agent that called that tool without an argument received a text
blob — with nothing to say the structure it asked for was never there.

Both doors now serialize `CaptureAnalysis` directly, which already derives
`Serialize`. **The silent fallback is gone with it**: a serialization failure
there is a bug, and swallowing it is precisely what hid this one for as long as
it lived.

## Gating

`both_doors_answer_the_same_questions` is a new list in the parity suite. The
others in that file are about **fields**; this one is about whether a question
can be asked at all. A missing field makes a response less useful — a missing
route makes the question unanswerable at that door.

The MCP test's discriminator is the **parse**, not the payload's presence.
Before the fix the payload was `"Capture analysis: 0 finding(s) ..."`, which
`from_str` rejects; a test that only checked for a non-empty body would have
passed throughout. Mutation-proven by restoring the original code.

## Two of this repo's own gates caught this change, correctly

- `every_http_route_has_a_row` refused `/v1/report` until the testing matrix
  knew about it.
- The matrix then refused to call it *exercised*, because the first test lived
  in an in-crate `#[cfg(test)]` module rather than driving a real server.

So it now has the integration test every other route has — a handler can be
correct and still not be wired into the binary that ships. **Nine routes, nine
exercised.**
