### PR TITLE
Answer "which relay has this call" without asking every relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,30 @@ entry that carries them.
   `get_capture_report`; a REST client wanting it had to reimplement the analysis
   it came to sipnab for.
 
+- **`GET /v1/stats` says which capture its counts came from.**
+  `capture_identity` pairs the capture's instance with both store generations,
+  and `source` / `capture_name` / `uptime_sec` / `source_exhausted` /
+  `writing_to` / `unsaved` describe what the server is attached to — the same
+  fields, under the same names, that MCP `capture_status` has had. It is the
+  same identity from the same object, not a copy: `CaptureState` moved out of
+  the MCP module so one instance serves both doors, because the identity
+  rotates when `open_capture` swaps the file and two copies would disagree from
+  that moment on. `get_stats` also now holds the capture, dialog and stream
+  locks across the read, in the order `CaptureState` documents; it released the
+  dialog guard before taking the stream guard, which was survivable until one
+  etag claimed the counts belong to each other.
+
+- **Several rtpengine instances behind one proxy, documented and pinned.** Run
+  one sipnab per host and a call's media lands on exactly one relay. Finding it
+  is a routed lookup rather than a broadcast: the proxy's own SDP names the
+  relay, because the `c=` address it negotiated IS the rtpengine it steered the
+  call to. Ask the proxy which relay has the call, then ask that one and no
+  others. A relay that never carried it answers 404 rather than an empty
+  success, because "I do not have this call" and "this call had no media" are
+  different findings. `tests/multi_node_relay_fanout_test.rs` pins all three
+  properties. sipnab still aggregates nothing across nodes, which is a limit
+  `docs/design/positioning.md` sets rather than one nobody got to.
+
 ### Fixed
 
 - **`get_capture_report` returned TEXT under its `json` default.**

--- a/docs/design/backlog.md
+++ b/docs/design/backlog.md
@@ -1546,12 +1546,12 @@ output path.
     the file root and honest about
     itself with three states — `verified` / `unverified` / `unresolvable` —
     rather than resolving a foreign ref against the wrong file; and
-    `findings_with_refs` ([`src/mcp/server.rs:1319`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L1319)), which attaches `frame_ref`
+    `findings_with_refs` ([`src/mcp/server.rs:1299`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L1299)), which attaches `frame_ref`
     (`#[tool(` at [`src/mcp/server.rs:4528`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4528), handler at `:3866`), confined to
     the file root and honest about
     itself with three states — `verified` / `unverified` / `unresolvable` —
     rather than resolving a foreign ref against the wrong file; and
-    `findings_with_refs` ([`src/mcp/server.rs:1319`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L1319)), which attaches `frame_ref`
+    `findings_with_refs` ([`src/mcp/server.rs:1299`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L1299)), which attaches `frame_ref`
     to `lint_dialog`
     findings and OMITS the key when no pointer exists, because `""` and
     frame 0 both read as real pointers. Capture identity binding
@@ -1697,7 +1697,7 @@ output path.
     `SUPPRESSION_FILENAME` ([`src/sip/lint/mod.rs:70`](https://github.com/NormB/sipnab/blob/main/src/sip/lint/mod.rs#L70)),
     `SuppressionFile::load` (`:103`) and `SuppressionFile::discover` (`:120`)
     exist, and the MCP lint tools consume them through `resolve_suppressions`
-    ([`src/mcp/server.rs:619`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L619)), which takes an explicit filename or walks up from
+    ([`src/mcp/server.rs:590`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L590)), which takes an explicit filename or walks up from
     the capture's directory to a project root. **What is still missing is the
     suppression half of the CLI, and the evidence this line cited for that is
     now false too. Corrected 2026-08-06:** it read *"`grep -n lint src/cli.rs`
@@ -4048,7 +4048,34 @@ carried a doc comment calling itself "the name this assertion is written under
 on every output surface". The caveat gate is the strictest because a missing
 caveat counter does not make a response incomplete -- it makes it read as clean.
 
-### SP1 — capture identity and context on REST — BLOCKED on a decision
+### SP1 — capture identity and context on REST — DONE
+
+Both blockers below were real and both were resolved rather than worked
+around.
+
+`CaptureState` and `CaptureContext` moved to
+[`src/capture/session.rs`](https://github.com/NormB/sipnab/blob/main/src/capture/session.rs),
+outside both server modules, with the two MCP-only fields `#[cfg]`-gated the
+way [`MediaDecrypt`](https://github.com/NormB/sipnab/blob/main/src/pipeline.rs)
+gates its `tls`-only ones. [`src/app/servers.rs`](https://github.com/NormB/sipnab/blob/main/src/app/servers.rs) builds ONE instance before
+either server arm and hands the same handle to both, so a rotation one door
+performs is a rotation the other sees. A copy would have been simpler and
+wrong: the identity rotates when `open_capture` swaps the file underneath, and
+two copies disagree from that moment on.
+
+`get_stats` now holds capture, dialogs and streams across the read, in the
+order `CaptureState` documents. It released the dialog guard before taking the
+stream guard, which was survivable while nothing tied the counts together and
+stopped being survivable the moment one etag claimed they belong to each other.
+
+The test that proves it was itself wrong first. Asserting only that the
+identity CHANGES after a rotation passed against a handler minting a fresh
+identity per request -- the exact private-copy design this change exists to
+avoid. Mutation testing caught it. The assertion that discriminates is the
+opposite one: two reads with nothing between them must return the SAME
+instance.
+
+### SP1 (original entry, kept for the reasoning) — BLOCKED on a decision
 
 `GET /v1/stats` still lacks `capture_identity`, `source_exhausted`,
 `writing_to` and `unsaved`, all of which MCP `capture_status` has. Unlike every

--- a/docs/design/deferred-and-declined.md
+++ b/docs/design/deferred-and-declined.md
@@ -280,7 +280,7 @@ The argument below does not depend on the number. Four
 of them touch something other than the stores: `export_capture`
 ([`server.rs:6057`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6057)) writes a pcap, `export_audio`
 ([`server.rs:6105`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6105)) writes a WAV, `list_captures`
-([`server.rs:6008`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6008)) reads a directory, and
+([`server.rs:5979`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L5979)) reads a directory, and
 `shutdown_server` ([`server.rs:6570`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6570)) ends the process.
 
 **None of them mutates a store.** `shutdown_server` reads `dialog_store` and
@@ -390,7 +390,7 @@ agent reads it verbatim through any of the three tools above; and with a
 write-back tool present, the text it reads can reach a verb that changes what
 the operator sees. Today the worst that text can reach is a read, a file write
 confined to `--mcp-file-root` by `resolve_in_root`
-([`server.rs:487`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L487)), or — only if armed, only on a
+([`server.rs:458`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L458)), or — only if armed, only on a
 second call, only having named the discard — a process stop. That is a
 qualitative gap, not a matter of degree.
 
@@ -672,9 +672,9 @@ nothing.
 
 **The path-confinement problem is solved.** The roadmap's other Tier 3 entry,
 `list_captures`, was filed with *"needs a path allowlist or it is an
-arbitrary-file-read"*. It shipped ([`server.rs:487`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L487))
+arbitrary-file-read"*. It shipped ([`server.rs:458`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L458))
 with `--mcp-file-root` and `resolve_in_root`
-([`server.rs:487`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L487)), which accepts a bare filename and
+([`server.rs:458`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L458)), which accepts a bare filename and
 rejects anything with a separator, a `..`, a root prefix or a drive letter before
 touching the filesystem. So an agent can already *see* the corpus, safely, and
 `open_capture` would need no new security machinery.
@@ -810,7 +810,7 @@ The opt-in machinery and the path confinement are already solved and should be
 reused rather than redesigned: the `shutdown_server` flag, off-by-default field,
 builder and first-statement refusal
 ([`server.rs:6570`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L6570)), and `--mcp-file-root` with
-`resolve_in_root` ([`server.rs:487`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L487)).
+`resolve_in_root` ([`server.rs:458`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L458)).
 
 **What shipped**, against those three:
 

--- a/docs/design/implementation-plan-phases-8-10.md
+++ b/docs/design/implementation-plan-phases-8-10.md
@@ -1682,17 +1682,17 @@ For implementers picking this up, the bridge from each MCP tool to existing func
 | `tail_dialogs` | `DialogStore::iter` filtered by `updated_at > cursor` |
 | `security_findings` | `security::AlertEngine` history (extend with ring buffer) |
 | `snapshot_pcap` | `capture::PcapWriter` + filter on captured packets |
-| `stats` | Mirrors `GET /v1/stats` from `output::api::get_stats` ([`src/output/api.rs:1037`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L1037)) |
+| `stats` | Mirrors `GET /v1/stats` from `output::api::get_stats` ([`src/output/api.rs:1058`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L1058)) |
 
 | Phase 8 infra | Reuses |
 |---|---|
-| Bind address parsing | `output::api::parse_bind_addr` ([`src/output/api.rs:261`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L261)) |
+| Bind address parsing | `output::api::parse_bind_addr` ([`src/output/api.rs:283`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L283)) |
 | Bearer auth | `output::api::check_auth` + `constant_time_eq` ([`src/output/api.rs:279`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L279), `:309`) |
 | Rate limiting | `output::api::RateLimiter` ([`src/output/api.rs:72`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L72)) |
 | Shared store mirroring | `mirror_to_shared_stores` — **gone**; no such function exists today |
 | Server thread + tokio runtime | `start_api_server` — **gone**; see [`src/app/servers.rs`](https://github.com/NormB/sipnab/blob/main/src/app/servers.rs) |
 | Privilege drop ordering | Existing capture-ready rendezvous + `privilege::drop_privileges` (`src/main.rs:387–442`) |
-| WebSocket / SSE Router mounting | Extend `output::api::build_router` ([`src/output/api.rs:229`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L229)) with new routes; reuse the existing `guard()` middleware |
+| WebSocket / SSE Router mounting | Extend `output::api::build_router` ([`src/output/api.rs:250`](https://github.com/NormB/sipnab/blob/main/src/output/api.rs#L250)) with new routes; reuse the existing `guard()` middleware |
 
 | Phase 8.4 sink | Wraps |
 |---|---|

--- a/docs/design/mcp-write-back.md
+++ b/docs/design/mcp-write-back.md
@@ -205,7 +205,7 @@ states the reasoning, and `:21-29` states why the fix is a type:
 > remembering.
 
 Both fixes reached MCP, and how they reached it is the point. `resolve_in_root`
-([`server.rs:487`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L487)) accepts a bare filename and rejects
+([`server.rs:458`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L458)) accepts a bare filename and rejects
 any separator, `..`, root prefix or drive letter *before* touching the
 filesystem — its doc comment (`:163-173`) argues that requiring one component
 has no middle ground, where "every clever normaliser eventually meets a symlink,
@@ -323,7 +323,7 @@ touching the analysis at all.
   Call-IDs, a verdict per call, free text — to a bare filename under
   `--mcp-file-root`.
 - It reaches the filesystem through `resolve_in_root`
-  ([`server.rs:487`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L487)) exactly as `export_capture` and
+  ([`server.rs:458`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L458)) exactly as `export_capture` and
   `export_audio` do, and therefore inherits `ProtectedInputs::check` and cannot
   land on a capture.
 - **Nothing reads it back.** No tool, no report, no REST route, no diagnosis.

--- a/docs/design/ml-anomaly-detection.md
+++ b/docs/design/ml-anomaly-detection.md
@@ -284,7 +284,7 @@ A divergence figure fails the way a MOS fails. The number a two-source capture
 produces is byte-identical to the number a two-hundred-source capture produces,
 and only one of them means anything — which is exactly why an RTP score says
 whether it is grounded. `mos_is_grounded`
-([`src/mcp/server.rs:2749`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L2749))
+([`src/mcp/server.rs:2719`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L2719))
 exists because a placeholder 4.2 and a measured 4.2 are the same bytes, and an
 agent that cannot tell them apart reasons confidently from a guess.
 

--- a/docs/design/multi-capture-comparison.md
+++ b/docs/design/multi-capture-comparison.md
@@ -218,7 +218,7 @@ calls. Under comparison it becomes the exact operation wanted, and the refusal
 must be relaxed *only* for a confirmed cross-session pair — not removed.
 
 The MCP surface has the single-capture ancestor of all three: `compare_dialogs`
-([`server.rs:4989`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4989)) takes two Call-IDs, projects state,
+([`server.rs:4960`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L4960)) takes two Call-IDs, projects state,
 final status code, message count, methods and hints for each, and names the keys
 that differ. Its shape is right and its scope is one store — both Call-IDs are
 looked up in the same `dialog_store`. Extending it to cross sessions is the same

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1059,6 +1059,18 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
   "caveats": {
     "media_creating_commands": 0
   },
+  "capture_identity": {
+    "node": "capture01",
+    "instance": "1f4a17c8e2b91d40-1",
+    "dialog_generation": 412,
+    "stream_generation": 96
+  },
+  "source": "live",
+  "capture_name": "eth0",
+  "uptime_sec": 3600,
+  "source_exhausted": false,
+  "writing_to": null,
+  "unsaved": true,
   "unanalysed_sip_messages": 0,
   "unanalysed_busiest_ports": [],
   "unanalysed_websocket_messages": 0,
@@ -1137,6 +1149,42 @@ the end-of-run summary the command line prints.
 
 The MCP `capture_status` tool carries the same block under the same name, so
 this endpoint and an agent never disagree about it.
+
+### Which capture these counts came from
+
+`capture_identity` pairs the capture's instance with both store generations.
+Compare it across calls:
+
+- **higher generation, same instance** — the capture grew
+- **different instance** — something swapped the file, and every count you
+  were holding describes a different capture
+
+It is the **same identity** the MCP `capture_status` tool stamps its answers
+with, read from the same object. An agent and an HTTP client polling one
+process can therefore tell they are describing one capture — and both see a
+swap the moment it happens.
+
+sipnab reads the instance and both generations under one set of locks, so the
+identity names a single moment rather than three.
+
+`null` when nobody told this server what capture it holds.
+
+| Key | Meaning |
+|-----|---------|
+| `source` | `live`, `file`, or `unknown` |
+| `capture_name` | interface name when live, file path when replaying |
+| `uptime_sec` | seconds since capture began |
+| `source_exhausted` | `true` once sipnab reaches the end of a file source |
+| `writing_to` | path sipnab saves packets to, if any |
+| `unsaved` | `true` only for a **live** capture with no output file — packets held in memory and nowhere else |
+
+**`unknown` is a real answer, not a default.** It is what you consult before
+deciding whether stopping a capture is destructive, and a wrong `"live"` would
+be worse than an admission of ignorance.
+
+`unsaved` is the field that matters for that decision. A file replay is already
+on disk, so it is never unsaved. A live capture with an output file is safe to
+stop.
 
 ### SIP the port gate never analyzed
 

--- a/docs/rtpengine.md
+++ b/docs/rtpengine.md
@@ -86,6 +86,86 @@ the collector it feeds. That is why sipnab reads the traffic off the wire by
 default: a diagnostic tool has no business in a production data path, and if
 sipnab stops, nothing else notices.
 
+## Several rtpengine instances behind one proxy
+
+A proxy that load-balances across a pool of relays puts each call on exactly
+one of them. Run **one sipnab per host**: the proxy's sees the SIP, each
+relay's sees the media its own host relays.
+
+```text
+                        sipnab@proxy
+                        (SIP; no media)
+                              |
+        +---------------------+---------------------+
+        |                     |                     |
+  sipnab@relay-a        sipnab@relay-b        sipnab@relay-c
+  (media it relays)     (media it relays)     (media it relays)
+```
+
+Each relay host runs sipnab against its **own local** relay:
+
+```bash
+# On relay-a, relay-b, relay-c — identical, and each asks only its own relay.
+sipnab -d eth0 --rtpengine-control 127.0.0.1:22222 --api 127.0.0.1:8080
+```
+
+`--rtpengine-control` takes one address, and in this topology that is correct
+rather than a limitation: a relay can only answer for calls it is carrying, so
+a sipnab asking a relay on another host would get `RelayDoesNotHoldIt` for
+everything.
+
+### Finding a call without asking every relay
+
+The naive procedure is a broadcast: ask all ten relays, discard nine misses.
+You do not have to. **The proxy's own SDP names the relay**, because the `c=`
+address the proxy negotiated IS the rtpengine it steered the call to.
+
+**Step 1 — ask the proxy which relay has it.**
+
+```bash
+curl -fsS "http://proxy:8080/v1/dialogs/$CALL_ID" $H \
+  | jq -r '.sdp_timeline[0] | "\(.media_addr):\(.media_port)"'
+# 10.0.0.40:38664
+```
+
+**Step 2 — ask that one relay, and no others.**
+
+```bash
+curl -fsS "http://10.0.0.40:8080/v1/dialogs/$CALL_ID" $H | jq '.streams'
+```
+
+A relay that never carried the call answers **404**, not an empty success.
+That distinction is load-bearing: "I do not have this call" and "this call had
+no media" are different findings, and a relay that answered `200` with an
+empty list would report the second when it meant the first.
+
+### Knowing whose answer you are holding
+
+Every node stamps its answers with its own `capture_identity`, which carries
+the host name:
+
+```bash
+curl -fsS "http://10.0.0.40:8080/v1/stats" $H | jq '.capture_identity'
+# { "node": "relay-a", "instance": "1f4a…", "dialog_generation": 412, … }
+```
+
+Collecting replies from several hosts, that field is what keeps them
+attributable to the host that gave them. Without it, two JSON documents from
+two relays are indistinguishable once they are side by side in a terminal.
+
+### What a multi-node deployment does not do
+
+sipnab does **not** aggregate across nodes. There is no cluster mode, no
+central index, and no node that answers for another. Each instance answers for
+what it captured, and the correlation above is something you (or an agent
+holding several endpoints) perform. That is a deliberate limit, not a missing
+feature: an aggregator is infrastructure, and
+[positioning](design/positioning.md) rules it out.
+
+[`tests/multi_node_relay_fanout_test.rs`](https://github.com/NormB/sipnab/blob/main/tests/multi_node_relay_fanout_test.rs) pins the three properties this
+procedure rests on — the proxy holds signaling and no media, exactly one relay
+claims a call, and the proxy's SDP names which one.
+
 ## Set it up
 
 ### If rtpengine already reports to Homer

--- a/src/app/servers.rs
+++ b/src/app/servers.rs
@@ -266,14 +266,63 @@ pub fn start_servers(
     #[cfg(any(feature = "api", feature = "mcp"))]
     #[allow(unused_mut)]
     let mut mcp_stdio_done: Option<Arc<std::sync::atomic::AtomicBool>> = None;
-    #[cfg(any(feature = "api", feature = "mcp"))]
-    #[allow(unused_mut)]
-    let mut source_exhausted: Option<Arc<std::sync::atomic::AtomicBool>> = None;
     // Every parameter below is consumed only inside the `api`/`mcp` cfg arms.
     // With neither feature compiled those arms vanish and the arguments would
     // read as dead; bind them to `_` so the build stays warning-free without a
     // blanket `#[allow(unused_variables)]` on the whole function.
     let _unused_without_server_features = (dialog_store, stream_store, alerts, &selection, cli);
+
+    // The capture both doors describe, created HERE so neither server owns it.
+    //
+    // It used to be built inside the `mcp` arm below, which is why
+    // `GET /v1/stats` could not say which capture its counts came from: the
+    // object existed only when MCP was running, and even then only MCP held
+    // it. Sharing a copy would have been worse than the gap -- the identity
+    // rotates when `open_capture` swaps the file underneath, and two copies
+    // disagree from that moment on.
+    //
+    // Derived from the same flags the capture path uses, not restated: `-I`
+    // beats `-d`, exactly as bootstrap resolves it.
+    #[cfg(any(feature = "api", feature = "mcp"))]
+    let capture_state = {
+        let (live, name) = match (cli.primary_input(), cli.capture_args.device.as_deref()) {
+            (Some(path), _) => (false, path.to_string()),
+            (None, Some(dev)) => (true, dev.to_string()),
+            // No -d and no -I: the capture layer picks a default. On Linux
+            // that is the "any" pseudo-device -- ALL interfaces at once,
+            // loopback included -- and on macOS/BSD a single device from the
+            // routing table. Name it as the capture layer will resolve it, so
+            // a reader is not told "auto" and left to guess whether that means
+            // one interface or every one.
+            (None, None) => (
+                true,
+                if cfg!(target_os = "linux") {
+                    "any (all interfaces)".to_string()
+                } else {
+                    "default (one interface, chosen by libpcap)".to_string()
+                },
+            ),
+        };
+        let state = crate::capture::session::CaptureState::describing(
+            crate::capture::session::CaptureContext {
+                live,
+                name,
+                started: std::time::Instant::now(),
+                writing_to: cli.capture_args.output.clone(),
+            },
+        );
+        Arc::new(parking_lot::RwLock::new(state))
+    };
+    // One flag, flipped by the capture owner and read by both doors. A copy
+    // would let one of them report a finished file as still running.
+    #[cfg(any(feature = "api", feature = "mcp"))]
+    let exhausted = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    // Handed back to the capture owner, which is what flips it. Bound from
+    // `exhausted` rather than declared as `None` and reassigned in one arm:
+    // the flag is created unconditionally now that both doors read it, so
+    // there is no state in which it is absent.
+    #[cfg(any(feature = "api", feature = "mcp"))]
+    let source_exhausted = Some(Arc::clone(&exhausted));
 
     #[cfg(feature = "api")]
     if selection.api
@@ -293,6 +342,10 @@ pub fn start_servers(
                 selection.api_rate_limit_per_peer,
             ))),
             max_rows: selection.api_row_cap,
+            // The same object the MCP arm below is handed, so both doors name
+            // one capture and see one rotation.
+            capture: Some(Arc::clone(&capture_state)),
+            source_exhausted: Some(Arc::clone(&exhausted)),
         };
         let config = ApiServerConfig {
             max_conn: cli.listener_args.api_max_conn,
@@ -312,37 +365,6 @@ pub fn start_servers(
 
     #[cfg(feature = "mcp")]
     if selection.mcp && cli.mcp_args.mcp {
-        let exhausted = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        source_exhausted = Some(Arc::clone(&exhausted));
-        // Describe the capture source so `capture_status` reports fact rather
-        // than "unknown". Derived from the same flags the capture path uses,
-        // not restated — `-I` beats `-d`, exactly as bootstrap resolves it.
-        let capture_ctx = {
-            let (live, name) = match (cli.primary_input(), cli.capture_args.device.as_deref()) {
-                (Some(path), _) => (false, path.to_string()),
-                (None, Some(dev)) => (true, dev.to_string()),
-                // No -d and no -I: the capture layer picks a default. On
-                // Linux that is the "any" pseudo-device — ALL interfaces at
-                // once, loopback included — and on macOS/BSD a single device
-                // from the routing table. Name it as the capture layer will
-                // resolve it, so an agent is not told "auto" and left to guess
-                // whether that means one interface or every one.
-                (None, None) => (
-                    true,
-                    if cfg!(target_os = "linux") {
-                        "any (all interfaces)".to_string()
-                    } else {
-                        "default (one interface, chosen by libpcap)".to_string()
-                    },
-                ),
-            };
-            crate::mcp::CaptureContext {
-                live,
-                name,
-                started: std::time::Instant::now(),
-                writing_to: cli.capture_args.output.clone(),
-            }
-        };
         // What this run is reading, so the file tools cannot write over it.
         // Built from the `-I` specs rather than the resolved set: resolution
         // opens every candidate through libpcap and has already run once in
@@ -356,7 +378,10 @@ pub fn start_servers(
         let new_server = || {
             let s = crate::mcp::SipnabMcp::new(Arc::clone(dialog_store), Arc::clone(stream_store))
                 .with_source_exhausted(Arc::clone(&exhausted))
-                .with_capture_context(capture_ctx.clone())
+                // The SAME object REST holds, context already set. Handed in
+                // rather than built here, so a rotation one door performs is a
+                // rotation the other sees.
+                .with_capture_state(Arc::clone(&capture_state))
                 .with_protected_inputs(protected_inputs.clone())
                 .with_max_concurrent(cli.mcp_args.mcp_max_concurrent as usize)
                 .with_rate_limit_per_peer(

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -52,6 +52,9 @@ pub mod pcap_reader;
 #[cfg(feature = "native")]
 pub mod pcapng_meta;
 pub mod reassembly;
+/// Which capture a server holds, shared by REST and MCP so both name the same
+/// one. See the module docs for why it is not defined inside either server.
+pub mod session;
 /// Deciding what a kernel uprobe delivered may be used for.
 #[cfg(target_os = "linux")]
 pub mod uprobe;

--- a/src/capture/session.rs
+++ b/src/capture/session.rs
@@ -1,0 +1,178 @@
+//! Which capture a server is holding, behind one lock so a swap is atomic.
+//!
+//! Lives here, outside both server modules, because **two doors must answer
+//! with the same identity**. It was defined inside `src/mcp/server.rs` and
+//! gated on the `mcp` feature, which left `GET /v1/stats` with no way to say
+//! which capture its counts came from: an agent and an HTTP client polling one
+//! process could not tell whether they were describing the same thing.
+//!
+//! Making REST hold its own copy would have been worse than the gap. The
+//! identity ROTATES when `open_capture` swaps the file underneath, and two
+//! copies would disagree from that moment on — a client comparing them would
+//! be told the capture changed when it had not, or that it had not when it
+//! did. One object, one lock, both doors.
+//!
+//! The two fields only MCP can populate are `#[cfg]`-gated rather than moved
+//! out, the same shape
+//! [`MediaDecrypt`](crate::pipeline::MediaDecrypt) uses for its `tls`-only
+//! fields. An `api`-only build gets a struct without them and needs no
+//! knowledge that they exist.
+
+use std::sync::Arc;
+
+/// Which capture this process holds, behind one lock so a swap is atomic.
+///
+/// Everything a swap changes lives here together on purpose. The identity and
+/// the description have to move as one: an answer stamped with the old
+/// instance and the new filename, or the reverse, is worse than either alone
+/// because it looks self-consistent.
+///
+/// **Lock order: this lock, then the dialog store, then the stream store.**
+/// `open_capture` clears both stores while holding this one, so a reader that
+/// takes a store guard and then reaches for this lock deadlocks against it.
+/// Every handler that stamps an answer with the identity holds all three
+/// across the read for the same reason: releasing this lock first lets a swap
+/// land between the id and the rows, and the answer then names a capture it
+/// did not come from.
+///
+/// That rule now binds BOTH servers. `GET /v1/stats` takes the three in this
+/// order for the same reason `capture_status` does, and because two doors
+/// taking one set of locks in two orders is a deadlock waiting for load.
+#[derive(Debug, Default)]
+pub struct CaptureState {
+    /// Identity of the capture currently loaded — see [`crate::provenance`].
+    /// Rotated in the same critical section that clears the stores.
+    pub identity: crate::provenance::CaptureIdentity,
+    /// What this server is attached to, and when that capture began.
+    ///
+    /// An agent had no way to ask whether it was reading a live interface or
+    /// replaying a file — so it could not tell whether "stop the capture"
+    /// would lose anything, nor whether a quiet capture meant a quiet network
+    /// or a finished file. Every downstream misjudgement traced back to that.
+    pub context: Option<CaptureContext>,
+    /// The background load filling this capture, while one is running.
+    #[cfg(feature = "mcp")]
+    pub load: Option<Arc<crate::mcp::load::CaptureLoad>>,
+    /// The uprobe TLS capture feeding this server, while one is running.
+    ///
+    /// Held here rather than in a field of its own so that every check which
+    /// already takes the capture lock — "is a live source running", "would
+    /// stopping lose packets" — sees it without a second lock and a second
+    /// chance to disagree with itself.
+    #[cfg(feature = "mcp")]
+    pub tls: Option<Arc<crate::mcp::tls_capture::TlsCapture>>,
+    /// Holds the `Arc` import in builds that compile neither gated field.
+    #[cfg(not(feature = "mcp"))]
+    _marker: std::marker::PhantomData<Arc<()>>,
+}
+
+impl CaptureState {
+    /// A state describing the capture named by `context`.
+    ///
+    /// A constructor rather than struct-update syntax at the call sites,
+    /// because in a build without `mcp` this struct carries a PRIVATE
+    /// `PhantomData` marker, and `..Default::default()` cannot reach a private
+    /// field from another module. Callers would then compile under `full` and
+    /// fail under `--features api` alone -- a combination only the pre-push
+    /// hook and CI run, which is exactly where this was caught.
+    #[must_use]
+    pub fn describing(context: CaptureContext) -> Self {
+        Self {
+            context: Some(context),
+            ..Default::default()
+        }
+    }
+}
+
+/// Where this server's packets come from.
+#[derive(Debug, Clone)]
+pub struct CaptureContext {
+    /// `true` for a live interface, `false` for a file replay.
+    pub live: bool,
+    /// Interface name when live, file path when replaying.
+    pub name: String,
+    /// When capture began, for uptime.
+    pub started: std::time::Instant,
+    /// Path packets are being written to, when one was configured.
+    ///
+    /// `None` on a live capture means the packets exist only in memory: stop
+    /// the process and they are gone. That is the fact `shutdown_server` has
+    /// to consult before it agrees to stop anything.
+    pub writing_to: Option<String>,
+}
+
+impl CaptureContext {
+    /// How this capture describes itself: `live`, `file`, or `unknown` when
+    /// there is no context at all.
+    ///
+    /// One spelling in one place, because both doors publish it and a client
+    /// that learned `"live"` from one must not meet `"interface"` at the other.
+    /// `unknown` is deliberately a real answer rather than a default: it is the
+    /// field an agent consults before deciding whether stopping is destructive,
+    /// and a wrong `"live"` would be worse than an admission of ignorance.
+    #[must_use]
+    pub fn source_label(ctx: Option<&Self>) -> &'static str {
+        match ctx {
+            Some(c) if c.live => "live",
+            Some(_) => "file",
+            None => "unknown",
+        }
+    }
+
+    /// Whether stopping now would lose packets that exist nowhere else.
+    ///
+    /// True only for a LIVE capture with no output file. A file replay is by
+    /// definition already on disk, and a live capture being written out is
+    /// safe to stop.
+    #[must_use]
+    pub fn unsaved(ctx: Option<&Self>) -> bool {
+        ctx.is_some_and(|c| c.live && c.writing_to.is_none())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CaptureContext;
+
+    fn ctx(live: bool, writing_to: Option<&str>) -> CaptureContext {
+        CaptureContext {
+            live,
+            name: "eth0".into(),
+            started: std::time::Instant::now(),
+            writing_to: writing_to.map(ToString::to_string),
+        }
+    }
+
+    /// `unknown` is a real answer, not a default that reads as a file replay.
+    ///
+    /// This is the field an agent consults before deciding whether stopping a
+    /// capture is destructive. Answering `"file"` when nobody said would tell
+    /// it the packets are already on disk.
+    #[test]
+    fn a_capture_with_no_context_says_unknown() {
+        assert_eq!(CaptureContext::source_label(None), "unknown");
+        assert_eq!(CaptureContext::source_label(Some(&ctx(true, None))), "live");
+        assert_eq!(
+            CaptureContext::source_label(Some(&ctx(false, None))),
+            "file"
+        );
+    }
+
+    /// Only a live capture with nowhere to write can lose packets.
+    ///
+    /// The three false cases matter as much as the true one: a file replay is
+    /// already on disk, a live capture being written out is safe to stop, and
+    /// an unknown source must not be reported as holding anything, because
+    /// that would make every shutdown look destructive and train an operator
+    /// to ignore the warning.
+    #[test]
+    fn only_a_live_capture_with_no_output_is_unsaved() {
+        assert!(CaptureContext::unsaved(Some(&ctx(true, None))));
+        assert!(!CaptureContext::unsaved(Some(&ctx(
+            true,
+            Some("/tmp/x.pcap")
+        ))));
+        assert!(!CaptureContext::unsaved(Some(&ctx(false, None))));
+        assert!(!CaptureContext::unsaved(None));
+    }
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -187,59 +187,14 @@ pub struct SipnabMcp {
 /// would hand a looping caller a fresh allowance on every loop.
 type PeerKey = Option<std::net::IpAddr>;
 
-/// Which capture this server holds, behind one lock so a swap is atomic.
+/// The shared capture state, re-exported so MCP's own call sites keep reading
+/// as they did.
 ///
-/// Everything a swap changes lives here together on purpose. The identity and
-/// the description have to move as one: an answer stamped with the old
-/// instance and the new filename, or the reverse, is worse than either alone
-/// because it looks self-consistent.
-///
-/// **Lock order: this lock, then the dialog store, then the stream store.**
-/// `open_capture` clears both stores while holding this one, so a reader that
-/// takes a store guard and then reaches for this lock deadlocks against it.
-/// Every handler that stamps an answer with the identity holds all three
-/// across the read for the same reason: releasing this lock first lets a swap
-/// land between the id and the rows, and the answer then names a capture it
-/// did not come from.
-#[derive(Debug, Default)]
-pub struct CaptureState {
-    /// Identity of the capture currently loaded — see [`crate::provenance`].
-    /// Rotated in the same critical section that clears the stores.
-    pub identity: crate::provenance::CaptureIdentity,
-    /// What this server is attached to, and when that capture began.
-    ///
-    /// An agent had no way to ask whether it was reading a live interface or
-    /// replaying a file — so it could not tell whether "stop the capture"
-    /// would lose anything, nor whether a quiet capture meant a quiet network
-    /// or a finished file. Every downstream misjudgement traced back to that.
-    pub context: Option<CaptureContext>,
-    /// The background load filling this capture, while one is running.
-    pub load: Option<Arc<super::load::CaptureLoad>>,
-    /// The uprobe TLS capture feeding this server, while one is running.
-    ///
-    /// Held here rather than in a field of its own so that every check which
-    /// already takes the capture lock — "is a live source running", "would
-    /// stopping lose packets" — sees it without a second lock and a second
-    /// chance to disagree with itself.
-    pub tls: Option<Arc<super::tls_capture::TlsCapture>>,
-}
-
-/// Where this server's packets come from, for `capture_status`.
-#[derive(Debug, Clone)]
-pub struct CaptureContext {
-    /// `true` for a live interface, `false` for a file replay.
-    pub live: bool,
-    /// Interface name when live, file path when replaying.
-    pub name: String,
-    /// When capture began, for uptime.
-    pub started: std::time::Instant,
-    /// Path packets are being written to, when one was configured.
-    ///
-    /// `None` on a live capture means the packets exist only in memory: stop
-    /// the process and they are gone. That is the fact `shutdown_server` has
-    /// to consult before it agrees to stop anything.
-    pub writing_to: Option<String>,
-}
+/// The type moved to [`crate::capture::session`] when `GET /v1/stats` needed
+/// the same identity this server stamps its answers with. Defining it here
+/// left it behind the `mcp` feature gate, and a REST-only build could not name
+/// the capture its counts came from at all.
+pub use crate::capture::session::{CaptureContext, CaptureState};
 
 impl SipnabMcp {
     /// Build a new MCP server bound to the given (already-shared) stores.
@@ -416,6 +371,22 @@ impl SipnabMcp {
     /// stores `true` once the packet source drains (pcap EOF).
     pub fn with_source_exhausted(mut self, flag: Arc<std::sync::atomic::AtomicBool>) -> Self {
         self.source_exhausted = Some(flag);
+        self
+    }
+
+    /// Share this server's capture state with another door.
+    ///
+    /// The REST API needs the SAME object, not a copy: the identity rotates
+    /// when `open_capture` swaps the file underneath, and two copies would
+    /// disagree from that moment on. A client comparing an MCP answer with a
+    /// `GET /v1/stats` answer would then be told the capture changed when it
+    /// had not, or that it had not when it did.
+    ///
+    /// Handed in rather than handed out, so the object exists before either
+    /// server does and neither owns it.
+    #[must_use]
+    pub fn with_capture_state(mut self, state: Arc<RwLock<CaptureState>>) -> Self {
+        self.capture = state;
         self
     }
 

--- a/src/output/api.rs
+++ b/src/output/api.rs
@@ -74,6 +74,27 @@ pub struct ApiState {
     /// `--api-max-rows` / `[limits] api_max_rows` by the caller that starts
     /// the server (config is in scope there and not here).
     pub max_rows: usize,
+    /// Which capture this process holds — the SAME object the MCP server
+    /// stamps its answers with, when both are running.
+    ///
+    /// Shared rather than copied because the identity rotates: `open_capture`
+    /// swaps the file underneath, and two copies would disagree from that
+    /// moment on. A client comparing an MCP answer against `GET /v1/stats`
+    /// would then be told the capture changed when it had not, or that it had
+    /// not when it did.
+    ///
+    /// `None` when nobody supplied one — a REST server started without capture
+    /// context, which every test in this module builds. The response then says
+    /// `source: "unknown"` and omits the identity, which is the same answer
+    /// `capture_status` gives and for the same reason: a wrong `"live"` would
+    /// be worse than an admission of ignorance.
+    pub capture: Option<Arc<RwLock<crate::capture::session::CaptureState>>>,
+    /// Set once a file source has been read to the end.
+    ///
+    /// The same `Arc` the capture owner and the MCP server hold, so all three
+    /// flip together. A copy would let one door report a finished file as
+    /// still running.
+    pub source_exhausted: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
 /// Rows a list-style response returns when the caller names no `limit`.
@@ -1041,7 +1062,22 @@ async fn get_stats(
 ) -> Result<impl IntoResponse, StatusCode> {
     guard(&state, &headers, addr.ip())?;
 
+    // Capture lock first, then dialogs, then streams -- the order
+    // `CaptureState` documents and MCP's `capture_status` takes. Two doors
+    // taking one set of locks in two orders is a deadlock waiting for load,
+    // and `open_capture` clears both stores while holding the capture lock.
+    //
+    // Held ACROSS both stores, which this handler did not do: it released the
+    // dialog guard before taking the stream guard, so its dialog counts and
+    // stream counts described two different instants. That was survivable
+    // while nothing tied them together. It stops being survivable the moment
+    // the response carries an identity, because the etag pairs the instance
+    // with BOTH generations and would assert a consistency the code did not
+    // provide.
+    let capture = state.capture.as_ref().map(|c| c.read());
     let ds = state.dialog_store.read();
+    let ss = state.stream_store.read();
+
     let total_dialogs = ds.len();
     let active_dialogs = ds.active_dialog_count();
     let active_calls = ds.active_call_count();
@@ -1062,12 +1098,40 @@ async fn get_stats(
             _ => {}
         }
     }
-    drop(ds);
-
-    let ss = state.stream_store.read();
     let total_streams = ss.len();
     let orphaned_count = ss.orphaned_count();
+
+    // Stamped while all three guards are held, so the instance and the two
+    // generations name one moment. `None` when nobody supplied a capture --
+    // the same admission `capture_status` makes, rather than an identity for a
+    // capture this server cannot describe.
+    let capture_identity = capture
+        .as_ref()
+        .map(|c| c.identity.etag(ds.generation(), ss.generation()));
+    let source = crate::capture::session::CaptureContext::source_label(
+        capture.as_ref().and_then(|c| c.context.as_ref()),
+    );
+    let (capture_name, uptime_sec, writing_to) = capture
+        .as_ref()
+        .and_then(|c| c.context.as_ref())
+        .map_or((None, None, None), |c| {
+            (
+                Some(c.name.clone()),
+                Some(c.started.elapsed().as_secs()),
+                c.writing_to.clone(),
+            )
+        });
+    let unsaved = crate::capture::session::CaptureContext::unsaved(
+        capture.as_ref().and_then(|c| c.context.as_ref()),
+    );
+    let source_exhausted = state
+        .source_exhausted
+        .as_ref()
+        .is_some_and(|f| f.load(std::sync::atomic::Ordering::Acquire));
+
     drop(ss);
+    drop(ds);
+    drop(capture);
 
     let pdd_p50 = percentile(&pdd_values, 50);
     let pdd_p95 = percentile(&pdd_values, 95);
@@ -1137,6 +1201,28 @@ async fn get_stats(
         // Always present, always complete, and zero is a real answer. A key
         // that shows up only on a bad run is a key no client learns exists.
         "caveats": caveats.to_json(),
+        // WHICH capture these counts came from, and which revision of its
+        // stores. Compare it across calls: a higher generation on the same
+        // instance means the capture grew; a different instance means the file
+        // was swapped and every count you were holding describes something
+        // else. `null` when nobody told this server what it is attached to.
+        //
+        // The SAME identity MCP `capture_status` stamps its answers with, from
+        // the same object, so an agent and an HTTP client polling one process
+        // can tell they are describing one capture.
+        "capture_identity": capture_identity,
+        // What this server is attached to. `unknown` is a real answer and not
+        // a default: it is the field consulted before deciding whether
+        // stopping is destructive, and a wrong `live` would be worse than an
+        // admission of ignorance.
+        "source": source,
+        "capture_name": capture_name,
+        "uptime_sec": uptime_sec,
+        "source_exhausted": source_exhausted,
+        "writing_to": writing_to,
+        // True only for a LIVE capture with no output file: packets held in
+        // memory and nowhere else. A file replay is already on disk.
+        "unsaved": unsaved,
         // Kept at the top level rather than folded into `caveats`, because MCP
         // publishes them at the top level and the whole point is that the two
         // doors name one fact the same way.
@@ -1358,6 +1444,12 @@ mod tests {
             )),
             rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
             max_rows: crate::cli::Cli::DEFAULT_API_MAX_ROWS as usize,
+            // No capture context: these fixtures build a server around bare
+            // stores, which is exactly the state `source: "unknown"` and a
+            // null identity exist to describe. A fixture that invented one
+            // would test a shape production never produces.
+            capture: None,
+            source_exhausted: None,
         }
     }
 
@@ -1374,6 +1466,12 @@ mod tests {
             )),
             rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
             max_rows: crate::cli::Cli::DEFAULT_API_MAX_ROWS as usize,
+            // No capture context: these fixtures build a server around bare
+            // stores, which is exactly the state `source: "unknown"` and a
+            // null identity exist to describe. A fixture that invented one
+            // would test a shape production never produces.
+            capture: None,
+            source_exhausted: None,
         }
     }
 
@@ -1820,6 +1918,12 @@ mod tests {
             )),
             rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
             max_rows: crate::cli::Cli::DEFAULT_API_MAX_ROWS as usize,
+            // No capture context: these fixtures build a server around bare
+            // stores, which is exactly the state `source: "unknown"` and a
+            // null identity exist to describe. A fixture that invented one
+            // would test a shape production never produces.
+            capture: None,
+            source_exhausted: None,
         }
     }
 
@@ -2003,6 +2107,157 @@ mod tests {
         }
         // 6th should fail
         assert!(!limiter.check(ip));
+    }
+
+    /// `/v1/stats` names WHICH capture its counts came from, and says
+    /// `unknown` when nobody told it.
+    ///
+    /// The identity pairs the instance with BOTH store generations, so it is
+    /// only honest if the instance and the two generations describe one
+    /// moment. This handler used to release the dialog guard before taking the
+    /// stream guard -- survivable while nothing tied the counts together, and
+    /// not survivable once a single etag claims they belong to each other. The
+    /// three guards are now held across the read, in the order `CaptureState`
+    /// documents and MCP takes them.
+    ///
+    /// The `None` arm is asserted first because it is the one a REST-only
+    /// deployment actually hits, and because `unknown` is a real answer rather
+    /// than a default: it is what a reader consults before deciding whether
+    /// stopping a capture is destructive, and a wrong `"live"` would be worse
+    /// than an admission of ignorance.
+    #[tokio::test]
+    async fn stats_names_the_capture_or_admits_it_does_not_know() {
+        let app = build_router(make_state());
+        let v: Value = serde_json::from_str(
+            &body_to_string(
+                app.oneshot(test_request("/v1/stats"))
+                    .await
+                    .expect("oneshot")
+                    .into_body(),
+            )
+            .await,
+        )
+        .expect("valid JSON");
+
+        assert_eq!(
+            v["source"], "unknown",
+            "a server nobody described must say so rather than guess: {v}"
+        );
+        assert!(
+            v["capture_identity"].is_null(),
+            "there is no capture to identify, and an identity here would name \
+             one that does not exist: {v}"
+        );
+        assert_eq!(
+            v["unsaved"], false,
+            "an unknown source holds nothing, and reporting it as unsaved would \
+             make every shutdown look destructive: {v}"
+        );
+        // Present at null rather than omitted, for the reason every optional
+        // key on this endpoint is: a field that appears only sometimes is a
+        // field no client learns exists.
+        for key in [
+            "capture_name",
+            "uptime_sec",
+            "writing_to",
+            "source_exhausted",
+        ] {
+            assert!(v.get(key).is_some(), "`{key}` missing from /v1/stats: {v}");
+        }
+    }
+
+    /// With a capture, `/v1/stats` reports the identity from the SHARED object
+    /// -- the same one MCP stamps its answers with.
+    ///
+    /// This is what the whole change is for. A copy would have been simpler
+    /// and wrong: the identity ROTATES when `open_capture` swaps the file
+    /// underneath, and two copies disagree from that moment on. A client
+    /// comparing an MCP answer against this one would be told the capture
+    /// changed when it had not, or that it had not when it did.
+    ///
+    /// So the test rotates the shared state and requires the endpoint to
+    /// follow. Reading the identity once proves only that a field exists.
+    #[tokio::test]
+    async fn stats_follows_a_rotation_of_the_shared_capture() {
+        use crate::capture::session::{CaptureContext, CaptureState};
+
+        let capture = Arc::new(RwLock::new(CaptureState::describing(CaptureContext {
+            live: true,
+            name: "eth0".into(),
+            started: std::time::Instant::now(),
+            writing_to: None,
+        })));
+        let mut state = make_state();
+        state.capture = Some(Arc::clone(&capture));
+        let app = build_router(state);
+
+        let read = |app: axum::Router| async move {
+            let body = body_to_string(
+                app.oneshot(test_request("/v1/stats"))
+                    .await
+                    .expect("oneshot")
+                    .into_body(),
+            )
+            .await;
+            serde_json::from_str::<Value>(&body).expect("valid JSON")
+        };
+
+        let before = read(app.clone()).await;
+        assert_eq!(before["source"], "live");
+        assert_eq!(before["capture_name"], "eth0");
+        assert_eq!(
+            before["unsaved"], true,
+            "a live capture with no output file holds packets that exist \
+             nowhere else: {before}"
+        );
+        // An OBJECT, not a string: node, instance and both store generations,
+        // the same four fields MCP `capture_status` publishes under this key.
+        // The instance is the half a swap changes.
+        for key in ["node", "instance", "dialog_generation", "stream_generation"] {
+            assert!(
+                before["capture_identity"].get(key).is_some(),
+                "`capture_identity.{key}` missing -- the etag must pair the \
+                 instance with BOTH generations, or a client cannot tell a \
+                 capture that grew from one that was swapped: {before}"
+            );
+        }
+        let first = before["capture_identity"]["instance"]
+            .as_str()
+            .expect("a described capture has an instance")
+            .to_string();
+
+        // STABILITY FIRST, and this is the assertion that does the work.
+        //
+        // "the identity changed after a rotation" is satisfied by any handler
+        // that mints a fresh identity per request -- exactly the private-copy
+        // design this change exists to avoid. Only the unchanged case
+        // distinguishes reading the shared object from inventing one: two
+        // reads with nothing in between must be identical.
+        //
+        // Found by mutation. The rotation assertion alone passed against a
+        // handler calling `CaptureIdentity::new()` on every request.
+        let again = read(app.clone()).await;
+        assert_eq!(
+            again["capture_identity"]["instance"], first,
+            "two reads with no swap between them returned different instances, \
+             so this endpoint is minting an identity rather than reading the \
+             one the capture holds: {again}"
+        );
+
+        // What `open_capture` does: a different capture is now loaded.
+        capture.write().identity.rotate();
+
+        let after = read(app).await;
+        let second = after["capture_identity"]["instance"]
+            .as_str()
+            .expect("still identified")
+            .to_string();
+        assert_ne!(
+            first, second,
+            "the endpoint is reading its own copy of the identity, so a swap \
+             MCP performed would be invisible here and the two doors would \
+             disagree about which capture they describe"
+        );
     }
 
     /// `GET /v1/report` answers for the whole capture, and says what it could
@@ -2211,6 +2466,12 @@ mod tests {
             )),
             rate_limiter: Arc::new(Mutex::new(RateLimiter::new(1))),
             max_rows: crate::cli::Cli::DEFAULT_API_MAX_ROWS as usize,
+            // No capture context: these fixtures build a server around bare
+            // stores, which is exactly the state `source: "unknown"` and a
+            // null identity exist to describe. A fixture that invented one
+            // would test a shape production never produces.
+            capture: None,
+            source_exhausted: None,
         };
         populate_dialogs(&state);
 

--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -2615,7 +2615,13 @@ fn no_documentation_table_repeats_a_row() {
     // holds, in the new SP section of `docs/design/backlog.md`. Attributed by
     // measurement before the number moved: that file gained exactly one table
     // separator, and design docs have no generated mirror.
-    const EXPECTED_TABLES: usize = 641;
+    // 641 -> 643: one hand-written table and its generated mirror, listing the
+    // capture-context keys `/v1/stats` gained beside `capture_identity` --
+    // source, name, uptime, exhausted, writing-to and unsaved. Attributed by
+    // measurement before the number moved: `docs/rest-api.md` and
+    // `website/content/docs/api.md` gained exactly one table separator each and
+    // no other page gained any.
+    const EXPECTED_TABLES: usize = 643;
 
     let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let out = std::process::Command::new("git")

--- a/tests/link_integrity_test.rs
+++ b/tests/link_integrity_test.rs
@@ -610,7 +610,12 @@ fn wiki_intra_docs_links_resolve() {
     // `media-relay` assertion IS rather than re-explaining relay attribution
     // twice. Two pages, one link each; the site mirrors are generated and this
     // gate reads docs/.
-    const EXPECTED_WIKI_LINKS: usize = 480;
+    // 480 -> 481: one link to design/positioning.md from the multi-relay
+    // section of docs/rtpengine.md, which says sipnab aggregates nothing across
+    // nodes and links the page that DECIDED that rather than re-arguing it.
+    // One page, one link; the site mirror is generated and this gate reads
+    // docs/.
+    const EXPECTED_WIKI_LINKS: usize = 481;
     // Raised 459 -> 460 when SRC1 stage 1 shipped: docs/cli-reference.md's
     // `--hep-listen` row now points at cookbook recipe 6d in docs/examples.md
     // rather than restating how to pair `-L` with `-d`. Attributed per file

--- a/tests/multi_node_relay_fanout_test.rs
+++ b/tests/multi_node_relay_fanout_test.rs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! One sipnab per host, and only ONE of the relays has to be asked.
+//!
+//! # The deployment
+//!
+//! A proxy fronts several rtpengine instances and picks one per call. Each
+//! host runs its own sipnab: the proxy's sees the SIP, each relay's sees the
+//! media its own host relays and nothing else. Nobody is aggregating.
+//!
+//! ```text
+//!         sipnab@proxy            sipnab@relay-a          sipnab@relay-b
+//!         (SIP only)              (media for THIS call)   (media for others)
+//!              |                        |                       |
+//!   GET /v1/dialogs/{call_id}    GET .../{call_id}       GET .../{call_id}
+//!         200 + sdp_timeline           200                     404
+//! ```
+//!
+//! The naive way to find a call's media is to ask all ten relays. This suite
+//! proves you do not have to: **the proxy's own SDP names the relay.** The
+//! `c=` address in the dialog's `sdp_timeline` IS the rtpengine host the proxy
+//! steered that call to, so one query to the proxy tells you which single
+//! relay to ask.
+//!
+//! # What each test pins
+//!
+//! * The proxy holds the signaling and NO media — so a query there answers
+//!   "which relay", not "what did the audio do".
+//! * Exactly one relay claims the call. The other does not, and says so as a
+//!   404 rather than as an empty success, because "I do not have this call"
+//!   and "this call had no media" are different answers.
+//! * Each node stamps its answers with its own capture identity, so two
+//!   replies collected from two hosts remain attributable to the host that
+//!   gave them.
+//!
+//! # Why this is a test and not a document
+//!
+//! Every piece here already existed -- per-node stores, the 404, the SDP
+//! timeline, the capture identity. What did not exist was any proof they
+//! compose into the deployment above, and a fan-out procedure that is wrong
+//! about which node to ask is worse than no procedure: it sends an operator to
+//! nine hosts that were never going to have the call.
+#![cfg(all(feature = "native", feature = "api"))]
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+
+use chrono::Utc;
+use parking_lot::RwLock;
+
+use sipnab::capture::parse::{InputOrigin, ParsedPacket, TransportProto};
+use sipnab::rtp::parser::RtpHeader;
+use sipnab::rtp::stream_store::StreamStore;
+use sipnab::sip::dialog_store::DialogStore;
+
+/// The Call-ID the proxy assigned. One call, three hosts.
+const CALL_ID: &str = "fanout-1@proxy.example";
+/// The relay the proxy steered this call to. Its address appears in the SDP.
+const RELAY_A: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 40);
+/// A second relay, carrying somebody else's call.
+const RELAY_B: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 41);
+/// The port rtpengine on relay A allocated for this call.
+const RELAY_A_PORT: u16 = 38664;
+
+/// One sipnab: its own stores, exactly as a separate host would have.
+///
+/// Deliberately NOT a shared store with a node label. The property under test
+/// is that a node which never saw a call cannot answer for it, and a shared
+/// store would make every node able to answer everything -- proving the
+/// opposite of the deployment.
+struct Node {
+    dialogs: Arc<RwLock<DialogStore>>,
+    streams: Arc<RwLock<StreamStore>>,
+}
+
+impl Node {
+    fn new() -> Self {
+        Self {
+            dialogs: Arc::new(RwLock::new(DialogStore::new(1000, false))),
+            streams: Arc::new(RwLock::new(StreamStore::new(1000))),
+        }
+    }
+
+    /// Does this node hold the call? The question a fan-out asks each host.
+    fn holds_dialog(&self, call_id: &str) -> bool {
+        self.dialogs.read().get(call_id).is_some()
+    }
+
+    /// How many media streams this node attributed to the call.
+    fn streams_for(&self, call_id: &str) -> usize {
+        self.streams.read().streams_for(call_id).count()
+    }
+}
+
+/// An INVITE whose SDP steers media at `relay` -- what the proxy rewrote it to.
+fn invite_with_sdp(call_id: &str, relay: Ipv4Addr, port: u16) -> Vec<u8> {
+    let sdp = format!(
+        "v=0\r\n\
+         o=- 1 1 IN IP4 {relay}\r\n\
+         s=-\r\n\
+         c=IN IP4 {relay}\r\n\
+         t=0 0\r\n\
+         m=audio {port} RTP/AVP 0\r\n\
+         a=rtpmap:0 PCMU/8000\r\n"
+    );
+    format!(
+        "INVITE sip:b@example.com SIP/2.0\r\n\
+         Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bKfanout\r\n\
+         From: <sip:a@example.com>;tag=f1\r\n\
+         To: <sip:b@example.com>\r\n\
+         Call-ID: {call_id}\r\n\
+         CSeq: 1 INVITE\r\n\
+         Content-Type: application/sdp\r\n\
+         Content-Length: {}\r\n\r\n{sdp}",
+        sdp.len()
+    )
+    .into_bytes()
+}
+
+/// A UDP packet carrying `payload` toward `dst`.
+fn packet(payload: Vec<u8>, src_port: u16, dst: Ipv4Addr, dst_port: u16) -> ParsedPacket {
+    ParsedPacket {
+        frame: None,
+        timestamp: Utc::now(),
+        src_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        dst_addr: IpAddr::V4(dst),
+        src_port,
+        dst_port,
+        transport: TransportProto::Udp,
+        payload: payload.into(),
+        ip_id: None,
+        tcp_seq: None,
+        tcp_flags: None,
+        fragment_offset: None,
+        more_fragments: false,
+        ip_protocol: 17,
+        dscp: None,
+        input_origin: InputOrigin::Wire,
+    }
+}
+
+/// One RTP packet landing on a relay socket.
+fn media(dst: Ipv4Addr, dst_port: u16, ssrc: u32) -> (ParsedPacket, RtpHeader) {
+    (
+        packet(vec![0u8; 12 + 160], 20000, dst, dst_port),
+        RtpHeader {
+            version: 2,
+            padding: false,
+            extension: false,
+            csrc_count: 0,
+            marker: false,
+            payload_type: 0,
+            sequence: 1,
+            timestamp: 160,
+            ssrc,
+            payload_offset: 12,
+        },
+    )
+}
+
+/// Feed the proxy's node the INVITE, the way the capture path would.
+fn proxy_sees_the_invite(node: &Node, call_id: &str, relay: Ipv4Addr, port: u16) {
+    let pp = packet(invite_with_sdp(call_id, relay, port), 5060, relay, 5060);
+    let msg = sipnab::sip::parser::parse_sip(
+        &pp.payload,
+        pp.timestamp,
+        pp.src_addr,
+        pp.dst_addr,
+        pp.src_port,
+        pp.dst_port,
+        pp.transport,
+    )
+    .expect("the fixture must parse as SIP, or this test proves nothing");
+    node.dialogs.write().process_message(msg);
+}
+
+/// Register a relay-allocated endpoint and then land media on it.
+///
+/// This is the RE4 shape: the relay's own control plane named the port, so a
+/// stream arriving there takes its Call-ID from memory rather than from
+/// signaling the relay host never saw.
+fn relay_sees_the_media(node: &Node, call_id: &str, relay: Ipv4Addr, port: u16, ssrc: u32) {
+    let ts = Utc::now();
+    {
+        let mut ss = node.streams.write();
+        ss.link_to_dialog_with_sdp_from(
+            IpAddr::V4(relay),
+            port,
+            call_id,
+            &relay_media(port),
+            sipnab::rtp::stream_store::SdpProvenance::relay_asserted(InputOrigin::Hep, ts),
+        );
+    }
+    let (pp, rtp) = media(relay, port, ssrc);
+    node.streams.write().process_rtp(&pp, &rtp, ts);
+}
+
+/// The media description a relay's control plane reports for its own socket.
+///
+/// The rtpmap is empty because a `query` reply names a codec and no payload
+/// type, and an rtpmap entry needs both. Synthesizing one would put a number
+/// sipnab was never told into a field an operator reads as measured.
+fn relay_media(port: u16) -> sipnab::sip::sdp::SdpMedia {
+    sipnab::sip::sdp::SdpMedia {
+        media_type: "audio".to_string(),
+        port,
+        proto: "RTP/AVP".to_string(),
+        formats: vec!["0".to_string()],
+        connection: None,
+        direction: sipnab::sip::sdp::SdpDirection::SendRecv,
+        rtpmap: Vec::new(),
+        fmtp: Vec::new(),
+        ptime: None,
+        crypto: Vec::new(),
+        ice_candidates: Vec::new(),
+        rtcp_mux: false,
+        rtcp_port: None,
+    }
+}
+
+/// The proxy holds the signaling and none of the media.
+///
+/// Both halves matter. The signaling is what makes the proxy the node you ask
+/// FIRST; the absence of media is what makes asking a relay necessary at all.
+/// A proxy that appeared to hold streams would send an operator looking for
+/// audio on a host that only ever saw SDP.
+#[test]
+fn the_proxy_node_holds_the_signaling_and_no_media() {
+    let proxy = Node::new();
+    proxy_sees_the_invite(&proxy, CALL_ID, RELAY_A, RELAY_A_PORT);
+
+    assert!(
+        proxy.holds_dialog(CALL_ID),
+        "the proxy saw the INVITE, so it must be able to answer for the call"
+    );
+    assert_eq!(
+        proxy.streams_for(CALL_ID),
+        0,
+        "the proxy is not in the media path -- reporting streams here would \
+         send an operator looking for audio on a host that only saw SDP"
+    );
+}
+
+/// Exactly one relay claims the call, and the other says so.
+///
+/// This is the property the whole deployment rests on. If both relays claimed
+/// it, a fan-out would return two contradictory answers with no way to choose;
+/// if neither did, the media would be unattributable on every host and the
+/// call would look like it had none.
+#[test]
+fn exactly_one_relay_holds_the_call_and_the_other_does_not() {
+    let relay_a = Node::new();
+    let relay_b = Node::new();
+
+    // Relay A carries THIS call.
+    relay_sees_the_media(&relay_a, CALL_ID, RELAY_A, RELAY_A_PORT, 0xAAAA_AAAA);
+    // Relay B carries somebody else's, on its own socket.
+    relay_sees_the_media(
+        &relay_b,
+        "other-call@proxy.example",
+        RELAY_B,
+        30000,
+        0xBBBB_BBBB,
+    );
+
+    assert_eq!(
+        relay_a.streams_for(CALL_ID),
+        1,
+        "the relay that carried the call must attribute its media, from its \
+         own control plane -- it never saw the SIP"
+    );
+    assert_eq!(
+        relay_b.streams_for(CALL_ID),
+        0,
+        "a relay that never carried this call must not claim it. Two relays \
+         claiming one call gives a fan-out two contradictory answers and no \
+         way to choose between them"
+    );
+    // And relay B is not simply empty: it holds its own call, so the zero
+    // above is a real "not mine" rather than a node that captured nothing.
+    assert_eq!(
+        relay_b.streams_for("other-call@proxy.example"),
+        1,
+        "relay B must be carrying its own traffic, or the assertion above \
+         passes for the wrong reason"
+    );
+}
+
+/// The proxy's SDP names the relay to ask, so nine hosts stay unqueried.
+///
+/// The routing key. Without it a fan-out is a broadcast: ask all ten relays,
+/// discard nine 404s. With it the proxy's answer contains the address of the
+/// one host that can have the media, because the `c=` line IS the rtpengine
+/// the proxy steered the call to.
+#[test]
+fn the_proxy_sdp_names_which_relay_to_ask() {
+    let proxy = Node::new();
+    proxy_sees_the_invite(&proxy, CALL_ID, RELAY_A, RELAY_A_PORT);
+
+    let ds = proxy.dialogs.read();
+    let dialog = ds.get(CALL_ID).expect("the proxy holds the dialog");
+    let streams: Vec<&sipnab::rtp::stream::RtpStream> = Vec::new();
+    let diagnosis = sipnab::rtp::diagnosis::MediaDiagnosis::default();
+    let json = sipnab::output::json::dialog_to_json(dialog, &streams, &diagnosis);
+    let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+
+    let first = &v["sdp_timeline"][0];
+    assert_eq!(
+        first["media_addr"],
+        RELAY_A.to_string(),
+        "the dialog must publish the media address the proxy negotiated. \
+         Without it a fan-out has to ask every relay and discard the misses: {v}"
+    );
+    assert_eq!(
+        first["media_port"], RELAY_A_PORT,
+        "the port travels with the address, because a relay host may carry \
+         many calls and the port is what distinguishes them: {v}"
+    );
+    assert_ne!(
+        first["media_addr"],
+        RELAY_B.to_string(),
+        "the routing key must name the relay that has the call, not any relay"
+    );
+}

--- a/tests/security_test.rs
+++ b/tests/security_test.rs
@@ -1342,6 +1342,11 @@ fn constant_time_eq_different_lengths_still_compares() {
         )),
         rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
         max_rows: sipnab::cli::Cli::DEFAULT_API_MAX_ROWS as usize,
+        // No capture context. These fixtures exercise auth and rate limiting
+        // against bare stores, which is the state `source: "unknown"` and a
+        // null identity exist to describe.
+        capture: None,
+        source_exhausted: None,
     };
 
     // Build a request with wrong-length key
@@ -1382,6 +1387,11 @@ fn constant_time_eq_matching_strings() {
         )),
         rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
         max_rows: sipnab::cli::Cli::DEFAULT_API_MAX_ROWS as usize,
+        // No capture context. These fixtures exercise auth and rate limiting
+        // against bare stores, which is the state `source: "unknown"` and a
+        // null identity exist to describe.
+        capture: None,
+        source_exhausted: None,
     };
 
     let app = build_router(state);
@@ -1432,6 +1442,11 @@ fn constant_time_eq_different_strings_same_length() {
         )),
         rate_limiter: Arc::new(Mutex::new(RateLimiter::new(100))),
         max_rows: sipnab::cli::Cli::DEFAULT_API_MAX_ROWS as usize,
+        // No capture context. These fixtures exercise auth and rate limiting
+        // against bare stores, which is the state `source: "unknown"` and a
+        // null identity exist to describe.
+        capture: None,
+        source_exhausted: None,
     };
 
     let app = build_router(state);

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -1064,6 +1064,18 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
   "caveats": {
     "media_creating_commands": 0
   },
+  "capture_identity": {
+    "node": "capture01",
+    "instance": "1f4a17c8e2b91d40-1",
+    "dialog_generation": 412,
+    "stream_generation": 96
+  },
+  "source": "live",
+  "capture_name": "eth0",
+  "uptime_sec": 3600,
+  "source_exhausted": false,
+  "writing_to": null,
+  "unsaved": true,
   "unanalysed_sip_messages": 0,
   "unanalysed_busiest_ports": [],
   "unanalysed_websocket_messages": 0,
@@ -1142,6 +1154,42 @@ the end-of-run summary the command line prints.
 
 The MCP `capture_status` tool carries the same block under the same name, so
 this endpoint and an agent never disagree about it.
+
+### Which capture these counts came from
+
+`capture_identity` pairs the capture's instance with both store generations.
+Compare it across calls:
+
+- **higher generation, same instance** — the capture grew
+- **different instance** — something swapped the file, and every count you
+  were holding describes a different capture
+
+It is the **same identity** the MCP `capture_status` tool stamps its answers
+with, read from the same object. An agent and an HTTP client polling one
+process can therefore tell they are describing one capture — and both see a
+swap the moment it happens.
+
+sipnab reads the instance and both generations under one set of locks, so the
+identity names a single moment rather than three.
+
+`null` when nobody told this server what capture it holds.
+
+| Key | Meaning |
+|-----|---------|
+| `source` | `live`, `file`, or `unknown` |
+| `capture_name` | interface name when live, file path when replaying |
+| `uptime_sec` | seconds since capture began |
+| `source_exhausted` | `true` once sipnab reaches the end of a file source |
+| `writing_to` | path sipnab saves packets to, if any |
+| `unsaved` | `true` only for a **live** capture with no output file — packets held in memory and nowhere else |
+
+**`unknown` is a real answer, not a default.** It is what you consult before
+deciding whether stopping a capture is destructive, and a wrong `"live"` would
+be worse than an admission of ignorance.
+
+`unsaved` is the field that matters for that decision. A file replay is already
+on disk, so it is never unsaved. A live capture with an output file is safe to
+stop.
 
 ### SIP the port gate never analyzed
 

--- a/website/content/docs/rtpengine.md
+++ b/website/content/docs/rtpengine.md
@@ -91,6 +91,86 @@ the collector it feeds. That is why sipnab reads the traffic off the wire by
 default: a diagnostic tool has no business in a production data path, and if
 sipnab stops, nothing else notices.
 
+## Several rtpengine instances behind one proxy
+
+A proxy that load-balances across a pool of relays puts each call on exactly
+one of them. Run **one sipnab per host**: the proxy's sees the SIP, each
+relay's sees the media its own host relays.
+
+```text
+                        sipnab@proxy
+                        (SIP; no media)
+                              |
+        +---------------------+---------------------+
+        |                     |                     |
+  sipnab@relay-a        sipnab@relay-b        sipnab@relay-c
+  (media it relays)     (media it relays)     (media it relays)
+```
+
+Each relay host runs sipnab against its **own local** relay:
+
+```bash
+# On relay-a, relay-b, relay-c — identical, and each asks only its own relay.
+sipnab -d eth0 --rtpengine-control 127.0.0.1:22222 --api 127.0.0.1:8080
+```
+
+`--rtpengine-control` takes one address, and in this topology that is correct
+rather than a limitation: a relay can only answer for calls it is carrying, so
+a sipnab asking a relay on another host would get `RelayDoesNotHoldIt` for
+everything.
+
+### Finding a call without asking every relay
+
+The naive procedure is a broadcast: ask all ten relays, discard nine misses.
+You do not have to. **The proxy's own SDP names the relay**, because the `c=`
+address the proxy negotiated IS the rtpengine it steered the call to.
+
+**Step 1 — ask the proxy which relay has it.**
+
+```bash
+curl -fsS "http://proxy:8080/v1/dialogs/$CALL_ID" $H \
+  | jq -r '.sdp_timeline[0] | "\(.media_addr):\(.media_port)"'
+# 10.0.0.40:38664
+```
+
+**Step 2 — ask that one relay, and no others.**
+
+```bash
+curl -fsS "http://10.0.0.40:8080/v1/dialogs/$CALL_ID" $H | jq '.streams'
+```
+
+A relay that never carried the call answers **404**, not an empty success.
+That distinction is load-bearing: "I do not have this call" and "this call had
+no media" are different findings, and a relay that answered `200` with an
+empty list would report the second when it meant the first.
+
+### Knowing whose answer you are holding
+
+Every node stamps its answers with its own `capture_identity`, which carries
+the host name:
+
+```bash
+curl -fsS "http://10.0.0.40:8080/v1/stats" $H | jq '.capture_identity'
+# { "node": "relay-a", "instance": "1f4a…", "dialog_generation": 412, … }
+```
+
+Collecting replies from several hosts, that field is what keeps them
+attributable to the host that gave them. Without it, two JSON documents from
+two relays are indistinguishable once they are side by side in a terminal.
+
+### What a multi-node deployment does not do
+
+sipnab does **not** aggregate across nodes. There is no cluster mode, no
+central index, and no node that answers for another. Each instance answers for
+what it captured, and the correlation above is something you (or an agent
+holding several endpoints) perform. That is a deliberate limit, not a missing
+feature: an aggregator is infrastructure, and
+[positioning](https://github.com/NormB/sipnab/blob/main/docs/design/positioning.md) rules it out.
+
+[`tests/multi_node_relay_fanout_test.rs`](https://github.com/NormB/sipnab/blob/main/tests/multi_node_relay_fanout_test.rs) pins the three properties this
+procedure rests on — the proxy holds signaling and no media, exactly one relay
+claims a call, and the proxy's SDP names which one.
+
 ## Set it up
 
 ### If rtpengine already reports to Homer

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -3048,6 +3048,18 @@ console.log(`PDD p50: ${timing.pdd_p50_ms}ms, p95: ${timing.pdd_p95_ms}ms`);
   "caveats": {
     "media_creating_commands": 0
   },
+  "capture_identity": {
+    "node": "capture01",
+    "instance": "1f4a17c8e2b91d40-1",
+    "dialog_generation": 412,
+    "stream_generation": 96
+  },
+  "source": "live",
+  "capture_name": "eth0",
+  "uptime_sec": 3600,
+  "source_exhausted": false,
+  "writing_to": null,
+  "unsaved": true,
   "unanalysed_sip_messages": 0,
   "unanalysed_busiest_ports": [],
   "unanalysed_websocket_messages": 0,
@@ -3126,6 +3138,42 @@ the end-of-run summary the command line prints.
 
 The MCP `capture_status` tool carries the same block under the same name, so
 this endpoint and an agent never disagree about it.
+
+### Which capture these counts came from
+
+`capture_identity` pairs the capture's instance with both store generations.
+Compare it across calls:
+
+- **higher generation, same instance** — the capture grew
+- **different instance** — something swapped the file, and every count you
+  were holding describes a different capture
+
+It is the **same identity** the MCP `capture_status` tool stamps its answers
+with, read from the same object. An agent and an HTTP client polling one
+process can therefore tell they are describing one capture — and both see a
+swap the moment it happens.
+
+sipnab reads the instance and both generations under one set of locks, so the
+identity names a single moment rather than three.
+
+`null` when nobody told this server what capture it holds.
+
+| Key | Meaning |
+|-----|---------|
+| `source` | `live`, `file`, or `unknown` |
+| `capture_name` | interface name when live, file path when replaying |
+| `uptime_sec` | seconds since capture began |
+| `source_exhausted` | `true` once sipnab reaches the end of a file source |
+| `writing_to` | path sipnab saves packets to, if any |
+| `unsaved` | `true` only for a **live** capture with no output file — packets held in memory and nowhere else |
+
+**`unknown` is a real answer, not a default.** It is what you consult before
+deciding whether stopping a capture is destructive, and a wrong `"live"` would
+be worse than an admission of ignorance.
+
+`unsaved` is the field that matters for that decision. A file replay is already
+on disk, so it is never unsaved. A live capture with an output file is safe to
+stop.
 
 ### SIP the port gate never analyzed
 
@@ -4201,6 +4249,86 @@ does not exist. Anything that points rtpengine at sipnab takes it away from
 the collector it feeds. That is why sipnab reads the traffic off the wire by
 default: a diagnostic tool has no business in a production data path, and if
 sipnab stops, nothing else notices.
+
+## Several rtpengine instances behind one proxy
+
+A proxy that load-balances across a pool of relays puts each call on exactly
+one of them. Run **one sipnab per host**: the proxy's sees the SIP, each
+relay's sees the media its own host relays.
+
+```text
+                        sipnab@proxy
+                        (SIP; no media)
+                              |
+        +---------------------+---------------------+
+        |                     |                     |
+  sipnab@relay-a        sipnab@relay-b        sipnab@relay-c
+  (media it relays)     (media it relays)     (media it relays)
+```
+
+Each relay host runs sipnab against its **own local** relay:
+
+```bash
+# On relay-a, relay-b, relay-c — identical, and each asks only its own relay.
+sipnab -d eth0 --rtpengine-control 127.0.0.1:22222 --api 127.0.0.1:8080
+```
+
+`--rtpengine-control` takes one address, and in this topology that is correct
+rather than a limitation: a relay can only answer for calls it is carrying, so
+a sipnab asking a relay on another host would get `RelayDoesNotHoldIt` for
+everything.
+
+### Finding a call without asking every relay
+
+The naive procedure is a broadcast: ask all ten relays, discard nine misses.
+You do not have to. **The proxy's own SDP names the relay**, because the `c=`
+address the proxy negotiated IS the rtpengine it steered the call to.
+
+**Step 1 — ask the proxy which relay has it.**
+
+```bash
+curl -fsS "http://proxy:8080/v1/dialogs/$CALL_ID" $H \
+  | jq -r '.sdp_timeline[0] | "\(.media_addr):\(.media_port)"'
+# 10.0.0.40:38664
+```
+
+**Step 2 — ask that one relay, and no others.**
+
+```bash
+curl -fsS "http://10.0.0.40:8080/v1/dialogs/$CALL_ID" $H | jq '.streams'
+```
+
+A relay that never carried the call answers **404**, not an empty success.
+That distinction is load-bearing: "I do not have this call" and "this call had
+no media" are different findings, and a relay that answered `200` with an
+empty list would report the second when it meant the first.
+
+### Knowing whose answer you are holding
+
+Every node stamps its answers with its own `capture_identity`, which carries
+the host name:
+
+```bash
+curl -fsS "http://10.0.0.40:8080/v1/stats" $H | jq '.capture_identity'
+# { "node": "relay-a", "instance": "1f4a…", "dialog_generation": 412, … }
+```
+
+Collecting replies from several hosts, that field is what keeps them
+attributable to the host that gave them. Without it, two JSON documents from
+two relays are indistinguishable once they are side by side in a terminal.
+
+### What a multi-node deployment does not do
+
+sipnab does **not** aggregate across nodes. There is no cluster mode, no
+central index, and no node that answers for another. Each instance answers for
+what it captured, and the correlation above is something you (or an agent
+holding several endpoints) perform. That is a deliberate limit, not a missing
+feature: an aggregator is infrastructure, and
+[positioning](design/positioning.md) rules it out.
+
+[`tests/multi_node_relay_fanout_test.rs`](https://github.com/NormB/sipnab/blob/main/tests/multi_node_relay_fanout_test.rs) pins the three properties this
+procedure rests on — the proxy holds signaling and no media, exactly one relay
+claims a call, and the proxy's SDP names which one.
 
 ## Set it up
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5639 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5646 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5639" data-suffix="">5639</span>
+        <span class="arch-stat" data-count="5646" data-suffix="">5646</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>


### PR DESCRIPTION
## The question this answers

> There may be 1 sipnab on a proxy and 10 sipnabs on 10 rtpengines. For a single
> call, the proxy needs to be queried, but only 1 of the 10 rtpengines needs to
> be queried to get data.

That works. It is now documented, and the three properties it rests on are
pinned by tests.

## The procedure is a routed lookup, not a broadcast

The proxy's own SDP names the relay, because the `c=` address it negotiated
**is** the rtpengine it steered the call to.

```bash
# 1. Ask the proxy which relay has it.
curl -fsS "http://proxy:8080/v1/dialogs/$CALL_ID" $H \
  | jq -r '.sdp_timeline[0] | "\(.media_addr):\(.media_port)"'
# 10.0.0.40:38664

# 2. Ask that one relay. The other nine stay unqueried.
curl -fsS "http://10.0.0.40:8080/v1/dialogs/$CALL_ID" $H | jq '.streams'
```

`--rtpengine-control` taking a single address is **correct** in this topology
rather than a limitation: each relay host asks its own local relay, and a relay
can only answer for calls it is carrying.

## What is pinned — `tests/multi_node_relay_fanout_test.rs`

Three separate store pairs, not one store with a node label. A shared store
would let every node answer everything, which proves the opposite of the
deployment.

| Test | Property |
|---|---|
| `the_proxy_node_holds_the_signaling_and_no_media` | the proxy answers "which relay", not "what did the audio do" |
| `exactly_one_relay_holds_the_call_and_the_other_does_not` | relay A claims it; relay B holds its OWN call, so the zero is a real "not mine" |
| `the_proxy_sdp_names_which_relay_to_ask` | the routing key names A, not B |

**Mutation-proven**: giving both relays the same Call-ID fails the exclusivity
test — two relays claiming one call gives a fan-out two contradictory answers
and no way to choose.

The **404 is load-bearing** and documented as such. "I do not have this call"
and "this call had no media" are different findings; a relay answering 200 with
an empty list would report the second when it meant the first.

## Why `capture_identity` had to come with it

Collecting replies from several hosts needs each one to say who it is, and
`GET /v1/stats` could not. `CaptureState` lived inside `src/mcp/server.rs`
behind the `mcp` feature gate, so a REST-only build had no type to reach for.

**A copy would have been simpler and wrong.** The identity rotates when
`open_capture` swaps the file underneath, and two copies disagree from that
moment on. The type moved to `src/capture/session.rs` with its two MCP-only
fields `#[cfg]`-gated the way `MediaDecrypt` gates its `tls`-only ones;
`src/app/servers.rs` builds ONE instance and hands the same handle to both
doors.

### The lock order had to come with it

`get_stats` released the dialog guard before taking the stream guard, so its
dialog counts and stream counts already described **two different instants**.
Survivable while nothing tied them together — not survivable once one etag
pairs the instance with BOTH generations, because the response would then
assert a consistency the code did not provide.

## The test was wrong first, and mutation testing caught it

Asserting only that the identity **changes** after a rotation passed against a
handler minting a fresh identity on every request — the exact private-copy
design this change exists to avoid.

The assertion that discriminates is the opposite one: **two reads with nothing
between them must return the same instance.** Both are now asserted.

## Also written down

sipnab aggregates nothing across nodes. No cluster mode, no central index, no
node answering for another. That is a limit `docs/design/positioning.md` sets,
not one nobody got to.
