### PR TITLE
docs: gate the llms aggregates, which nothing was checking

### DIFF
--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -210,7 +210,13 @@ process, so the floor is not optional.
   output is stale. The same arrangement covers the operator
   pages: [`build-site-pages.py`](../../scripts/build-site-pages.py) renders
   each entry in its `PAGES` registry from `docs/` into [`website/content/docs/`](../../website/content/docs/),
-  gated by `site_pages_mirror_is_current`. Every page in that registry got
+  gated by `site_pages_mirror_is_current`. That same script also writes
+  `llms.txt` and `llms-full.txt` into `website/static/`, from ALL the published
+  pages — `docs/internals/` included — and `llms_aggregates_are_current` gates
+  them. Which script owns them is the trap: `build-site-internals.py` does not
+  touch the aggregates, so editing an internals page and regenerating only the
+  internals mirror satisfies the gate that checks the mirror and leaves the
+  aggregates stale. Run both generators, or run `build-site-pages.py` last. Every page in that registry got
   there the same way — hand-maintained on both sides until they diverged. Read
   the registry for what it holds today, not this sentence. The cookbook shared
   2 of its 36 commands with the site copy; the REST API page was 430 lines

--- a/scripts/build-site-pages.py
+++ b/scripts/build-site-pages.py
@@ -566,6 +566,16 @@ def main() -> int:
         if len(sys.argv) > 1
         else root / "website" / "content" / "docs"
     )
+    # argv[2] redirects the llms files the same way argv[1] redirects the
+    # pages. Without it a caller that passes a temp dir still overwrites the
+    # committed `llms-full.txt`, so a freshness gate could not diff the two
+    # without mutating the tree it is checking.
+    static_dir = (
+        Path(sys.argv[2])
+        if len(sys.argv) > 2
+        else root / "website" / "static"
+    )
+    static_dir.mkdir(parents=True, exist_ok=True)
     out_dir.mkdir(parents=True, exist_ok=True)
     _load_anchors(root)
     for src, site_name, want_h1, title, weight, description in PAGES:
@@ -577,7 +587,7 @@ def main() -> int:
         print(f"  {src:22s} -> {site_name}")
     # Written into static/ so Zola copies them to the site root verbatim,
     # where the llms.txt convention expects them.
-    write_llms_txt(root, root / "website" / "static")
+    write_llms_txt(root, static_dir)
     return 0
 
 

--- a/tests/config_wiring_test.rs
+++ b/tests/config_wiring_test.rs
@@ -2096,7 +2096,12 @@ fn probe_reassembly_ttl_secs() -> (String, String) {
 /// 20 ms, so any connect races a process that has already exited.
 #[cfg(feature = "metrics")]
 fn probe_metrics_max_conn() -> (String, String) {
-    use std::io::{BufRead, BufReader, Write};
+    use std::io::{BufRead, BufReader, Read, Write};
+
+    /// What `handle_metrics_connection` gives a client to send its request
+    /// line, and therefore how long a parked connection holds its slot.
+    /// Mirrors the `set_read_timeout` in `src/output/prometheus_server.rs`.
+    const METRICS_HANDLER_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
     /// Bind an ephemeral port and release it, so the probe knows the number.
     fn free_port() -> u16 {
@@ -2126,22 +2131,72 @@ fn probe_metrics_max_conn() -> (String, String) {
             .spawn()
             .expect("spawn sipnab");
 
-        // Wait for the listener, without consuming a slot: a connect that is
-        // closed again releases its permit when the handler's read fails.
+        // Wait until the server actually SERVES, not merely until a connect
+        // succeeds. A bare connect takes a permit and its handler holds it for
+        // as long as the read blocks, so under `metrics_max_conn = 1` the
+        // readiness probe itself can still own the only slot when the parked
+        // connection arrives -- the parked one is then refused, holds nothing,
+        // and the measurement below reads "served" while the key works fine.
+        // A completed scrape proves both that the server is up and that a
+        // permit is free again.
+        let ready_by = std::time::Instant::now() + std::time::Duration::from_secs(30);
         let mut up = false;
-        for _ in 0..60 {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            if std::net::TcpStream::connect(&addr).is_ok() {
-                up = true;
-                break;
+        while std::time::Instant::now() < ready_by {
+            if let Ok(mut s) = std::net::TcpStream::connect(&addr) {
+                let _ = s.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+                let _ = write!(
+                    s,
+                    "GET /metrics HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"
+                );
+                let mut line = String::new();
+                if BufReader::new(&s).read_line(&mut line).unwrap_or(0) > 0
+                    && !line.contains(" 503 ")
+                {
+                    up = true;
+                    break;
+                }
             }
+            std::thread::sleep(std::time::Duration::from_millis(50));
         }
-        assert!(up, "the metrics server never came up on {addr}");
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert!(up, "the metrics server never served a scrape on {addr}");
 
-        // One connection parked mid-request, holding its slot.
-        let parked = std::net::TcpStream::connect(&addr).expect("park a connection");
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        // Park a connection and PROVE it holds a slot, rather than sleeping and
+        // assuming the accept loop got to it. The two outcomes are
+        // distinguishable on the wire: a REFUSED connection is answered `503`
+        // and closed, while a HELD one receives nothing at all, because its
+        // handler is blocked reading a request line this probe never sends. So
+        // an empty read IS the proof, and a 503 means this attempt took no slot
+        // and must be retried.
+        let parked_by = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let parked = loop {
+            assert!(
+                std::time::Instant::now() < parked_by,
+                "no connection ever held a metrics slot on {addr}, so the \
+                 premise this probe rests on was never established. That is a \
+                 statement about this machine, not about the key."
+            );
+            let s = std::net::TcpStream::connect(&addr).expect("park a connection");
+            let _ = s.set_read_timeout(Some(std::time::Duration::from_millis(250)));
+            let mut buf = [0u8; 32];
+            match (&s).read(&mut buf) {
+                // Timed out with no bytes: a handler owns this socket and is
+                // blocked on the request line. The slot is held.
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+                {
+                    break s;
+                }
+                // Anything else -- a `503`, or a close -- means no slot was
+                // taken. Drop it and try again.
+                _ => {}
+            }
+        };
+        // Every measurement below must land inside the handler's read timeout,
+        // or the parked connection releases its slot mid-probe.
+        let held_since = std::time::Instant::now();
 
         let mut status = String::from("no-answer");
         if let Ok(mut s) = std::net::TcpStream::connect(&addr) {
@@ -2159,6 +2214,22 @@ fn probe_metrics_max_conn() -> (String, String) {
                 };
             }
         }
+
+        // A "served" verdict is only evidence about the key if the parked
+        // connection still held its slot throughout. Past the handler's read
+        // timeout it does not, and "served" would then say nothing -- exactly
+        // the reading that would get a working key deleted.
+        let elapsed = held_since.elapsed();
+        assert!(
+            status == "second-scrape-refused" || elapsed < METRICS_HANDLER_READ_TIMEOUT,
+            "the second scrape took {elapsed:?}, past the {:?} the parked \
+             connection holds its slot for, so `{status}` is not evidence \
+             about metrics_max_conn -- the slot was released mid-probe. This \
+             machine was too slow to OBSERVE the key; that is not the same as \
+             the key being dead, and the limit must not be deleted on the \
+             strength of it.",
+            METRICS_HANDLER_READ_TIMEOUT
+        );
 
         drop(parked);
         let _ = child.kill();

--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -4581,3 +4581,62 @@ fn the_prose_gate_logic_has_one_source() {
         }
     }
 }
+
+/// `llms.txt` and `llms-full.txt` are current with the pages they aggregate.
+///
+/// These two files had no gate at all. `site_internals_mirror_is_current`
+/// compares `website/content/docs/internals` against `docs/internals` and stops
+/// there, so the aggregate could drift from its own sources with every check
+/// green — and did, through a full local hook and a green CI run.
+///
+/// The trap is which generator owns them. `build-site-pages.py` writes them
+/// from ALL the published pages, `docs/internals/` included;
+/// `build-site-internals.py` does not touch them. So editing an internals page
+/// and running only the internals generator refreshes the mirror a gate DOES
+/// check and leaves these two behind.
+#[test]
+fn llms_aggregates_are_current() {
+    let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    // pid and line, never a fixed path: two tests sharing one would race, and a
+    // leftover from a killed run would be read as this run's output.
+    let tmp = std::env::temp_dir().join(format!("sipnab-llms-{}-{}", std::process::id(), line!()));
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    // argv[2] keeps the generator off the committed files. Without it this
+    // gate would OVERWRITE the very thing it is checking and always pass.
+    let out = std::process::Command::new("python3")
+        .arg(repo.join("scripts/build-site-pages.py"))
+        .arg(tmp.join("pages"))
+        .arg(tmp.join("static"))
+        .current_dir(repo)
+        .output()
+        .expect("run scripts/build-site-pages.py — python3 must be on PATH");
+    assert!(
+        out.status.success(),
+        "build-site-pages.py failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let mut stale = Vec::new();
+    for name in ["llms.txt", "llms-full.txt"] {
+        let fresh = std::fs::read_to_string(tmp.join("static").join(name))
+            .unwrap_or_else(|e| panic!("the generator wrote no {name}: {e}"));
+        let have =
+            std::fs::read_to_string(repo.join("website/static").join(name)).unwrap_or_default();
+        assert!(
+            !fresh.is_empty(),
+            "{name} generated EMPTY — an empty file would match an empty \
+             committed one and this gate would pass on nothing"
+        );
+        if fresh != have {
+            stale.push(name);
+        }
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(
+        stale.is_empty(),
+        "website/static is stale — regenerate with \
+         `python3 scripts/build-site-pages.py` and commit: {stale:?}"
+    );
+}

--- a/website/content/docs/internals/_index.md
+++ b/website/content/docs/internals/_index.md
@@ -218,7 +218,13 @@ process, so the floor is not optional.
   output is stale. The same arrangement covers the operator
   pages: [`build-site-pages.py`](https://github.com/NormB/sipnab/blob/main/scripts/build-site-pages.py) renders
   each entry in its `PAGES` registry from `docs/` into [`website/content/docs/`](https://github.com/NormB/sipnab/blob/main/website/content/docs),
-  gated by `site_pages_mirror_is_current`. Every page in that registry got
+  gated by `site_pages_mirror_is_current`. That same script also writes
+  `llms.txt` and `llms-full.txt` into `website/static/`, from ALL the published
+  pages — `docs/internals/` included — and `llms_aggregates_are_current` gates
+  them. Which script owns them is the trap: `build-site-internals.py` does not
+  touch the aggregates, so editing an internals page and regenerating only the
+  internals mirror satisfies the gate that checks the mirror and leaves the
+  aggregates stale. Run both generators, or run `build-site-pages.py` last. Every page in that registry got
   there the same way — hand-maintained on both sides until they diverged. Read
   the registry for what it holds today, not this sentence. The cookbook shared
   2 of its 36 commands with the site copy; the REST API page was 430 lines

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5716 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5717 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5716" data-suffix="">5716</span>
+        <span class="arch-stat" data-count="5717" data-suffix="">5717</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>


### PR DESCRIPTION
Two gate fixes. Rebased onto #267.

---

## 1. `llms.txt` / `llms-full.txt` had no freshness gate at all

#265 fixed one instance of the resulting drift; this stops it recurring.

**The trap is which generator owns them.** `build-site-pages.py` writes both aggregates from **all** the published pages, `docs/internals/` included. `build-site-internals.py` does not touch them. So editing an internals page and regenerating only the internals mirror satisfies `site_internals_mirror_is_current` — the gate that *does* exist — and leaves the aggregates stale. That is how the drift in #265 reached a green CI run and a full local hook without anything noticing.

**Why a gate could not simply be added.** `write_llms_txt` was hardcoded to `website/static/`, ignoring the output directory `argv[1]` already honours for pages. A test that regenerated into a temp directory would still have overwritten the committed files and then compared them against themselves — passing unconditionally, forever. `argv[2]` now redirects the aggregates the same way.

`llms_aggregates_are_current` regenerates into a temp directory and diffs both files. Mutation-verified: dropping one table row from the committed `llms-full.txt` fails it. It refuses an empty generated file, because an empty file would match an empty committed one and pass on nothing. Temp path keyed on pid and line.

---

## 2. `metrics_max_conn` probe reported a working limit as dead

`every_documented_limits_key_changes_observable_behaviour` failed with "second-scrape-served" both with and without the key. **The key is fine — the probe could not see it.**

Two races, and the first is not timing-sensitive at all:

1. The readiness loop connected and dropped, but a bare connect is *accepted* and its handler holds the permit until the blocking read gives up. Under `metrics_max_conn = 1` that leaves the readiness probe owning the only slot, so the connection the probe then "parks" is **refused** — it holds nothing, and every measurement after it is meaningless.
2. The park was followed by a fixed 200 ms sleep and a single attempt.

**Reproduced (1) deterministically** against the real binary: hold one slot, then connect, and the "parked" socket receives `HTTP/1.1 503 Service Unavailable`. CPU contention does **not** reproduce it — the old probe passes 3/3 at 0% idle — so this was never the flake it looked like, and re-running would have buried it.

Both races are closed by construction rather than by waiting longer:

- Readiness now waits for a scrape that actually returns non-503, proving both that the server is up and that a permit is free again.
- The park is **proven** to hold a slot before anything is measured. The outcomes are distinguishable on the wire: a refused connection is answered `503` and closed; a held one receives nothing, because its handler is blocked reading a request line the probe never sends. An empty read is the proof; a `503` means no slot was taken, and the probe retries.

A "served" verdict is additionally guarded against the handler's 5 s read timeout, so a slot released mid-probe fails loudly instead of being reported as evidence the limit does not bite — the same reasoning `assert_premise_inside_window` applies to the rate-limit probes.

No fixed sleep remains in the probe.

---

`bash .githooks/pre-commit` passes in full; the push ran corpus validation against the private corpus (15 test binaries, VALIDATED). No corpus content and no PII in this branch.
