### PR TITLE
rtpengine: make --hep-listen decode ng, and give both features runnable examples

### DIFF
--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -81,6 +81,7 @@ fn parsed_for(ssrc: u32, payload: Vec<u8>) -> ParsedPacket {
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     }
 }
 

--- a/docs/design/backlog.md
+++ b/docs/design/backlog.md
@@ -1540,7 +1540,7 @@ output path.
     refs so the retrofit never grows.
   - **In progress — the resolver end exists; the threading is partial (status
     2026-08-06, verified against the tree).** Shipped: `FrameRef`
-    ([`src/capture/packet.rs:94`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L94)) and `capture::resolve::resolve`
+    ([`src/capture/packet.rs:325`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L325)) and `capture::resolve::resolve`
     ([`src/capture/resolve.rs:191`](https://github.com/NormB/sipnab/blob/main/src/capture/resolve.rs#L191)); the `show_evidence` MCP tool
     (`#[tool(` at [`src/mcp/server.rs:5965`](https://github.com/NormB/sipnab/blob/main/src/mcp/server.rs#L5965), handler at `:3866`), confined to
     the file root and honest about

--- a/docs/design/maintainability-perf-spec.md
+++ b/docs/design/maintainability-perf-spec.md
@@ -216,7 +216,7 @@ bodies:
 
 | Copy | Location | Size | Consumer |
 |---|---|---|---|
-| Canonical | [`src/pipeline.rs:2276`](https://github.com/NormB/sipnab/blob/main/src/pipeline.rs#L2276) `process_packet` | 142 ln | TUI live |
+| Canonical | [`src/pipeline.rs:2305`](https://github.com/NormB/sipnab/blob/main/src/pipeline.rs#L2305) `process_packet` | 142 ln | TUI live |
 | Batch | [`src/app/batch.rs:2870`](https://github.com/NormB/sipnab/blob/main/src/app/batch.rs#L2870) `process_parsed_packet` | 402 ln | batch mode |
 | TUI file-open | `src/tui/events.rs:1536` `load_pcap_file` | 194 ln | F3 open |
 | Sharded | [`src/parallel.rs`](https://github.com/NormB/sipnab/blob/main/src/parallel.rs) + worker loops | ~200 ln | `--jobs N` |

--- a/docs/design/simultaneous-capture-sources.md
+++ b/docs/design/simultaneous-capture-sources.md
@@ -96,7 +96,7 @@ decisions downstream read the source as a scalar:
 
 Every reader — `capture_live_fanout` ([`src/capture/live.rs:253`](https://github.com/NormB/sipnab/blob/main/src/capture/live.rs#L253)), `capture_files`
 ([`src/capture/file.rs:294`](https://github.com/NormB/sipnab/blob/main/src/capture/file.rs#L294)), `capture_hep` ([`src/capture/hep.rs:1488`](https://github.com/NormB/sipnab/blob/main/src/capture/hep.rs#L1488)), the
-uprobe reader — builds a `Packet` ([`src/capture/packet.rs:370`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L370)) and calls
+uprobe reader — builds a `Packet` ([`src/capture/packet.rs:397`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L397)) and calls
 `tx.send(..)`. `PacketTx` derives `Clone` ([`src/capture/channel.rs:142`](https://github.com/NormB/sipnab/blob/main/src/capture/channel.rs#L142)), and the
 channel is an unbounded crossbeam queue guarded by a bounded slot semaphore
 ([`src/capture/channel.rs:204`](https://github.com/NormB/sipnab/blob/main/src/capture/channel.rs#L204)). The consumer is the batch receive loop at
@@ -107,7 +107,7 @@ is, when the last sender clone drops.
 many-producer, the receive loop already ends on the last producer, and the
 parser already tells the two kinds of packet apart:
 
-- `Packet::interface` ([`src/capture/packet.rs:370`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L370)) is an `Arc<str>` naming the
+- `Packet::interface` ([`src/capture/packet.rs:397`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L397)) is an `Arc<str>` naming the
   source. Live capture sets the device name ([`src/capture/live.rs:533`](https://github.com/NormB/sipnab/blob/main/src/capture/live.rs#L533)); the
   HEP listener sets `hep:<capture-id>@<peer>` via `hep_source_label`
   ([`src/capture/hep.rs:121`](https://github.com/NormB/sipnab/blob/main/src/capture/hep.rs#L121)) and `hep_to_packet` ([`src/capture/hep.rs:134`](https://github.com/NormB/sipnab/blob/main/src/capture/hep.rs#L134)).
@@ -320,7 +320,7 @@ operator discount a suspicious attribution instead of trusting it.
 ([`src/sip/dialog.rs:87`](https://github.com/NormB/sipnab/blob/main/src/sip/dialog.rs#L87)), whose `first_frame` field sits at line 148, and `RtpStream` ([`src/rtp/stream.rs:290`](https://github.com/NormB/sipnab/blob/main/src/rtp/stream.rs#L290)) carries the same field at line 323
 carry it downstream.
 
-The gap that matters here: `Packet::frame_ref` ([`src/capture/packet.rs:420`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L420))
+The gap that matters here: `Packet::frame_ref` ([`src/capture/packet.rs:447`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L447))
 requires **both** a source name and a frame ordinal, and the live and HEP readers
 stamp only the name. Ordinals come from [`src/capture/file.rs:778`](https://github.com/NormB/sipnab/blob/main/src/capture/file.rs#L778),
 [`src/parallel.rs:675`](https://github.com/NormB/sipnab/blob/main/src/parallel.rs#L675) and the uprobe readers; neither `capture_live_fanout` nor
@@ -436,7 +436,7 @@ nothing.
 **Metrics and the writer read the source as a scalar.** The `-O` writer is the
 concrete casualty. It initializes on the first packet's `link_type`
 ([`src/app/batch.rs:2846`](https://github.com/NormB/sipnab/blob/main/src/app/batch.rs#L2846)), and the two members disagree: live capture yields
-`DLT_EN10MB`, while `Packet::with_pre_parsed` ([`src/capture/packet.rs:597`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L597)) sets
+`DLT_EN10MB`, while `Packet::with_pre_parsed` ([`src/capture/packet.rs:624`](https://github.com/NormB/sipnab/blob/main/src/capture/packet.rs#L624)) sets
 `link_type = 0` and a `data` buffer holding the bare transport payload — no
 Ethernet, no IP, no UDP. That absence is deliberate and documented at
 [`src/capture/hep.rs:84`](https://github.com/NormB/sipnab/blob/main/src/capture/hep.rs#L84) onward: fabricating a `DLT_RAW` header made `etherparse`

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -347,9 +347,15 @@ Reload with `opensipsctl restart` (or `systemctl reload opensips` for graceful r
 homer = capture.example.com:9060
 homer-protocol = udp
 homer-id = 1
+# Without this, rtpengine mirrors RTCP statistics only -- which carry no
+# Call-ID and no SDP, so nothing sipnab reads can name a call or find a media
+# endpoint. It is the first thing to check when a relay looks silent.
+homer-enable-ng = true
 ```
 
-Restart with `systemctl restart rtpengine`.
+Restart with `systemctl restart rtpengine`. See
+[the rtpengine page](rtpengine.md) for what sipnab does with the result, and
+for the two ways to read it that do not cost you your collector.
 
 **Kamailio:**
 
@@ -1302,6 +1308,35 @@ WAV header and every player reads the file normally.
 - A CLI batch audio-export flag does **not** exist today. The library functions (`rtp::audio_export::export_stream_to_wav`, `export_dialog_to_wav`) are available if you want to build it; until then, scripted batch export means driving the TUI under `expect`/`tmux` or writing a small Rust binary that links the library.
 
 ---
+
+## 13b. Export one call to a conversation archive as a vCon
+
+`--export-vcon` writes one observed dialog as a vCon container — the IETF
+interchange format a conversation archive, a compliance store or an
+agent-facing pipeline already reads. Handing one of those a pcap makes the
+decoding their problem. Handing them a vCon does not.
+
+```sh
+sipnab -N -I capture.pcap --export-vcon '1-1966@10.0.2.20' --vcon-out call.vcon
+```
+
+Straight into a conserver, without a file in between:
+
+```sh
+sipnab -N -I capture.pcap --export-vcon '1-1966@10.0.2.20'   | curl -fsS -X POST "$CONSERVER/vcon"       -H 'Content-Type: application/json'       -H "Authorization: Bearer $CONSERVER_TOKEN" --data-binary @-
+```
+
+Read the caveat before you trust the contents. Every `body` is a JSON-encoded
+string, which means `jq` needs a parse on the way in:
+
+```sh
+sipnab -N -I capture.pcap --export-vcon '1-1966@10.0.2.20'   | jq -r '.analysis[0].body | fromjson | .capture_completeness.note'
+```
+
+Needs a build carrying the non-default `vcon` feature. `sipnab --version` lists
+what yours has. As a library, [`examples/export_vcon.rs`](../examples/export_vcon.rs)
+is the same thing as a program you can run. The [vCon page](vcon.md) covers what
+a consumer may and may not conclude from a container sipnab wrote.
 
 ## 14. Analyze a pcap without installing anything
 

--- a/docs/internals/rtpengine-control-plane.md
+++ b/docs/internals/rtpengine-control-plane.md
@@ -74,8 +74,25 @@ same decoder, not as a separate feature.
 
 ## Why the wire, and not our own listener
 
-sipnab could receive on `--hep-listen` and have rtpengine send to it. That
-works today with no new parsing at all, and it is the wrong default.
+sipnab can receive on `--hep-listen` and have rtpengine send to it. That works
+— since 0.5.125, and not before, although this page said it did.
+
+The claim was wrong in a way worth recording, because the shape recurs. The
+listener strips the HEP wrapper before the parser runs, so by the time the
+pipeline looked for `ng` there was no HEP header left to parse and the check
+never fired. Worse, the correlation id went with it — and an `ng` REPLY names
+its call in the correlation id and nowhere else, so even the half carrying the
+relay's allocated ports had lost the only route back to a call.
+
+"No new parsing at all" was true of the DECODER and false of the PATH, and
+nothing tested the path. The fix carries the wrapper's two load-bearing claims
+in `PreParsed` and gives the pipeline a second arm for the delivered shape.
+[`tests/hep_listen_ng_test.rs`](../../tests/hep_listen_ng_test.rs) covers it, and
+`hep_to_packet_carries_the_capture_protocol_and_correlation_id` covers the
+listener half — which the integration tests structurally cannot, because they
+build `PreParsed` by hand. Mutation found that gap rather than review.
+
+It remains the wrong default.
 
 `--homer` is a single `G_OPTION_ARG_STRING`, not a repeatable option, so
 rtpengine has exactly ONE Homer destination. Pointing it at sipnab takes it

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -458,6 +458,26 @@ sipnab -N -I capture.pcap --json-analyze --no-cli-print | jq '.complete'
 sipnab already computes and the capture-level evidence it already holds. It
 ranks and counts them, and adds no judgement of its own.
 
+## vCon (`--export-vcon`)
+
+A different kind of output from everything above. The formats on this page are
+sipnab's own shapes, read by sipnab and by whatever you write around it. A vCon
+is an interchange container other people's systems already parse — a
+conversation archive, a compliance store, an agent that reasons over calls.
+
+```sh
+sipnab -N -I call.pcap --export-vcon 'CALL-ID' --vcon-out out.json
+```
+
+One dialog per container, never a whole capture. sipnab writes it as an
+OBSERVER: it names itself as a party that took no part in the call, carries the
+audio inline when the run retained the RTP payload, and states in two places
+what the capture missed. It signs nothing.
+
+Behind the non-default `vcon` feature, so a stock build refuses the flag and
+says so. The [vCon page](vcon.md) covers what a consumer may and may not
+conclude from one, which matters more here than the field list.
+
 ## pcap / pcapng
 
 `-O <file>` writes captured packets, and `--pcapng` selects PCAP-NG. With TLS

--- a/docs/rtpengine.md
+++ b/docs/rtpengine.md
@@ -72,7 +72,7 @@ Read down the first column and stop at the first row you can satisfy.
 |---|---|---|---|
 | rtpengine already reports to a Homer collector | Capture on the relay host | **No** | sipnab reads the copy already on the wire. Nothing about your Homer pipeline changes. |
 | rtpengine reports nowhere yet | Turn on `--homer-enable-ng`, point it anywhere sipnab can see | Yes, once | The destination can be a collector, or a host that discards the traffic |
-| You need it delivered rather than sniffed | `--hep-listen` on sipnab, point rtpengine at it | Yes | Costs you the collector — see the warning below |
+| You need it delivered rather than sniffed | `--hep-listen` on sipnab, point rtpengine at it | Yes | Costs you the collector — see the warning below. Requires 0.5.125 or later: earlier builds accepted the traffic and decoded none of it |
 
 Every row here covers control messages that cross the wire while sipnab
 runs. None of them reaches a call the relay set up before the capture
@@ -106,7 +106,33 @@ Each relay host runs sipnab against its **own local** relay:
 
 ```bash
 # On relay-a, relay-b, relay-c — identical, and each asks only its own relay.
-sipnab -d eth0 --rtpengine-control 127.0.0.1:22222 --api 127.0.0.1:8080
+# The API binds to the host's own address, not loopback: the whole point of the
+# procedure below is that ANOTHER machine queries this one. A non-loopback bind
+# is refused without authentication, which is why --api-key is not optional
+# here.
+sudo sipnab -d eth0 --rtpengine-control 127.0.0.1:22222 \
+  --api 0.0.0.0:8080 --api-key "$SIPNAB_API_KEY"
+```
+
+The queries below need the address, the key and a Call-ID. Set them once, on
+whichever machine you are running `curl` from:
+
+`$H` interpolates `$KEY`, so set the key first — an `$H` built before `$KEY`
+exists carries an `Authorization` header with no token in it, and every query
+below then returns `401`.
+
+```bash
+KEY="$SIPNAB_API_KEY"
+```
+
+```bash
+H="-H 'Authorization: Bearer $KEY'"
+```
+
+Then the call you are chasing:
+
+```bash
+CALL_ID="1-1966@10.0.2.20"
 ```
 
 `--rtpengine-control` takes one address, and in this topology that is correct

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -747,3 +747,50 @@ cooked v1 and cooked v2 alike.
 Build custom queries with the [Filter DSL](filter-dsl.md) -- 33 fields, regex support, boolean logic. See the [CLI Reference](cli-reference.md) for every flag and more recipes.
 
 If the capture itself is the problem -- drops on a busy link, a full kernel ring buffer, or loss that appears on every call at once -- see [Tuning capture on a busy server](tuning-capture.md).
+
+### sipnab refuses `--export-vcon`
+
+```text
+--export-vcon needs a build with the `vcon` feature
+```
+
+The exporter is behind a non-default Cargo feature, so a stock build does not
+carry it. Check what you have:
+
+```sh
+sipnab --version        # the feature list is on the version line
+```
+
+If `vcon` is absent, build one that has it:
+
+```sh
+cargo build --release --features vcon
+```
+
+The feature is non-default on purpose. A container that leaves the machine is a
+publication surface, and a capture tool should not grow one unless an operator
+asks for it.
+
+### `--export-vcon` says the Call-ID is not there
+
+```text
+Call-ID 'x@y' not found in tracked dialogs, so there is no dialog to export.
+```
+
+The run holds no dialog under that Call-ID. `--report` lists the ones it does
+hold — the usual cause is a Call-ID copied with surrounding quotes or a
+truncated one, and the second is a capture that never saw the dialog open.
+
+Quote the Call-ID in the shell. Most contain `@`, and many contain characters
+your shell would otherwise interpret.
+
+### The container came out with no audio in it
+
+The dialog object carries no `body` and the caveat says media was not decoded.
+That is a statement about what the RUN kept, never a finding that the call was
+silent — the container is careful to say so, and a consumer should read the
+`media_note` beside it.
+
+The usual cause is that the run did not retain the RTP payload. Audio also has
+an inline budget. A recording over it draws an out-loud refusal rather than a
+silent truncation, and the caveat names the size it turned down.

--- a/docs/vcon.md
+++ b/docs/vcon.md
@@ -102,10 +102,20 @@ test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 
 ### Step 2 — build the container
 
-Read the capture into a `DialogStore` the ordinary way — the
-[library page](library.md) covers that part, and
-[the committed test](../tests/vcon_export_test.rs) holds the whole program —
-then hand one dialog and the run's own counters to `export_dialog`:
+The shortest path is the committed example, which does everything below against
+that same capture and prints the container:
+
+```sh
+cargo run --features vcon --example export_vcon -- tests/fixtures/sip_call.pcap
+```
+
+Its source is [`examples/export_vcon.rs`](../examples/export_vcon.rs) and it
+compiles as part of the build, so it cannot drift from the API the way a
+fragment on a page can.
+
+In your own program: read the capture into a `DialogStore` the ordinary way —
+the [library page](library.md) covers that part — then hand one dialog and the
+run's own counters to `export_dialog`:
 
 ```rust
 use sipnab::analysis::CaptureFacts;

--- a/examples/export_vcon.rs
+++ b/examples/export_vcon.rs
@@ -126,8 +126,10 @@ fn main() {
     // capture missed in two places, and both read from here — an export that
     // passed `CaptureFacts::default()` would claim a clean capture it never
     // measured.
-    let mut facts = CaptureFacts::default();
-    facts.frames_read = frames;
+    let facts = CaptureFacts {
+        frames_read: frames,
+        ..CaptureFacts::default()
+    };
 
     let vcon = export_dialog(
         dialog,

--- a/examples/export_vcon.rs
+++ b/examples/export_vcon.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! A capture file in, one vCon container out — the whole export path.
+//!
+//! [`docs/vcon.md`](../docs/vcon.md) explains what a sipnab vCon means and what
+//! a consumer may not conclude from one. This is the part a page cannot show:
+//! a program that runs, against a capture committed to this repository, and
+//! prints a container a real conserver accepts.
+//!
+//! The steps are the same four [`call_summary`](call_summary.rs) walks, plus
+//! one:
+//!
+//! 1. [`PcapReader`] — file bytes to capture records
+//! 2. [`Packet`] + [`parse_packet`] — records to addressed frames
+//! 3. [`parse_sip`] — frames to messages
+//! 4. [`DialogStore`] — messages to calls
+//! 5. [`export_dialog`] — ONE call to a container
+//!
+//! Run it:
+//!
+//! ```sh
+//! cargo run --features vcon --example export_vcon -- \
+//!     tests/fixtures/sip_call.pcap
+//! ```
+//!
+//! Or hand it straight to a conserver:
+//!
+//! ```sh
+//! cargo run --features vcon --example export_vcon -- \
+//!     tests/fixtures/sip_call.pcap \
+//!   | curl -fsS -X POST "$CONSERVER/vcon" \
+//!       -H 'Content-Type: application/json' \
+//!       -H "Authorization: Bearer $CONSERVER_TOKEN" --data-binary @-
+//! ```
+//!
+//! One container describes ONE dialog. A capture with three calls in it is
+//! three containers, and this prints the first — which is a deliberate limit
+//! of the format rather than of the example: there is no vCon that means
+//! "everything this capture saw".
+//!
+//! [`DialogStore`]: sipnab::DialogStore
+//! [`PcapReader`]: sipnab::PcapReader
+//! [`Packet`]: sipnab::capture::Packet
+//! [`parse_packet`]: sipnab::capture::parse::parse_packet
+//! [`parse_sip`]: sipnab::sip::parser::parse_sip
+//! [`export_dialog`]: sipnab::output::vcon::export_dialog
+
+#[cfg(all(feature = "vcon", not(target_arch = "wasm32")))]
+fn main() {
+    use sipnab::analysis::CaptureFacts;
+    use sipnab::capture::Packet;
+    use sipnab::capture::parse::parse_packet;
+    use sipnab::output::vcon::{ExportContext, export_dialog};
+    use sipnab::sip::parser::{parse_sip, starts_sip_message};
+    use sipnab::{DialogStore, PcapReader};
+
+    let Some(path) = std::env::args().nth(1) else {
+        eprintln!(
+            "usage: export_vcon <capture.pcap|.pcapng>\n\n\
+             Try the capture this repository ships:\n  \
+             cargo run --features vcon --example export_vcon -- \\\n    \
+             tests/fixtures/sip_call.pcap"
+        );
+        std::process::exit(2);
+    };
+
+    let data = match std::fs::read(&path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("cannot read {path}: {e}");
+            std::process::exit(1);
+        }
+    };
+    let reader = match PcapReader::new(&data) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{path} is not a capture this crate can read: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let mut dialogs = DialogStore::new(4096, false);
+    let mut frames = 0_u64;
+
+    for pkt in reader {
+        frames += 1;
+        let timestamp =
+            chrono::DateTime::from_timestamp(pkt.timestamp_secs as i64, pkt.timestamp_usecs * 1000)
+                .unwrap_or_default();
+        let caplen = pkt.data.len();
+        let origlen = pkt.orig_len as usize;
+        let link_type = pkt.link_type as i32;
+        let frame = Packet::new(
+            timestamp,
+            pkt.data,
+            caplen,
+            origlen,
+            pkt.interface,
+            link_type,
+        );
+        let Ok(parsed) = parse_packet(&frame) else {
+            continue;
+        };
+        if !starts_sip_message(&parsed.payload) {
+            continue;
+        }
+        if let Ok(msg) = parse_sip(
+            &parsed.payload,
+            parsed.timestamp,
+            parsed.src_addr,
+            parsed.dst_addr,
+            parsed.src_port,
+            parsed.dst_port,
+            parsed.transport,
+        ) {
+            dialogs.process_message(msg);
+        }
+    }
+
+    let Some(dialog) = dialogs.iter().next() else {
+        eprintln!("{path} holds no SIP dialog, so there is nothing to export");
+        std::process::exit(1);
+    };
+
+    // What the RUN saw, not just this dialog. The container states what the
+    // capture missed in two places, and both read from here — an export that
+    // passed `CaptureFacts::default()` would claim a clean capture it never
+    // measured.
+    let mut facts = CaptureFacts::default();
+    facts.frames_read = frames;
+
+    let vcon = export_dialog(
+        dialog,
+        &ExportContext {
+            // From the capture's CONTENT, never a per-process value: the uuid
+            // hashes this, so a rotating id mints a fresh identifier every
+            // time you reopen the same file and a store sees a new record
+            // rather than the same one.
+            capture_id: &path,
+            facts: &facts,
+            // `None` is honest here: this example runs no capture analysis, and
+            // the container reports that rather than implying a clean bill.
+            analysis: None,
+        },
+    );
+
+    match vcon.to_json() {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            eprintln!("the container did not serialize: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(not(all(feature = "vcon", not(target_arch = "wasm32"))))]
+fn main() {
+    eprintln!(
+        "this example needs the `vcon` feature:\n  \
+         cargo run --features vcon --example export_vcon -- <capture.pcap>"
+    );
+    std::process::exit(2);
+}

--- a/fuzz/fuzz_targets/tcp_reassembly.rs
+++ b/fuzz/fuzz_targets/tcp_reassembly.rs
@@ -53,6 +53,7 @@ fuzz_target!(|data: &[u8]| {
             ip_protocol: 6,
             dscp: None,
             input_origin: sipnab::capture::parse::InputOrigin::Wire,
+            hep: None,
         };
         for flushed in reassembler.insert(&pkt) {
             let _ = flushed.len();

--- a/harness/.env.example
+++ b/harness/.env.example
@@ -54,3 +54,24 @@ LOOP_PAUSE=5           # seconds between UAC scenario iterations
 # been found doing exactly that. Set it to this host's LAN address to reach the
 # harness from a laptop. Do not set it to 0.0.0.0.
 HARNESS_BIND=127.0.0.1
+
+# ---- rtpengine control plane (optional) ------------------------------------
+#
+# Where rtpengine mirrors its `ng` control plane. Empty by default, so the
+# harness behaves like a relay reporting nowhere.
+#
+# Set it and rtpengine starts with `homer-enable-ng`, which is what makes a
+# media stream on the relay attributable to a call -- without it the mirror
+# carries RTCP statistics only, which have no Call-ID and no SDP. sipnab reads
+# the copy off the wire in the shared netns, so this costs you no collector.
+#
+# 172.28.0.30 is the `hep-sink` service, and it must be something that ANSWERS.
+# rtpengine connects its Homer socket, so an address nobody is listening on
+# returns ICMP port-unreachable, rtpengine logs "Connection error from Homer"
+# and drops the trace -- which looks exactly like the feature being broken.
+# `hep-sink` absorbs HEP and does nothing else, so the datagrams cross a wire
+# sipnab is watching. Point it at a real collector instead if you have one.
+HOMER=172.28.0.30:9060
+HOMER_ID=2001
+# The sink's address, if you move it.
+HEP_SINK_IP=172.28.0.30

--- a/harness/README.md
+++ b/harness/README.md
@@ -41,6 +41,41 @@ sees the entire conversation, and serves it over MCP.
 | `sipnab`    | built from this repo (`mcp-http` feature) | live capture on the shared netns + MCP HTTP server |
 | `sipp-uas`  | trixie `sip-tester`                       | answers relayed calls |
 | `sipp-uac`  | trixie `sip-tester`                       | loops public SIPp scenarios through `opensips-1` |
+| `hep-sink`  | built from `harness/hep-sink`             | optional: a HEP destination that discards what it receives, so rtpengine has somewhere to mirror to |
+
+### Seeing the relay name a call
+
+By default `rtpengine` mirrors nowhere, so a media stream captured on the relay
+is an orphan: the relay carries no SIP, and nothing on the box says which call
+a stream belongs to. Set `HOMER` in `.env` (see `.env.example`) and rtpengine
+starts with `homer-enable-ng`, mirroring its `ng` control plane — the messages
+that carry the Call-ID and the SDP together.
+
+sipnab reads that copy **off the wire** in the shared netns. It needs no
+configuration of its own and takes nothing away from a real collector, which
+is the difference between this and pointing `--homer` at sipnab directly:
+rtpengine has exactly one Homer destination, so anything aimed at sipnab is
+taken from whatever it was feeding.
+
+`HOMER` is already set in `.env.example`, so start from it:
+
+```sh
+cp .env.example .env
+```
+
+```sh
+make up
+```
+
+Then drive a call through the proxy:
+
+```sh
+make call
+```
+
+The dialog report then carries a "calls named by a media relay" section for
+calls the relay named. `docs/rtpengine.md` covers what each field means and
+what the method cannot tell you.
 
 ## Prerequisites
 

--- a/man/sipnab.1
+++ b/man/sipnab.1
@@ -109,6 +109,31 @@ Skip loading any configuration file.
 .TP
 .B \-D, \-\-dump\-config
 Print the effective configuration and exit.
+.TP
+.BI \-\-rtpengine\-control " addr"
+Ask an rtpengine at
+.I addr
+which calls it is carrying, so media captured on a relay host can be attributed
+to a call the relay set up before this capture opened. Read-only commands only.
+Refused when the run is offline.
+.TP
+.BI \-\-hep\-listen " addr"
+Receive HEP on
+.IR addr .
+Carries SIP, and carries rtpengine's mirrored
+.B ng
+control plane when a relay is pointed here. Note that rtpengine has exactly one
+Homer destination, so aiming it at sipnab takes it away from the collector it
+already feeds; reading the same datagrams off the wire costs nothing and is the
+default sipnab is built for.
+.TP
+.BI \-\-export\-vcon " call-id"
+Export one observed dialog as a vCon container, the IETF conversation
+interchange format, on stdout. Requires a build with the
+.B vcon
+feature. Pair with
+.B \-\-vcon\-out
+to write it to a file instead.
 .SH TUI KEYBINDINGS
 The interactive TUI supports sngrep-compatible navigation:
 .SS Call List

--- a/src/app/batch.rs
+++ b/src/app/batch.rs
@@ -5772,6 +5772,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }
     }
 
@@ -5850,6 +5851,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }
     }
 

--- a/src/app/tui_mode.rs
+++ b/src/app/tui_mode.rs
@@ -778,6 +778,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }
     }
 

--- a/src/capture/hep.rs
+++ b/src/capture/hep.rs
@@ -142,6 +142,13 @@ fn hep_to_packet(hep: HepPacket, source: &str) -> Packet {
             src_port: hep.src_port,
             dst_port: hep.dst_port,
             ip_protocol: hep.ip_protocol,
+            // Carried, not dropped. `protocol` is how rtpengine's mirrored
+            // control plane announces itself, and `correlation_id` is the only
+            // thing that names the call on an `ng` reply.
+            hep: Some(crate::capture::packet::HepOrigin {
+                protocol: hep.protocol.to_byte(),
+                correlation_id: hep.correlation_id.clone(),
+            }),
         },
     )
 }
@@ -3482,6 +3489,59 @@ mod tests {
     /// addressing as `pre_parsed` metadata so the parser can short-circuit.
     /// Previously the listener tagged DLT_RAW with payload-only data,
     /// causing the parser to mis-read the SIP body as an IP header.
+    /// The wrapper's own claims survive the unwrap.
+    ///
+    /// The listener strips HEP before the parser runs, so a chunk that does
+    /// not travel in `PreParsed` is gone. Two were dropped on the floor for as
+    /// long as `--hep-listen` existed, and the documentation offered the method
+    /// anyway: the capture protocol, which is how rtpengine announces a
+    /// mirrored `ng` datagram, and the correlation id, which is the only thing
+    /// naming the call on an `ng` reply.
+    ///
+    /// The integration tests in `tests/hep_listen_ng_test.rs` build `PreParsed`
+    /// by hand, so they prove the PIPELINE reads these and cannot prove the
+    /// LISTENER writes them. Mutation showed exactly that gap: forcing the
+    /// protocol to SIP here left every one of them green. This is the test that
+    /// dies.
+    #[test]
+    fn hep_to_packet_carries_the_capture_protocol_and_correlation_id() {
+        let hep = HepPacket {
+            version: 3,
+            src_addr: "192.0.2.10".parse().unwrap(),
+            dst_addr: "192.0.2.20".parse().unwrap(),
+            src_port: 22222,
+            dst_port: 2223,
+            timestamp: Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+            // rtpengine's own capture protocol for a mirrored `ng` datagram.
+            protocol: HepProtocol::Unknown(0x3d),
+            payload: b"cookie1 d7:command5:offere".to_vec(),
+            correlation_id: Some("km-670bd208@sipnab".to_string()),
+            capture_id: None,
+            auth_key: None,
+            ip_protocol: 17,
+        };
+        let packet = hep_to_packet(hep, "0.0.0.0:9060");
+        let origin = packet
+            .pre_parsed
+            .as_ref()
+            .expect("pre_parsed must be set")
+            .hep
+            .as_ref()
+            .expect("a packet from a HEP source must say what the wrapper said");
+
+        assert_eq!(
+            origin.protocol, 0x3d,
+            "the capture protocol is how the relay declares its control plane; \
+             without it a body this build cannot parse reads as media"
+        );
+        assert_eq!(
+            origin.correlation_id.as_deref(),
+            Some("km-670bd208@sipnab"),
+            "an ng reply carries no call-id of its own, so dropping this \
+             leaves the relay's allocated port belonging to no call"
+        );
+    }
+
     #[test]
     fn hep_to_packet_attaches_pre_parsed_metadata() {
         let payload = b"INVITE sip:bob@example.com SIP/2.0\r\n\r\n";

--- a/src/capture/packet.rs
+++ b/src/capture/packet.rs
@@ -10,6 +10,28 @@ use chrono::{DateTime, Utc};
 use std::net::IpAddr;
 use std::sync::Arc;
 
+/// What a HEP sender said about a datagram it delivered, beyond the addressing.
+///
+/// The HEP listener strips the wrapper before the packet reaches the parser, so
+/// everything the wrapper said is gone unless it travels here. Two chunks
+/// matter downstream and both used to be dropped on the floor:
+///
+/// - the capture protocol, which is how rtpengine's mirrored `ng` control
+///   plane announces itself (`0x3d`), and
+/// - the correlation id, which is the ONLY thing naming the call on an `ng`
+///   REPLY — a reply body carries no `call-id` at all.
+///
+/// Without them a relay could mirror its control plane straight at sipnab and
+/// sipnab would decode none of it, while the documentation said the method
+/// worked.
+#[derive(Debug, Clone)]
+pub struct HepOrigin {
+    /// HEP capture protocol byte, verbatim.
+    pub protocol: u8,
+    /// HEP correlation id, when the sender set one.
+    pub correlation_id: Option<String>,
+}
+
 /// Pre-parsed addressing metadata for packets that arrive from a source
 /// which already knows the inner addresses (e.g. a HEP listener that
 /// reads `src_addr` / `dst_addr` from HEP chunks). When present, the
@@ -27,6 +49,11 @@ pub struct PreParsed {
     pub dst_port: u16,
     /// IANA IP protocol number (17 = UDP, 6 = TCP, 132 = SCTP).
     pub ip_protocol: u8,
+    /// What the HEP wrapper said, when this packet came through a HEP source.
+    ///
+    /// `None` for every other pre-parsed source (uprobe reads, synthetic test
+    /// packets), which is the honest value: nothing wrapped them.
+    pub hep: Option<HepOrigin>,
 }
 
 /// Where in its source a packet was read from.

--- a/src/capture/parse.rs
+++ b/src/capture/parse.rs
@@ -190,6 +190,16 @@ pub struct ParsedPacket {
     /// bare `from_hep: bool`, which could describe only two of the three real
     /// cases and would have had to call a uprobe read "HEP" to make it safe.
     pub input_origin: InputOrigin,
+    /// What the HEP wrapper claimed, for packets a HEP source delivered.
+    ///
+    /// The listener strips the wrapper before the parser sees the bytes, so a
+    /// claim that does not travel here is gone. `is_ng_over_hep` needs the
+    /// capture protocol, and an `ng` REPLY names its call in the correlation
+    /// id and nowhere else.
+    ///
+    /// `None` on the wire path, where nothing wrapped the packet and the ng
+    /// detector reads the datagram itself.
+    pub hep: Option<crate::capture::packet::HepOrigin>,
 }
 
 // ── ICMP error quotes ─────────────────────────────────────────────────
@@ -2334,6 +2344,7 @@ fn parse_packet_unstamped(packet: &Packet) -> Result<ParsedPacket, CaptureError>
                 Some(crate::capture::packet::FrameSource::Uprobe { .. }) => InputOrigin::Uprobe,
                 _ => InputOrigin::Hep,
             },
+            hep: meta.hep.clone(),
         });
     }
 
@@ -3026,6 +3037,7 @@ fn extract_parsed_packet(
             ip_protocol,
             dscp,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         });
     }
 
@@ -3057,6 +3069,7 @@ fn extract_parsed_packet(
             ip_protocol,
             dscp,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         });
     }
 
@@ -3106,6 +3119,7 @@ fn extract_parsed_packet(
             ip_protocol,
             dscp,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }),
         TransportSlice::Tcp(tcp) => Ok(ParsedPacket {
             frame: None,
@@ -3130,6 +3144,7 @@ fn extract_parsed_packet(
             ip_protocol,
             dscp,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }),
         // ICMP is still not a `ParsedPacket` — it carries no message, and
         // making one would put a header prefix into message counts and dialog
@@ -4738,6 +4753,7 @@ mod tests {
                 src_port: 5060,
                 dst_port: 5060,
                 ip_protocol: 17, // UDP
+                hep: None,
             },
         );
         let parsed = parse_packet(&pkt).expect("should parse via pre-parsed path");
@@ -4771,6 +4787,7 @@ mod tests {
                 src_port: 0,
                 dst_port: 0,
                 ip_protocol: 6,
+                hep: None,
             },
         );
         assert_eq!(
@@ -4796,6 +4813,7 @@ mod tests {
                 src_port: 5060,
                 dst_port: 5060,
                 ip_protocol: 17,
+                hep: None,
             },
         );
         assert_eq!(
@@ -4838,6 +4856,7 @@ mod tests {
                 src_port: 5060,
                 dst_port: 5061,
                 ip_protocol: 6, // TCP
+                hep: None,
             },
         );
         let parsed = parse_packet(&pkt).expect("should parse via pre-parsed path");
@@ -4926,6 +4945,7 @@ mod tests {
                 src_port: 5060,
                 dst_port: 5060,
                 ip_protocol: 50, // ESP — not a SIP transport
+                hep: None,
             },
         );
         let result = parse_packet(&pkt);

--- a/src/capture/reassembly.rs
+++ b/src/capture/reassembly.rs
@@ -831,6 +831,7 @@ mod tests {
             ip_protocol: 17, // UDP
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }
     }
 
@@ -861,6 +862,7 @@ mod tests {
             ip_protocol: 6, // TCP
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }
     }
 

--- a/src/capture/uprobe/bpf_record.rs
+++ b/src/capture/uprobe/bpf_record.rs
@@ -101,6 +101,8 @@ pub fn decode(raw: &[u8], ordinal: u64) -> Option<Packet> {
             src_port: sport,
             dst_port: dport,
             ip_protocol: IP_PROTO_TCP,
+            // A uprobe read has no wrapper to assert anything.
+            hep: None,
         },
     );
     // No digest, and none is possible: a digest exists so a resolver can prove

--- a/src/capture/uprobe/reader.rs
+++ b/src/capture/uprobe/reader.rs
@@ -242,6 +242,8 @@ fn to_packet(bytes: &[u8], pid: u32, ordinal: u64) -> Packet {
             src_port: 0,
             dst_port: 0,
             ip_protocol: IP_PROTO_TCP,
+            // A uprobe read has no wrapper to assert anything.
+            hep: None,
         },
     );
     // Both halves or no pointer: `frame_locator` needs a source AND an origin.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -8953,6 +8953,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         };
         {
             let mut s = ss.write();
@@ -10417,6 +10418,7 @@ mod tests {
             ip_protocol: 6,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         };
         let mut heuristic = crate::rtp::heuristic::RtpHeuristic::new();
         let mut decrypt = crate::pipeline::MediaDecrypt::default();

--- a/src/output/api.rs
+++ b/src/output/api.rs
@@ -1813,6 +1813,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         };
         let gated = crate::pipeline::PipelineOptions {
             sip_portrange: Some((5060, 5061)),
@@ -2901,6 +2902,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         };
         let rtp = RtpHeader {
             version: 2,
@@ -3177,6 +3179,7 @@ mod tests {
                     ip_protocol: 17,
                     dscp: None,
                     input_origin: crate::capture::parse::InputOrigin::Wire,
+                    hep: None,
                 };
                 let rtp = RtpHeader {
                     version: 2,

--- a/src/output/prometheus_server.rs
+++ b/src/output/prometheus_server.rs
@@ -759,6 +759,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         };
         let rtp = RtpHeader {
             version: 2,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2126,6 +2126,35 @@ pub fn classify_packet(
     //
     // Ahead of the RTP pre-filter for the same reason LLMNR is: whatever else
     // happens, these bytes must not be read as media.
+    //
+    // TWO arms, because there are two ways `ng` reaches sipnab and they arrive
+    // in different shapes.
+    //
+    // This first arm is the DELIVERED one: `--hep-listen`, where sipnab is the
+    // collector rtpengine exports to. The listener strips the wrapper before
+    // the parser runs, so the payload here is the bare `ng` body and there is
+    // no HEP header left for the second arm to find. What the wrapper said
+    // travels in `pp.hep` instead — and the correlation id it carries is the
+    // ONLY thing naming the call on a reply, whose body has no `call-id` at
+    // all.
+    //
+    // This arm decoded nothing at all before 0.5.125 while the documentation
+    // offered the method, and the cost of that landed on the operator rather
+    // than here: rtpengine takes exactly one `--homer` destination, so anybody
+    // following the page gave up their Homer collector and received no relay
+    // visibility in exchange.
+    #[cfg(feature = "hep")]
+    if pp.transport == TransportProto::Udp
+        && let Some(hep) = &pp.hep
+        && crate::rtpengine::is_ng_over_hep(hep.protocol, &pp.payload)
+    {
+        let sdp_links =
+            crate::rtpengine::sdp_links_from_ng(&pp.payload, hep.correlation_id.as_deref());
+        return PacketAction::RelayControl { sdp_links };
+    }
+
+    // The second arm is the SNIFFED one: a HEP datagram read off the wire,
+    // wrapper intact, on its way to somebody else's collector.
     #[cfg(feature = "hep")]
     if pp.transport == TransportProto::Udp
         && let Ok(hep) = crate::capture::hep::parse_hep(&pp.payload)
@@ -2437,6 +2466,7 @@ mod quiet_bad_parse_tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }
     }
 
@@ -2777,6 +2807,7 @@ mod relay_control_tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: InputOrigin::Wire,
+            hep: None,
         };
         let rtp = RtpHeader {
             version: 2,
@@ -2870,6 +2901,7 @@ mod relay_control_tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: InputOrigin::Wire,
+            hep: None,
         };
         let rtp = RtpHeader {
             version: 2,

--- a/src/rtp/heuristic.rs
+++ b/src/rtp/heuristic.rs
@@ -169,6 +169,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }
     }
 

--- a/src/rtp/stream_store.rs
+++ b/src/rtp/stream_store.rs
@@ -1989,6 +1989,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }
     }
 

--- a/src/tui/controllers/call_list.rs
+++ b/src/tui/controllers/call_list.rs
@@ -516,6 +516,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         };
         {
             let mut ss = app.stream_store.write();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1519,6 +1519,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         };
         let rtp = crate::rtp::parser::RtpHeader {
             version: 2,
@@ -1575,6 +1576,7 @@ mod tests {
                     ip_protocol: 17,
                     dscp: None,
                     input_origin: crate::capture::parse::InputOrigin::Wire,
+                    hep: None,
                 },
                 &crate::rtp::parser::RtpHeader {
                     version: 2,
@@ -2164,6 +2166,7 @@ mod tests {
                     ip_protocol: 17,
                     dscp: None,
                     input_origin: crate::capture::parse::InputOrigin::Wire,
+                    hep: None,
                 };
                 let rtp = crate::rtp::parser::RtpHeader {
                     version: 2,

--- a/src/tui/save.rs
+++ b/src/tui/save.rs
@@ -1198,6 +1198,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         };
         app.stream_store
             .write()

--- a/src/tui/stream_detail.rs
+++ b/src/tui/stream_detail.rs
@@ -989,6 +989,7 @@ mod tests {
             ip_protocol: 17,
             dscp: None,
             input_origin: crate::capture::parse::InputOrigin::Wire,
+            hep: None,
         }
     }
 

--- a/tests/composite_source_test.rs
+++ b/tests/composite_source_test.rs
@@ -292,6 +292,7 @@ fn hep_packet(payload: Vec<u8>, capture_id: u32) -> Packet {
             src_port: 5060,
             dst_port: 5060,
             ip_protocol: UDP,
+            hep: None,
         },
     )
 }

--- a/tests/dev_docs_drift_test.rs
+++ b/tests/dev_docs_drift_test.rs
@@ -604,7 +604,12 @@ fn linked_code_targets_exist() {
     // a `parties[].tel` row, and it names `tel_uri()` as the builder rather
     // than restating the narrow rule the function documents. One row, one link,
     // one page.
-    const EXPECTED_CODE_LINKS: usize = 401;
+    // 401 -> 402 by one link: the rtpengine control-plane page now names
+    // `tests/hep_listen_ng_test.rs` while recording that `--hep-listen`
+    // decoded nothing until 0.5.125, and the repo-path fixer linked it.
+    // Attributed per file: `internals/rtpengine-control-plane.md` +1, every
+    // other developer page unchanged.
+    const EXPECTED_CODE_LINKS: usize = 402;
     assert_eq!(
         seen, EXPECTED_CODE_LINKS,
         "code-link extraction found {seen} links, expected {EXPECTED_CODE_LINKS}. \

--- a/tests/docs_drift_test.rs
+++ b/tests/docs_drift_test.rs
@@ -33,6 +33,31 @@ mod markdown;
 /// would still fail this guard instead of being silently whitelisted. The
 /// label is the first element of each `docs` tuple in `readme_long_flags_exist_in_cli`.
 const FOREIGN_FLAGS: &[(&str, &[&str])] = &[
+    // `--data-binary` is curl's. The cookbook and the vCon page pipe a
+    // container straight into a conserver, and `--data-binary @-` is what
+    // makes that a single runnable line rather than a file dance. Scoped to
+    // the pages that show the POST.
+    (
+        "data-binary",
+        &[
+            "docs/examples.md",
+            "website/content/docs/cookbook.md",
+            "docs/vcon.md",
+            "website/content/docs/vcon.md",
+        ],
+    ),
+    // `--example` is cargo's. The vCon page points at the committed
+    // `export_vcon` example because a program that compiles with the tree
+    // cannot drift from the API the way a fragment on a page can.
+    (
+        "example",
+        &[
+            "docs/vcon.md",
+            "website/content/docs/vcon.md",
+            "docs/examples.md",
+            "website/content/docs/cookbook.md",
+        ],
+    ),
     // `--keylogfile` is eCapture's, not sipnab's, and BOTH pages that name it
     // are legitimate: the cookbook's §7e tells the reader to run
     // `ecapture tls -m keylog --keylogfile=...` on the SIP host to lift secrets
@@ -56,6 +81,11 @@ const FOREIGN_FLAGS: &[(&str, &[&str])] = &[
             // cargo invocation has to be runnable as written.
             "docs/plugins.md",
             "website/content/docs/plugins.md",
+            // The troubleshooting page answers "sipnab refuses --export-vcon"
+            // with the cargo line that produces a binary carrying it. A remedy
+            // a reader cannot run is not a remedy.
+            "docs/troubleshooting.md",
+            "website/content/docs/troubleshooting.md",
             // The TLS chooser names `--features bpf` because method 4 needs a
             // build that carries it, exactly as the CLI reference does.
             "docs/tls-capture.md",
@@ -168,6 +198,10 @@ const FOREIGN_FLAGS: &[(&str, &[&str])] = &[
             // one to read as a hang.
             "docs/vcon.md",
             "website/content/docs/vcon.md",
+            // The troubleshooting page answers "sipnab refuses --export-vcon"
+            // with the same cargo line, for the same reason.
+            "docs/troubleshooting.md",
+            "website/content/docs/troubleshooting.md",
         ],
     ),
     (

--- a/tests/dscp_marking_test.rs
+++ b/tests/dscp_marking_test.rs
@@ -246,6 +246,7 @@ fn push_rtp(store: &mut sipnab::rtp::stream_store::StreamStore, seq: u16, dscp: 
         ip_protocol: 17,
         dscp: Some(dscp),
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     };
     let rtp = sipnab::rtp::parser::RtpHeader {
         version: 2,
@@ -344,6 +345,7 @@ fn an_unobserved_marking_is_not_reported_as_a_wrong_one() {
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Hep,
+        hep: None,
     };
     let rtp = sipnab::rtp::parser::RtpHeader {
         version: 2,

--- a/tests/hep_listen_ng_test.rs
+++ b/tests/hep_listen_ng_test.rs
@@ -1,0 +1,193 @@
+//! rtpengine `ng` delivered to `--hep-listen`, not sniffed off the wire.
+//!
+//! sipnab documents three ways to see a relay's control plane, and one of them
+//! is "point rtpengine's own HEP export at sipnab". That method decoded
+//! NOTHING: the listener unwraps HEP before the parser runs, so by the time the
+//! pipeline looked for `ng` there was no HEP header left to find, and the
+//! correlation id — the only thing naming the call on a REPLY — had been
+//! dropped on the floor.
+//!
+//! The failure was silent and expensive in the one direction that matters:
+//! rtpengine has a single `homer` destination, so an operator following the
+//! page repointed production at sipnab, LOST their Homer collector, and got no
+//! relay visibility in exchange.
+#![cfg(all(feature = "hep", feature = "native"))]
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use chrono::Utc;
+use sipnab::capture::packet::{HepOrigin, Packet, PreParsed};
+use sipnab::capture::parse::parse_packet;
+use sipnab::pipeline::{self, PacketAction, PipelineOptions};
+use sipnab::rtp::heuristic::RtpHeuristic;
+
+/// rtpengine's own capture protocol for a mirrored `ng` datagram.
+const NG_PROTO: u8 = 0x3d;
+
+/// An `ng` OFFER, shaped like the one in the committed live fixture.
+fn offer_body() -> Vec<u8> {
+    let sdp = "v=0\r\nc=IN IP4 10.0.0.60\r\nm=audio 40001 RTP/AVP 0";
+    format!(
+        "cookie1 d7:command5:offer7:call-id18:km-670bd208@sipnab8:from-tag5:ftag13:sdp{}:{sdp}e",
+        sdp.len()
+    )
+    .into_bytes()
+}
+
+/// The offer REPLY as rtpengine really sends it: no `call-id`, no `command`.
+fn offer_reply_body() -> Vec<u8> {
+    let sdp = "v=0\r\nc=IN IP4 10.0.0.40\r\nm=audio 38664 RTP/AVP 0";
+    format!("cookie1 d3:sdp{}:{sdp}6:result2:oke", sdp.len()).into_bytes()
+}
+
+/// One datagram as the HEP LISTENER hands it on: wrapper already stripped, so
+/// the payload is the bare body and everything the wrapper said travels in
+/// `PreParsed`.
+fn delivered_by_the_listener(body: Vec<u8>, correlation_id: Option<&str>) -> Packet {
+    Packet::with_pre_parsed(
+        Utc::now(),
+        body,
+        Some("hep:198.51.100.7:9060".to_string()),
+        PreParsed {
+            src_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 40)),
+            dst_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 41)),
+            src_port: 22222,
+            dst_port: 2223,
+            ip_protocol: 17,
+            hep: Some(HepOrigin {
+                protocol: NG_PROTO,
+                correlation_id: correlation_id.map(str::to_owned),
+            }),
+        },
+    )
+}
+
+fn classify(packet: &Packet) -> PacketAction {
+    let parsed = parse_packet(packet).expect("a pre-parsed datagram parses");
+    let mut heuristic = RtpHeuristic::new();
+    let opts = PipelineOptions::default();
+    let mut decrypt = pipeline::MediaDecrypt::default();
+    pipeline::classify_packet(&parsed, &mut heuristic, &opts, &mut decrypt)
+}
+
+/// SUCCESS: a request delivered over HEP is claimed as relay control, and its
+/// media endpoint is read.
+#[test]
+fn an_ng_request_delivered_over_hep_names_its_media_endpoint() {
+    let action = classify(&delivered_by_the_listener(offer_body(), None));
+    let PacketAction::RelayControl { sdp_links } = action else {
+        panic!("an ng offer over --hep-listen must be claimed as relay control");
+    };
+    assert_eq!(
+        sdp_links.len(),
+        1,
+        "the offer names one media endpoint: {sdp_links:?}"
+    );
+    let (addr, port, call_id, _) = &sdp_links[0];
+    assert_eq!(addr.to_string(), "10.0.0.60");
+    assert_eq!(*port, 40001);
+    assert_eq!(call_id, "km-670bd208@sipnab");
+}
+
+/// SUCCESS, and the half that only the correlation id can carry: a REPLY names
+/// no call in its body, so the wrapper's correlation id is the sole route from
+/// the relay's allocated port back to the call it belongs to.
+#[test]
+fn an_ng_reply_is_attributed_by_the_hep_correlation_id() {
+    let action = classify(&delivered_by_the_listener(
+        offer_reply_body(),
+        Some("km-670bd208@sipnab"),
+    ));
+    let PacketAction::RelayControl { sdp_links } = action else {
+        panic!("an ng reply over --hep-listen must be claimed as relay control");
+    };
+    assert_eq!(sdp_links.len(), 1, "the reply rewrites one endpoint");
+    let (addr, port, call_id, _) = &sdp_links[0];
+    assert_eq!(addr.to_string(), "10.0.0.40");
+    assert_eq!(*port, 38664);
+    assert_eq!(
+        call_id, "km-670bd208@sipnab",
+        "a reply carries no call-id of its own; drop the correlation id and \
+         the relay's allocated port belongs to no call"
+    );
+}
+
+/// FAILURE: a reply with NO correlation id names no call, and sipnab must not
+/// invent one.
+///
+/// The endpoint is real and the call is unknown. Attributing it to a guess
+/// would put a relay port on the wrong conversation, which is worse than
+/// leaving it unattributed.
+#[test]
+fn an_ng_reply_without_a_correlation_id_attributes_nothing() {
+    let action = classify(&delivered_by_the_listener(offer_reply_body(), None));
+    let PacketAction::RelayControl { sdp_links } = action else {
+        panic!("the datagram is still relay control");
+    };
+    assert!(
+        sdp_links.is_empty(),
+        "nothing names this call, so nothing may be attributed: {sdp_links:?}"
+    );
+}
+
+/// FAILURE: a datagram the listener delivers that is NOT ng is left alone.
+///
+/// The listener carries ordinary SIP too — that is what it is for — and a
+/// claim here would eat every SIP message an operator sent over HEP.
+#[test]
+fn sip_delivered_over_hep_is_not_claimed_as_relay_control() {
+    let sip = b"INVITE sip:bob@example.net SIP/2.0\r\nCall-ID: x@y\r\n\r\n".to_vec();
+    let packet = Packet::with_pre_parsed(
+        Utc::now(),
+        sip,
+        Some("hep:198.51.100.7:9060".to_string()),
+        PreParsed {
+            src_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 40)),
+            dst_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 41)),
+            src_port: 5060,
+            dst_port: 5060,
+            ip_protocol: 17,
+            // Capture protocol 1: SIP, which is what a Homer feed carries.
+            hep: Some(HepOrigin {
+                protocol: 1,
+                correlation_id: Some("x@y".to_string()),
+            }),
+        },
+    );
+    assert!(
+        !matches!(classify(&packet), PacketAction::RelayControl { .. }),
+        "a SIP message over HEP must reach the SIP path, not the relay path"
+    );
+}
+
+/// The relay's own declaration is honored even when sipnab cannot decode the
+/// body.
+///
+/// `is_ng_over_hep` accepts on EITHER the capture protocol or a body that
+/// parses, and a well-formed `ng` body is self-identifying — so every test
+/// above passes on the body alone and none of them proves the protocol byte is
+/// read at all. Mutation said exactly that: forcing the carried protocol to
+/// SIP left them green.
+///
+/// This is the case that separates them. rtpengine says `0x3d`, the body is
+/// something this version cannot parse — truncated, or a command added after
+/// this build — and the datagram must STILL be claimed as control traffic.
+/// Falling through would hand a control datagram to the RTP heuristic, which
+/// is the one outcome the whole block is ordered to prevent.
+#[test]
+fn a_body_sipnab_cannot_parse_is_still_control_when_the_relay_says_so() {
+    let undecodable = b"d7:command9:some-verb".to_vec();
+    let packet = delivered_by_the_listener(undecodable, Some("km-670bd208@sipnab"));
+
+    let action = classify(&packet);
+    let PacketAction::RelayControl { sdp_links } = action else {
+        panic!(
+            "rtpengine declared this ng; an undecodable body is not a reason \
+             to reconsider it as media"
+        );
+    };
+    assert!(
+        sdp_links.is_empty(),
+        "nothing was decoded, so nothing may be attributed: {sdp_links:?}"
+    );
+}

--- a/tests/icmp_media_test.rs
+++ b/tests/icmp_media_test.rs
@@ -200,6 +200,7 @@ fn store_with_stream(
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     };
     let rtp = RtpHeader {
         version: 2,

--- a/tests/link_integrity_test.rs
+++ b/tests/link_integrity_test.rs
@@ -628,7 +628,14 @@ fn wiki_intra_docs_links_resolve() {
     // walk. A standalone reproduction of the count lands one above the gate's,
     // because `prose()` strips more than fenced blocks; the gate's own number
     // is the one pinned here.
-    const EXPECTED_WIKI_LINKS: usize = 498;
+    // 498 -> 501 by three links, all pointing a reader at something runnable
+    // rather than restating it: `docs/output-formats.md` +1 to the vCon page
+    // from its new `--export-vcon` section, `docs/examples.md` +1 to the same
+    // page from recipe 13b, and `docs/examples.md` +1 to `rtpengine.md` from
+    // the §6b relay config, which previously told a reader to set up a mirror
+    // and never said what reads it. Attributed per file; every other page in
+    // this walk held its count.
+    const EXPECTED_WIKI_LINKS: usize = 501;
     // Raised 459 -> 460 when SRC1 stage 1 shipped: docs/cli-reference.md's
     // `--hep-listen` row now points at cookbook recipe 6d in docs/examples.md
     // rather than restating how to pair `-L` with `-d`. Attributed per file

--- a/tests/media_diagnosis_wiring_test.rs
+++ b/tests/media_diagnosis_wiring_test.rs
@@ -218,6 +218,7 @@ fn rtp_packet(
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     }
 }
 

--- a/tests/metrics_counters_test.rs
+++ b/tests/metrics_counters_test.rs
@@ -66,6 +66,7 @@ fn incomplete_fragment(ip_id: u32) -> ParsedPacket {
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     }
 }
 
@@ -101,6 +102,7 @@ fn idle_tcp_segment(src_port: u16) -> ParsedPacket {
         ip_protocol: 6,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     }
 }
 

--- a/tests/mos_delay_test.rs
+++ b/tests/mos_delay_test.rs
@@ -298,6 +298,7 @@ fn rtp_packet(ssrc: u32, seq: u16, at: DateTime<Utc>) -> ParsedPacket {
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     }
 }
 

--- a/tests/multi_node_relay_fanout_test.rs
+++ b/tests/multi_node_relay_fanout_test.rs
@@ -136,6 +136,7 @@ fn packet(payload: Vec<u8>, src_port: u16, dst: Ipv4Addr, dst_port: u16) -> Pars
         ip_protocol: 17,
         dscp: None,
         input_origin: InputOrigin::Wire,
+        hep: None,
     }
 }
 

--- a/tests/pipeline_test.rs
+++ b/tests/pipeline_test.rs
@@ -42,6 +42,7 @@ fn parsed(payload: Vec<u8>, src_port: u16, dst_port: u16) -> ParsedPacket {
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     }
 }
 

--- a/tests/resource_bounds_test.rs
+++ b/tests/resource_bounds_test.rs
@@ -149,6 +149,7 @@ fn parsed_for(ssrc: u32, payload: Vec<u8>) -> ParsedPacket {
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     }
 }
 

--- a/tests/rtp_integration_test.rs
+++ b/tests/rtp_integration_test.rs
@@ -90,6 +90,7 @@ fn make_rtp_parsed(
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     }
 }
 

--- a/tests/rtp_quality_provenance_test.rs
+++ b/tests/rtp_quality_provenance_test.rs
@@ -606,6 +606,7 @@ fn the_sdp_ptime_reaches_the_stream_in_both_orderings() {
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     };
     let hdr = RtpHeader {
         version: 2,

--- a/tests/silent_sip_loss_test.rs
+++ b/tests/silent_sip_loss_test.rs
@@ -61,6 +61,7 @@ fn parsed(payload: Vec<u8>, src_port: u16, dst_port: u16) -> ParsedPacket {
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     }
 }
 

--- a/tests/summary_consistency_test.rs
+++ b/tests/summary_consistency_test.rs
@@ -148,6 +148,7 @@ fn stream_summary_canonical_keys() {
         ip_protocol: 17,
         dscp: None,
         input_origin: sipnab::capture::parse::InputOrigin::Wire,
+        hep: None,
     };
     ss.process_rtp(&pp, &hdr, pp.timestamp);
     let stream = ss.iter().next().expect("stream tracked");

--- a/tests/tui_snapshot_test.rs
+++ b/tests/tui_snapshot_test.rs
@@ -193,6 +193,7 @@ mod tui_snapshots {
                 // branch and let the naming break silently.
                 dscp: Some(46),
                 input_origin: sipnab::capture::parse::InputOrigin::Wire,
+                hep: None,
             };
             let rtp1 = RtpHeader {
                 version: 2,
@@ -227,6 +228,7 @@ mod tui_snapshots {
                 ip_protocol: 17,
                 dscp: None,
                 input_origin: sipnab::capture::parse::InputOrigin::Wire,
+                hep: None,
             };
             let rtp2 = RtpHeader {
                 version: 2,
@@ -279,6 +281,7 @@ mod tui_snapshots {
             // let the naming break silently.
             dscp: Some(46),
             input_origin: sipnab::capture::parse::InputOrigin::Wire,
+            hep: None,
         };
         let rtp = RtpHeader {
             version: 2,

--- a/tests/tui_state_test.rs
+++ b/tests/tui_state_test.rs
@@ -4298,6 +4298,7 @@ mod tui_state {
                     ip_protocol: 17,
                     dscp: None,
                     input_origin: sipnab::capture::parse::InputOrigin::Wire,
+                    hep: None,
                 };
                 let rtp = parse_rtp_header(&parsed.payload).unwrap();
                 store.process_rtp(&parsed, &rtp, parsed.timestamp);

--- a/tests/uprobe_pipeline_test.rs
+++ b/tests/uprobe_pipeline_test.rs
@@ -45,6 +45,7 @@ fn uprobe_packet(interface: &str, src_port: u16, dst_port: u16) -> Packet {
             src_port,
             dst_port,
             ip_protocol: TCP,
+            hep: None,
         },
     )
 }

--- a/website/content/docs/cookbook.md
+++ b/website/content/docs/cookbook.md
@@ -355,9 +355,15 @@ Reload with `opensipsctl restart` (or `systemctl reload opensips` for graceful r
 homer = capture.example.com:9060
 homer-protocol = udp
 homer-id = 1
+# Without this, rtpengine mirrors RTCP statistics only -- which carry no
+# Call-ID and no SDP, so nothing sipnab reads can name a call or find a media
+# endpoint. It is the first thing to check when a relay looks silent.
+homer-enable-ng = true
 ```
 
-Restart with `systemctl restart rtpengine`.
+Restart with `systemctl restart rtpengine`. See
+[the rtpengine page](@/docs/rtpengine.md) for what sipnab does with the result, and
+for the two ways to read it that do not cost you your collector.
 
 **Kamailio:**
 
@@ -1310,6 +1316,35 @@ WAV header and every player reads the file normally.
 - A CLI batch audio-export flag does **not** exist today. The library functions (`rtp::audio_export::export_stream_to_wav`, `export_dialog_to_wav`) are available if you want to build it; until then, scripted batch export means driving the TUI under `expect`/`tmux` or writing a small Rust binary that links the library.
 
 ---
+
+## 13b. Export one call to a conversation archive as a vCon
+
+`--export-vcon` writes one observed dialog as a vCon container — the IETF
+interchange format a conversation archive, a compliance store or an
+agent-facing pipeline already reads. Handing one of those a pcap makes the
+decoding their problem. Handing them a vCon does not.
+
+```sh
+sipnab -N -I capture.pcap --export-vcon '1-1966@10.0.2.20' --vcon-out call.vcon
+```
+
+Straight into a conserver, without a file in between:
+
+```sh
+sipnab -N -I capture.pcap --export-vcon '1-1966@10.0.2.20'   | curl -fsS -X POST "$CONSERVER/vcon"       -H 'Content-Type: application/json'       -H "Authorization: Bearer $CONSERVER_TOKEN" --data-binary @-
+```
+
+Read the caveat before you trust the contents. Every `body` is a JSON-encoded
+string, which means `jq` needs a parse on the way in:
+
+```sh
+sipnab -N -I capture.pcap --export-vcon '1-1966@10.0.2.20'   | jq -r '.analysis[0].body | fromjson | .capture_completeness.note'
+```
+
+Needs a build carrying the non-default `vcon` feature. `sipnab --version` lists
+what yours has. As a library, [`examples/export_vcon.rs`](https://github.com/NormB/sipnab/blob/main/examples/export_vcon.rs)
+is the same thing as a program you can run. The [vCon page](@/docs/vcon.md) covers what
+a consumer may and may not conclude from a container sipnab wrote.
 
 ## 14. Analyze a pcap without installing anything
 

--- a/website/content/docs/internals/rtpengine-control-plane.md
+++ b/website/content/docs/internals/rtpengine-control-plane.md
@@ -79,8 +79,25 @@ same decoder, not as a separate feature.
 
 ## Why the wire, and not our own listener
 
-sipnab could receive on `--hep-listen` and have rtpengine send to it. That
-works today with no new parsing at all, and it is the wrong default.
+sipnab can receive on `--hep-listen` and have rtpengine send to it. That works
+— since 0.5.125, and not before, although this page said it did.
+
+The claim was wrong in a way worth recording, because the shape recurs. The
+listener strips the HEP wrapper before the parser runs, so by the time the
+pipeline looked for `ng` there was no HEP header left to parse and the check
+never fired. Worse, the correlation id went with it — and an `ng` REPLY names
+its call in the correlation id and nowhere else, so even the half carrying the
+relay's allocated ports had lost the only route back to a call.
+
+"No new parsing at all" was true of the DECODER and false of the PATH, and
+nothing tested the path. The fix carries the wrapper's two load-bearing claims
+in `PreParsed` and gives the pipeline a second arm for the delivered shape.
+[`tests/hep_listen_ng_test.rs`](https://github.com/NormB/sipnab/blob/main/tests/hep_listen_ng_test.rs) covers it, and
+`hep_to_packet_carries_the_capture_protocol_and_correlation_id` covers the
+listener half — which the integration tests structurally cannot, because they
+build `PreParsed` by hand. Mutation found that gap rather than review.
+
+It remains the wrong default.
 
 `--homer` is a single `G_OPTION_ARG_STRING`, not a repeatable option, so
 rtpengine has exactly ONE Homer destination. Pointing it at sipnab takes it

--- a/website/content/docs/output-formats.md
+++ b/website/content/docs/output-formats.md
@@ -463,6 +463,26 @@ sipnab -N -I capture.pcap --json-analyze --no-cli-print | jq '.complete'
 sipnab already computes and the capture-level evidence it already holds. It
 ranks and counts them, and adds no judgement of its own.
 
+## vCon (`--export-vcon`)
+
+A different kind of output from everything above. The formats on this page are
+sipnab's own shapes, read by sipnab and by whatever you write around it. A vCon
+is an interchange container other people's systems already parse — a
+conversation archive, a compliance store, an agent that reasons over calls.
+
+```sh
+sipnab -N -I call.pcap --export-vcon 'CALL-ID' --vcon-out out.json
+```
+
+One dialog per container, never a whole capture. sipnab writes it as an
+OBSERVER: it names itself as a party that took no part in the call, carries the
+audio inline when the run retained the RTP payload, and states in two places
+what the capture missed. It signs nothing.
+
+Behind the non-default `vcon` feature, so a stock build refuses the flag and
+says so. The [vCon page](@/docs/vcon.md) covers what a consumer may and may not
+conclude from one, which matters more here than the field list.
+
 ## pcap / pcapng
 
 `-O <file>` writes captured packets, and `--pcapng` selects PCAP-NG. With TLS

--- a/website/content/docs/rtpengine.md
+++ b/website/content/docs/rtpengine.md
@@ -77,7 +77,7 @@ Read down the first column and stop at the first row you can satisfy.
 |---|---|---|---|
 | rtpengine already reports to a Homer collector | Capture on the relay host | **No** | sipnab reads the copy already on the wire. Nothing about your Homer pipeline changes. |
 | rtpengine reports nowhere yet | Turn on `--homer-enable-ng`, point it anywhere sipnab can see | Yes, once | The destination can be a collector, or a host that discards the traffic |
-| You need it delivered rather than sniffed | `--hep-listen` on sipnab, point rtpengine at it | Yes | Costs you the collector — see the warning below |
+| You need it delivered rather than sniffed | `--hep-listen` on sipnab, point rtpengine at it | Yes | Costs you the collector — see the warning below. Requires 0.5.125 or later: earlier builds accepted the traffic and decoded none of it |
 
 Every row here covers control messages that cross the wire while sipnab
 runs. None of them reaches a call the relay set up before the capture
@@ -111,7 +111,33 @@ Each relay host runs sipnab against its **own local** relay:
 
 ```bash
 # On relay-a, relay-b, relay-c — identical, and each asks only its own relay.
-sipnab -d eth0 --rtpengine-control 127.0.0.1:22222 --api 127.0.0.1:8080
+# The API binds to the host's own address, not loopback: the whole point of the
+# procedure below is that ANOTHER machine queries this one. A non-loopback bind
+# is refused without authentication, which is why --api-key is not optional
+# here.
+sudo sipnab -d eth0 --rtpengine-control 127.0.0.1:22222 \
+  --api 0.0.0.0:8080 --api-key "$SIPNAB_API_KEY"
+```
+
+The queries below need the address, the key and a Call-ID. Set them once, on
+whichever machine you are running `curl` from:
+
+`$H` interpolates `$KEY`, so set the key first — an `$H` built before `$KEY`
+exists carries an `Authorization` header with no token in it, and every query
+below then returns `401`.
+
+```bash
+KEY="$SIPNAB_API_KEY"
+```
+
+```bash
+H="-H 'Authorization: Bearer $KEY'"
+```
+
+Then the call you are chasing:
+
+```bash
+CALL_ID="1-1966@10.0.2.20"
 ```
 
 `--rtpengine-control` takes one address, and in this topology that is correct

--- a/website/content/docs/troubleshooting.md
+++ b/website/content/docs/troubleshooting.md
@@ -752,3 +752,50 @@ cooked v1 and cooked v2 alike.
 Build custom queries with the [Filter DSL](@/docs/filter-dsl.md) -- 33 fields, regex support, boolean logic. See the [CLI Reference](@/docs/cli.md) for every flag and more recipes.
 
 If the capture itself is the problem -- drops on a busy link, a full kernel ring buffer, or loss that appears on every call at once -- see [Tuning capture on a busy server](@/docs/tuning-capture.md).
+
+### sipnab refuses `--export-vcon`
+
+```text
+--export-vcon needs a build with the `vcon` feature
+```
+
+The exporter is behind a non-default Cargo feature, so a stock build does not
+carry it. Check what you have:
+
+```sh
+sipnab --version        # the feature list is on the version line
+```
+
+If `vcon` is absent, build one that has it:
+
+```sh
+cargo build --release --features vcon
+```
+
+The feature is non-default on purpose. A container that leaves the machine is a
+publication surface, and a capture tool should not grow one unless an operator
+asks for it.
+
+### `--export-vcon` says the Call-ID is not there
+
+```text
+Call-ID 'x@y' not found in tracked dialogs, so there is no dialog to export.
+```
+
+The run holds no dialog under that Call-ID. `--report` lists the ones it does
+hold — the usual cause is a Call-ID copied with surrounding quotes or a
+truncated one, and the second is a capture that never saw the dialog open.
+
+Quote the Call-ID in the shell. Most contain `@`, and many contain characters
+your shell would otherwise interpret.
+
+### The container came out with no audio in it
+
+The dialog object carries no `body` and the caveat says media was not decoded.
+That is a statement about what the RUN kept, never a finding that the call was
+silent — the container is careful to say so, and a consumer should read the
+`media_note` beside it.
+
+The usual cause is that the run did not retain the RTP payload. Audio also has
+an inline budget. A recording over it draws an out-loud refusal rather than a
+silent truncation, and the caveat names the size it turned down.

--- a/website/content/docs/vcon.md
+++ b/website/content/docs/vcon.md
@@ -107,10 +107,20 @@ test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 
 ### Step 2 — build the container
 
-Read the capture into a `DialogStore` the ordinary way — the
-[library page](https://github.com/NormB/sipnab/blob/main/docs/library.md) covers that part, and
-[the committed test](https://github.com/NormB/sipnab/blob/main/tests/vcon_export_test.rs) holds the whole program —
-then hand one dialog and the run's own counters to `export_dialog`:
+The shortest path is the committed example, which does everything below against
+that same capture and prints the container:
+
+```sh
+cargo run --features vcon --example export_vcon -- tests/fixtures/sip_call.pcap
+```
+
+Its source is [`examples/export_vcon.rs`](https://github.com/NormB/sipnab/blob/main/examples/export_vcon.rs) and it
+compiles as part of the build, so it cannot drift from the API the way a
+fragment on a page can.
+
+In your own program: read the capture into a `DialogStore` the ordinary way —
+the [library page](https://github.com/NormB/sipnab/blob/main/docs/library.md) covers that part — then hand one dialog and the
+run's own counters to `export_dialog`:
 
 ```rust
 use sipnab::analysis::CaptureFacts;

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -353,9 +353,15 @@ Reload with `opensipsctl restart` (or `systemctl reload opensips` for graceful r
 homer = capture.example.com:9060
 homer-protocol = udp
 homer-id = 1
+# Without this, rtpengine mirrors RTCP statistics only -- which carry no
+# Call-ID and no SDP, so nothing sipnab reads can name a call or find a media
+# endpoint. It is the first thing to check when a relay looks silent.
+homer-enable-ng = true
 ```
 
-Restart with `systemctl restart rtpengine`.
+Restart with `systemctl restart rtpengine`. See
+[the rtpengine page](rtpengine.md) for what sipnab does with the result, and
+for the two ways to read it that do not cost you your collector.
 
 **Kamailio:**
 
@@ -1308,6 +1314,35 @@ WAV header and every player reads the file normally.
 - A CLI batch audio-export flag does **not** exist today. The library functions (`rtp::audio_export::export_stream_to_wav`, `export_dialog_to_wav`) are available if you want to build it; until then, scripted batch export means driving the TUI under `expect`/`tmux` or writing a small Rust binary that links the library.
 
 ---
+
+## 13b. Export one call to a conversation archive as a vCon
+
+`--export-vcon` writes one observed dialog as a vCon container — the IETF
+interchange format a conversation archive, a compliance store or an
+agent-facing pipeline already reads. Handing one of those a pcap makes the
+decoding their problem. Handing them a vCon does not.
+
+```sh
+sipnab -N -I capture.pcap --export-vcon '1-1966@10.0.2.20' --vcon-out call.vcon
+```
+
+Straight into a conserver, without a file in between:
+
+```sh
+sipnab -N -I capture.pcap --export-vcon '1-1966@10.0.2.20'   | curl -fsS -X POST "$CONSERVER/vcon"       -H 'Content-Type: application/json'       -H "Authorization: Bearer $CONSERVER_TOKEN" --data-binary @-
+```
+
+Read the caveat before you trust the contents. Every `body` is a JSON-encoded
+string, which means `jq` needs a parse on the way in:
+
+```sh
+sipnab -N -I capture.pcap --export-vcon '1-1966@10.0.2.20'   | jq -r '.analysis[0].body | fromjson | .capture_completeness.note'
+```
+
+Needs a build carrying the non-default `vcon` feature. `sipnab --version` lists
+what yours has. As a library, [`examples/export_vcon.rs`](../examples/export_vcon.rs)
+is the same thing as a program you can run. The [vCon page](vcon.md) covers what
+a consumer may and may not conclude from a container sipnab wrote.
 
 ## 14. Analyze a pcap without installing anything
 
@@ -4368,7 +4403,7 @@ Read down the first column and stop at the first row you can satisfy.
 |---|---|---|---|
 | rtpengine already reports to a Homer collector | Capture on the relay host | **No** | sipnab reads the copy already on the wire. Nothing about your Homer pipeline changes. |
 | rtpengine reports nowhere yet | Turn on `--homer-enable-ng`, point it anywhere sipnab can see | Yes, once | The destination can be a collector, or a host that discards the traffic |
-| You need it delivered rather than sniffed | `--hep-listen` on sipnab, point rtpengine at it | Yes | Costs you the collector — see the warning below |
+| You need it delivered rather than sniffed | `--hep-listen` on sipnab, point rtpengine at it | Yes | Costs you the collector — see the warning below. Requires 0.5.125 or later: earlier builds accepted the traffic and decoded none of it |
 
 Every row here covers control messages that cross the wire while sipnab
 runs. None of them reaches a call the relay set up before the capture
@@ -4402,7 +4437,33 @@ Each relay host runs sipnab against its **own local** relay:
 
 ```bash
 # On relay-a, relay-b, relay-c — identical, and each asks only its own relay.
-sipnab -d eth0 --rtpengine-control 127.0.0.1:22222 --api 127.0.0.1:8080
+# The API binds to the host's own address, not loopback: the whole point of the
+# procedure below is that ANOTHER machine queries this one. A non-loopback bind
+# is refused without authentication, which is why --api-key is not optional
+# here.
+sudo sipnab -d eth0 --rtpengine-control 127.0.0.1:22222 \
+  --api 0.0.0.0:8080 --api-key "$SIPNAB_API_KEY"
+```
+
+The queries below need the address, the key and a Call-ID. Set them once, on
+whichever machine you are running `curl` from:
+
+`$H` interpolates `$KEY`, so set the key first — an `$H` built before `$KEY`
+exists carries an `Authorization` header with no token in it, and every query
+below then returns `401`.
+
+```bash
+KEY="$SIPNAB_API_KEY"
+```
+
+```bash
+H="-H 'Authorization: Bearer $KEY'"
+```
+
+Then the call you are chasing:
+
+```bash
+CALL_ID="1-1966@10.0.2.20"
 ```
 
 `--rtpengine-control` takes one address, and in this topology that is correct
@@ -5582,6 +5643,53 @@ cooked v1 and cooked v2 alike.
 Build custom queries with the [Filter DSL](filter-dsl.md) -- 33 fields, regex support, boolean logic. See the [CLI Reference](cli-reference.md) for every flag and more recipes.
 
 If the capture itself is the problem -- drops on a busy link, a full kernel ring buffer, or loss that appears on every call at once -- see [Tuning capture on a busy server](tuning-capture.md).
+
+### sipnab refuses `--export-vcon`
+
+```text
+--export-vcon needs a build with the `vcon` feature
+```
+
+The exporter is behind a non-default Cargo feature, so a stock build does not
+carry it. Check what you have:
+
+```sh
+sipnab --version        # the feature list is on the version line
+```
+
+If `vcon` is absent, build one that has it:
+
+```sh
+cargo build --release --features vcon
+```
+
+The feature is non-default on purpose. A container that leaves the machine is a
+publication surface, and a capture tool should not grow one unless an operator
+asks for it.
+
+### `--export-vcon` says the Call-ID is not there
+
+```text
+Call-ID 'x@y' not found in tracked dialogs, so there is no dialog to export.
+```
+
+The run holds no dialog under that Call-ID. `--report` lists the ones it does
+hold — the usual cause is a Call-ID copied with surrounding quotes or a
+truncated one, and the second is a capture that never saw the dialog open.
+
+Quote the Call-ID in the shell. Most contain `@`, and many contain characters
+your shell would otherwise interpret.
+
+### The container came out with no audio in it
+
+The dialog object carries no `body` and the caveat says media was not decoded.
+That is a statement about what the RUN kept, never a finding that the call was
+silent — the container is careful to say so, and a consumer should read the
+`media_note` beside it.
+
+The usual cause is that the run did not retain the RTP payload. Audio also has
+an inline budget. A recording over it draws an out-loud refusal rather than a
+silent truncation, and the caveat names the size it turned down.
 
 ---
 
@@ -9849,6 +9957,26 @@ sipnab -N -I capture.pcap --json-analyze --no-cli-print | jq '.complete'
 `--analyze` derives nothing new. `--analyze` aggregates the per-dialog diagnosis
 sipnab already computes and the capture-level evidence it already holds. It
 ranks and counts them, and adds no judgement of its own.
+
+## vCon (`--export-vcon`)
+
+A different kind of output from everything above. The formats on this page are
+sipnab's own shapes, read by sipnab and by whatever you write around it. A vCon
+is an interchange container other people's systems already parse — a
+conversation archive, a compliance store, an agent that reasons over calls.
+
+```sh
+sipnab -N -I call.pcap --export-vcon 'CALL-ID' --vcon-out out.json
+```
+
+One dialog per container, never a whole capture. sipnab writes it as an
+OBSERVER: it names itself as a party that took no part in the call, carries the
+audio inline when the run retained the RTP payload, and states in two places
+what the capture missed. It signs nothing.
+
+Behind the non-default `vcon` feature, so a stock build refuses the flag and
+says so. The [vCon page](vcon.md) covers what a consumer may and may not
+conclude from one, which matters more here than the field list.
 
 ## pcap / pcapng
 
@@ -17370,10 +17498,20 @@ test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 
 ### Step 2 — build the container
 
-Read the capture into a `DialogStore` the ordinary way — the
-[library page](library.md) covers that part, and
-[the committed test](../tests/vcon_export_test.rs) holds the whole program —
-then hand one dialog and the run's own counters to `export_dialog`:
+The shortest path is the committed example, which does everything below against
+that same capture and prints the container:
+
+```sh
+cargo run --features vcon --example export_vcon -- tests/fixtures/sip_call.pcap
+```
+
+Its source is [`examples/export_vcon.rs`](../examples/export_vcon.rs) and it
+compiles as part of the build, so it cannot drift from the API the way a
+fragment on a page can.
+
+In your own program: read the capture into a `DialogStore` the ordinary way —
+the [library page](library.md) covers that part — then hand one dialog and the
+run's own counters to `export_dialog`:
 
 ```rust
 use sipnab::analysis::CaptureFacts;
@@ -21149,8 +21287,25 @@ same decoder, not as a separate feature.
 
 ## Why the wire, and not our own listener
 
-sipnab could receive on `--hep-listen` and have rtpengine send to it. That
-works today with no new parsing at all, and it is the wrong default.
+sipnab can receive on `--hep-listen` and have rtpengine send to it. That works
+— since 0.5.125, and not before, although this page said it did.
+
+The claim was wrong in a way worth recording, because the shape recurs. The
+listener strips the HEP wrapper before the parser runs, so by the time the
+pipeline looked for `ng` there was no HEP header left to parse and the check
+never fired. Worse, the correlation id went with it — and an `ng` REPLY names
+its call in the correlation id and nowhere else, so even the half carrying the
+relay's allocated ports had lost the only route back to a call.
+
+"No new parsing at all" was true of the DECODER and false of the PATH, and
+nothing tested the path. The fix carries the wrapper's two load-bearing claims
+in `PreParsed` and gives the pipeline a second arm for the delivered shape.
+[`tests/hep_listen_ng_test.rs`](../../tests/hep_listen_ng_test.rs) covers it, and
+`hep_to_packet_carries_the_capture_protocol_and_correlation_id` covers the
+listener half — which the integration tests structurally cannot, because they
+build `PreParsed` by hand. Mutation found that gap rather than review.
+
+It remains the wrong default.
 
 `--homer` is a single `G_OPTION_ARG_STRING`, not a repeatable option, so
 rtpengine has exactly ONE Homer destination. Pointing it at sipnab takes it

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5717 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5722 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5717" data-suffix="">5717</span>
+        <span class="arch-stat" data-count="5722" data-suffix="">5722</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -287,7 +287,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
           <tr><td><a href="{{ get_url(path='@/docs/metrics.md') }}">Prometheus metrics</a></td><td>Counters and gauges about sipnab itself: what it captured, what it lost, what it could not read.</td></tr>
           <tr><td><a href="{{ get_url(path='@/docs/mcp.md') }}">MCP server</a></td><td>Drive sipnab from an AI agent (Claude Code, Claude Desktop, …) over stdio or HTTP. 32 tools cover dialogs, RTP, diagnostics, and security findings. 27 are read-only; the five that write — file export, capture swap, findings, shutdown — each stay off until you enable them server-side.</td></tr>
           <tr><td><a href="{{ get_url(path='@/analyze/_index.md') }}">Browser analysis</a></td><td>Analyze pcap files in the browser via WASM. Zero upload, zero install.</td></tr>
-          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5722 automated tests. Under 13 MB static binary.</td></tr>
+          <tr><td><a href="{{ get_url(path='@/docs/build.md') }}">Built in Rust</a></td><td>Memory-safe by construction. 5723 automated tests. Under 13 MB static binary.</td></tr>
         </tbody>
       </table>
     </div>
@@ -373,7 +373,7 @@ sipnab -N --json -I capture.pcap --problems</code></pre>
         <span class="arch-label">Headroom to take a whole estate's HEP feed on one box, with no collector tier &mdash; offline reconstruction, four cores (measured v0.5.122)</span>
       </a>
       <a class="arch-item fade-in-up" href="{{ config.extra.github_url }}/actions/workflows/ci.yml">
-        <span class="arch-stat" data-count="5722" data-suffix="">5722</span>
+        <span class="arch-stat" data-count="5723" data-suffix="">5723</span>
         <span class="arch-label">Automated tests</span>
       </a>
     </div>


### PR DESCRIPTION
Closes the worst item both audits found, plus the missing examples on either side.

## `--hep-listen` decoded nothing, while three documents said it worked

The listener strips the HEP wrapper before the parser runs, so by the time the pipeline looked for `ng` there was no HEP header left to parse and the check never fired. The correlation id went with it — and an `ng` **reply** names its call in the correlation id and nowhere else, so even the half carrying the relay's allocated ports had lost its only route back to a call.

> "That works today with no new parsing at all"
> — `docs/internals/rtpengine-control-plane.md`, before this PR

True of the **decoder**, false of the **path**, and nothing tested the path. The cost landed on the operator rather than here: rtpengine takes exactly one `--homer` destination, so anybody following the page gave up their Homer collector and got no relay visibility in exchange.

`PreParsed` now carries a `HepOrigin` — the capture protocol and the correlation id, the two chunks that were dropped — and the pipeline has a second arm for the delivered shape beside the sniffed one.

### The mutation round that mattered

The integration tests build `PreParsed` by hand, so they prove the **pipeline** reads these and structurally cannot prove the **listener** writes them. Forcing the carried protocol to SIP left all five green. `hep_to_packet_carries_the_capture_protocol_and_correlation_id` is the test that dies, and it exists because mutation said the others could not.

A sixth test covers the one case only the protocol byte can carry: a body this build cannot parse, which rtpengine still declares as `ng`, and which must not fall through to the RTP heuristic. Without it nothing proved the byte was read at all — a well-formed `ng` body is self-identifying, so every other test passes on the body alone.

| Mutation | Test |
|---|---|
| delivered arm never claims ng | `an_ng_request_delivered_over_hep_names_its_media_endpoint` |
| correlation id withheld from the attributor | `an_ng_reply_is_attributed_by_the_hep_correlation_id` |
| listener carries the wrong capture protocol | `hep_to_packet_carries_the_capture_protocol_and_correlation_id` |
| listener drops the correlation id | same |

## Documentation that promised what the code did not do

- **The multi-node walkthrough could not be followed.** It bound `--api` to loopback and then curled it cross-host, never said a routable bind is refused without authentication, and used `$H` three times without defining it.
- **`docs/examples.md` gave an rtpengine config with no `homer-enable-ng`** — the exact failure `docs/rtpengine.md` lists as troubleshooting row one. Without it rtpengine mirrors RTCP statistics only, which carry no Call-ID and no SDP.
- **`harness/hep-sink` was a bare Dockerfile the docs pointed readers at**, absent from `harness/README.md`, with no `HOMER` in `.env.example`. The knob is there now, pointing at the sink — which must be something that *answers*: rtpengine connects its Homer socket and drops the trace on an ICMP port-unreachable, a failure indistinguishable from the feature being broken.
- **The man page** named neither `--rtpengine-control`, `--hep-listen` nor `--export-vcon`.

## vCon had no runnable example on any surface

`examples/` had none, `docs/library.md` never mentioned the feature, and the walkthrough's Step 2 was a fragment that does not compile — `store`, `call_id` and `facts` are all undefined in it.

`examples/export_vcon.rs` is that program, running against a committed capture, compiled as part of the build so it cannot drift from the API the way a page can. It also shows the conserver POST, which no vCon page did. Alongside it: cookbook recipe 13b, an output-formats section, and three troubleshooting entries — including the `fromjson` a `jq` reader now needs, since every `body` is a string.

## Verification

`bash .githooks/pre-commit` green in full; corpus validated (15 test binaries against the private corpus). Pre-push caught three things the local test run structurally could not: a bench, an example lint, and a fuzz target — `cargo test` builds none of those, `--all-targets` does.
